### PR TITLE
Modified to allow abbreviated SHA1 and to mimic git-ls-tree and git-cat-file

### DIFF
--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -200,7 +200,7 @@ let cat_file = {
 	      let t, c, s =
 	        match v with
 	        | Value.Blob blob -> 
-		    let c = Blob.pretty blob in
+		    let c = Blob.to_raw blob in
 		    "blob", c, String.length c
 	        | Value.Commit commit ->
 		    let c = Commit.pretty commit in
@@ -310,7 +310,7 @@ let ls_tree = {
           S.read_exn t sha1 >>= fun v -> begin
             match v with
             | Value.Blob blob -> begin
-                printf "blob %s %s\n" (SHA.to_hex sha1) path;
+                printf "blob %s %s\n%!" (SHA.to_hex sha1) path;
                 return_unit
             end
             | Value.Tree tree -> begin
@@ -319,7 +319,7 @@ let ls_tree = {
                     let path' = Filename.concat path e.Tree.name in
                     let kind, is_dir = get_kind e.Tree.perm in
                     let mode = Tree.string_of_perm e.Tree.perm in
-                    printf "%s %s %s\t%s\n" mode kind (SHA.to_hex e.Tree.node) path';
+                    printf "%s %s %s\t%s\n%!" mode kind (SHA.to_hex e.Tree.node) path';
                     if is_dir && recurse then
                       walk recurse path' e.Tree.node
                     else
@@ -327,11 +327,11 @@ let ls_tree = {
                   ) tree
             end
             | Value.Tag tag -> begin
-                printf "tag %s %s\n" (SHA.to_hex sha1) path;
+                printf "tag %s %s\n%!" (SHA.to_hex sha1) path;
                 return_unit
             end
             | Value.Commit commit -> begin
-                printf "commit %s %s\n" (SHA.to_hex sha1) path;
+                printf "commit %s %s\n%!" (SHA.to_hex sha1) path;
                 walk recurse path (SHA.of_tree commit.Commit.tree)
             end
           end

--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -194,33 +194,43 @@ let cat_file = {
   let cat_file (module S: Store.S) ty_flag sz_flag id =
     run begin
       S.create () >>= fun t ->
-	S.read_exn t (SHA.of_hex id) >>= fun v -> begin
-	  let t, c, s =
-	    match v with
-	    | Value.Blob blob -> 
-		let c = Blob.pretty blob in
-		"blob", c, String.length c
-	    | Value.Commit commit ->
-		let c = Commit.pretty commit in
-		"commit", c, String.length c
-	    | Value.Tree tree ->
-		let c = Tree.pretty tree in
-		"tree", c, String.length c
-	    | Value.Tag tag ->
-		let c = Tag.pretty tag in
-		"tag", c, String.length c
-	  in
-	  if ty_flag then
-	    Printf.printf "%s%!" t;
+        Lwt.catch 
+          (fun () ->
+	    S.read_exn t (SHA.of_hex id) >>= fun v -> begin
+	      let t, c, s =
+	        match v with
+	        | Value.Blob blob -> 
+		    let c = Blob.pretty blob in
+		    "blob", c, String.length c
+	        | Value.Commit commit ->
+		    let c = Commit.pretty commit in
+		    "commit", c, String.length c
+	        | Value.Tree tree ->
+		    let c = Tree.pretty tree in
+		    "tree", c, String.length c
+	        | Value.Tag tag ->
+		    let c = Tag.pretty tag in
+		    "tag", c, String.length c
+	      in
+	      if ty_flag then
+	        Printf.printf "%s%!" t;
 
-	  if sz_flag then
-	    Printf.printf "%d%!" s;
+	      if sz_flag then
+	        Printf.printf "%d%!" s;
 
-	  if not ty_flag && not sz_flag then
-	    Printf.printf "%s%!" c;
+	      if not ty_flag && not sz_flag then
+	        Printf.printf "%s%!" c;
 
-	  return_unit
-	end 
+	      return_unit
+	    end 
+          )
+          (function
+            | SHA.Ambiguous -> eprintf "ambiguous argument\n%!"; exit 1
+            | Not_found ->
+                eprintf "unknown revision or path not in the working tree\n%!";
+                exit 1
+            | e -> eprintf "%s\n%!" (Printexc.to_string e); exit 1
+          )
     end
   in
   Term.(mk cat_file $ backend $ ty_flag $ sz_flag $ id)
@@ -327,7 +337,15 @@ let ls_tree = {
           end
         in
         let sha1 = SHA.of_hex oid in
-        walk recurse_flag "" sha1
+        Lwt.catch
+          (fun () -> walk recurse_flag "" sha1)
+          (function
+            | SHA.Ambiguous -> eprintf "ambiguous argument\n%!"; exit 1
+            | Not_found ->
+                eprintf "unknown revision or path not in the working tree\n%!";
+                exit 1
+            | e -> eprintf "%s\n%!" (Printexc.to_string e); exit 1
+          )          
     end 
   in
   Term.(mk ls $ backend $ recurse_flag $ oid)

--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -188,7 +188,7 @@ let cat_file = {
   let ty_flag = mk_flag ["t"] "Instead of the content, show the object type." in
   let sz_flag = mk_flag ["s"] "Instead of the content, show the object size." in
   let id =
-    let doc = Arg.info ~docv:"ID" ~doc:"The id of the repository object." [] in
+    let doc = Arg.info ~docv:"SHA1" ~doc:"The SHA1 of the repository object." [] in
     Arg.(required & pos 0 (some string) None & doc) 
   in
   let cat_file (module S: Store.S) ty_flag sz_flag id =
@@ -281,8 +281,8 @@ let ls_tree = {
   term =
   let recurse_flag = mk_flag ["r"] "Recurse into sub-trees." in
   let oid =
-    let doc = Arg.info [] ~docv:"ID"
-        ~doc:"The id of the commit." 
+    let doc = Arg.info [] ~docv:"SHA1"
+        ~doc:"The SHA1 of the tree." 
     in
     Arg.(required & pos 0 (some string) None & doc ) 
   in

--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -313,7 +313,7 @@ let ls_tree = {
         let rec walk recurse show_tree only_tree path sha1 =
           S.read_exn t sha1 >>= fun v -> begin
             match v with
-            | Value.Blob blob -> begin
+            | Value.Blob _ -> begin
                 printf "blob %s %s\n" (SHA.to_hex sha1) path;
                 return_unit
             end
@@ -338,7 +338,7 @@ let ls_tree = {
                       return_unit
                   ) tree
             end
-            | Value.Tag tag -> begin
+            | Value.Tag _ -> begin
                 printf "tag %s %s\n" (SHA.to_hex sha1) path;
                 return_unit
             end

--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -184,55 +184,55 @@ let cat_file = {
   doc  = "Provide content or type and size information for repository objects";
   man  = [];
   term =
-  let ty_flag = mk_flag ["t"] "Instead of the content, show the object type." in
-  let sz_flag = mk_flag ["s"] "Instead of the content, show the object size." in
-  let id =
-    let doc = Arg.info ~docv:"SHA1" ~doc:"The SHA1 of the repository object." [] in
-    Arg.(required & pos 0 (some string) None & doc) 
-  in
-  let cat_file (module S: Store.S) ty_flag sz_flag id =
-    run begin
-      S.create () >>= fun t ->
+    let ty_flag = mk_flag ["t"] "Instead of the content, show the object type." in
+    let sz_flag = mk_flag ["s"] "Instead of the content, show the object size." in
+    let id =
+      let doc = Arg.info ~docv:"SHA1" ~doc:"The SHA1 of the repository object." [] in
+      Arg.(required & pos 0 (some string) None & doc) 
+    in
+    let cat_file (module S: Store.S) ty_flag sz_flag id =
+      run begin
+        S.create () >>= fun t ->
         Lwt.catch 
           (fun () ->
-	    S.read_exn t (SHA.of_hex id) >>= fun v -> begin
-	      let t, c, s =
-	        match v with
-	        | Value.Blob blob -> 
-		    let c = Blob.to_raw blob in
-		    "blob", c, String.length c
-	        | Value.Commit commit ->
-		    let c = Commit.pretty commit in
-		    "commit", c, String.length c
-	        | Value.Tree tree ->
-		    let c = Tree.pretty tree in
-		    "tree", c, String.length c
-	        | Value.Tag tag ->
-		    let c = Tag.pretty tag in
-		    "tag", c, String.length c
-	      in
-	      if ty_flag then
-	        Printf.printf "%s%!" t;
+             S.read_exn t (SHA.of_hex id) >>= fun v -> begin
+               let t, c, s =
+                 match v with
+                 | Value.Blob blob -> 
+                   let c = Blob.to_raw blob in
+                   "blob", c, String.length c
+                 | Value.Commit commit ->
+                   let c = Commit.pretty commit in
+                   "commit", c, String.length c
+                 | Value.Tree tree ->
+                   let c = Tree.pretty tree in
+                   "tree", c, String.length c
+                 | Value.Tag tag ->
+                   let c = Tag.pretty tag in
+                   "tag", c, String.length c
+               in
+               if ty_flag then
+                 Printf.printf "%s%!" t;
 
-	      if sz_flag then
-	        Printf.printf "%d%!" s;
+               if sz_flag then
+                 Printf.printf "%d%!" s;
 
-	      if not ty_flag && not sz_flag then
-	        Printf.printf "%s%!" c;
+               if not ty_flag && not sz_flag then
+                 Printf.printf "%s%!" c;
 
-	      return_unit
-	    end 
+               return_unit
+             end 
           )
           (function
             | SHA.Ambiguous -> eprintf "ambiguous argument\n%!"; exit 1
             | Not_found ->
-                eprintf "unknown revision or path not in the working tree\n%!";
-                exit 1
+              eprintf "unknown revision or path not in the working tree\n%!";
+              exit 1
             | e -> eprintf "%s\n%!" (Printexc.to_string e); exit 1
           )
-    end
-  in
-  Term.(mk cat_file $ backend $ ty_flag $ sz_flag $ id)
+      end
+    in
+    Term.(mk cat_file $ backend $ ty_flag $ sz_flag $ id)
 }
 
 (* LS-REMOTE *)
@@ -288,20 +288,20 @@ let ls_tree = {
   doc  = "List the contents of a tree object.";
   man  = [];
   term =
-  let recurse_flag = mk_flag ["r"] "Recurse into sub-trees." in
-  let show_tree_flag = 
-    mk_flag ["t"] "Show tree entries even when going to recurse them." 
-  in
-  let only_tree_flag = mk_flag ["d"] "Show only the named tree entry itself." in
-  let oid =
-    let doc = Arg.info [] ~docv:"SHA1"
-        ~doc:"The SHA1 of the tree." 
+    let recurse_flag = mk_flag ["r"] "Recurse into sub-trees." in
+    let show_tree_flag = 
+      mk_flag ["t"] "Show tree entries even when going to recurse them." 
     in
-    Arg.(required & pos 0 (some string) None & doc ) 
-  in
-  let ls (module S: Store.S) recurse_flag show_tree_flag only_tree_flag oid =
-    run begin
-      S.create () >>= fun t ->
+    let only_tree_flag = mk_flag ["d"] "Show only the named tree entry itself." in
+    let oid =
+      let doc = Arg.info [] ~docv:"SHA1"
+          ~doc:"The SHA1 of the tree." 
+      in
+      Arg.(required & pos 0 (some string) None & doc ) 
+    in
+    let ls (module S: Store.S) recurse_flag show_tree_flag only_tree_flag oid =
+      run begin
+        S.create () >>= fun t ->
 
         let get_kind = function
           | `Dir    -> "tree",   true
@@ -315,36 +315,36 @@ let ls_tree = {
             | Value.Blob _ -> begin
                 printf "blob %s %s\n" (SHA.to_hex sha1) path;
                 return_unit
-            end
+              end
             | Value.Tree tree -> begin
                 Lwt_list.iter_s
                   (fun e -> 
-                    let path' = Filename.concat path e.Tree.name in
-                    let kind, is_dir = get_kind e.Tree.perm in
-                    let mode = Tree.fixed_length_string_of_perm e.Tree.perm in
-                    let show =
-                      if is_dir then
-                        not recurse || show_tree || only_tree
-                      else
-                        not only_tree
-                    in
-                    if show then
-                      print_string (String.concat "" [mode; " "; kind; " "; SHA.to_hex e.Tree.node; "\t"; path'; "\n"]);
-                      (*printf "%s %s %s\t%s\n" mode kind (SHA.to_hex e.Tree.node) path';*)
-                    if is_dir && recurse then
-                      walk recurse show_tree only_tree path' e.Tree.node
-                    else
-                      return_unit
+                     let path' = Filename.concat path e.Tree.name in
+                     let kind, is_dir = get_kind e.Tree.perm in
+                     let mode = Tree.fixed_length_string_of_perm e.Tree.perm in
+                     let show =
+                       if is_dir then
+                         not recurse || show_tree || only_tree
+                       else
+                         not only_tree
+                     in
+                     if show then
+                       print_string (String.concat "" [mode; " "; kind; " "; SHA.to_hex e.Tree.node; "\t"; path'; "\n"]);
+                     (*printf "%s %s %s\t%s\n" mode kind (SHA.to_hex e.Tree.node) path';*)
+                     if is_dir && recurse then
+                       walk recurse show_tree only_tree path' e.Tree.node
+                     else
+                       return_unit
                   ) tree
-            end
+              end
             | Value.Tag _ -> begin
                 printf "tag %s %s\n" (SHA.to_hex sha1) path;
                 return_unit
-            end
+              end
             | Value.Commit commit -> begin
                 (* printf "commit %s %s\n" (SHA.to_hex sha1) path; *)
                 walk recurse show_tree only_tree path (SHA.of_tree commit.Commit.tree)
-            end
+              end
           end
         in
         let sha1 = SHA.of_hex oid in
@@ -353,13 +353,13 @@ let ls_tree = {
           (function
             | SHA.Ambiguous -> eprintf "ambiguous argument\n%!"; exit 1
             | Not_found ->
-                eprintf "unknown revision or path not in the working tree\n%!";
-                exit 1
+              eprintf "unknown revision or path not in the working tree\n%!";
+              exit 1
             | e -> eprintf "%s\n%!" (Printexc.to_string e); exit 1
           )          
-    end 
-  in
-  Term.(mk ls $ backend $ recurse_flag $ show_tree_flag $ only_tree_flag $ oid)
+      end 
+    in
+    Term.(mk ls $ backend $ recurse_flag $ show_tree_flag $ only_tree_flag $ oid)
 }
 
 (* READ-TREE *)
@@ -545,7 +545,7 @@ let help = {
         | `Error e                -> `Error (false, e)
         | `Ok t when t = "topics" -> List.iter print_endline cmds; `Ok ()
         | `Ok t                   -> `Help (man_format, Some t) in
-  Term.(ret (pure help $Term.man_format $Term.choice_names $topic))
+    Term.(ret (pure help $Term.man_format $Term.choice_names $topic))
 }
 
 let default =
@@ -566,15 +566,15 @@ let default =
       "usage: ogit [--version]\n\
       \            [--help]\n\
       \            <command> [<args>]\n\
-      \n\
-      The most commonly used commands are:\n\
+       \n\
+       The most commonly used commands are:\n\
       \    clone       %s\n\
       \    fetch       %s\n\
       \    pull        %s\n\
       \    push        %s\n\
       \    graph       %s\n\
-      \n\
-      See 'ogit help <command>' for more information on a specific command.\n%!"
+       \n\
+       See 'ogit help <command>' for more information on a specific command.\n%!"
       clone.doc fetch.doc pull.doc push.doc graph.doc in
   Term.(pure usage $ (pure ())),
   Term.info "ogit"

--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -158,6 +158,7 @@ let run t =
   )
 
 (* CAT *)
+(*
 let cat = {
   name = "cat-file";
   doc  = "Provide content or type and size information for repository objects";
@@ -176,6 +177,53 @@ let cat = {
         return_unit
       end in
     Term.(mk cat_file $ file)
+}
+*)
+(* CAT-FILE *)
+let cat_file = {
+  name = "cat-file";
+  doc  = "Provide content or type and size information for repository objects";
+  man  = [];
+  term =
+  let ty_flag = mk_flag ["t"] "Instead of the content, show the object type." in
+  let sz_flag = mk_flag ["s"] "Instead of the content, show the object size." in
+  let id =
+    let doc = Arg.info ~docv:"ID" ~doc:"The id of the repository object." [] in
+    Arg.(required & pos 0 (some string) None & doc) 
+  in
+  let cat_file (module S: Store.S) ty_flag sz_flag id =
+    run begin
+      S.create () >>= fun t ->
+	S.read_exn t (SHA.of_hex id) >>= fun v -> begin
+	  let t, c, s =
+	    match v with
+	    | Value.Blob blob -> 
+		let c = Blob.pretty blob in
+		"blob", c, String.length c
+	    | Value.Commit commit ->
+		let c = Commit.pretty commit in
+		"commit", c, String.length c
+	    | Value.Tree tree ->
+		let c = Tree.pretty tree in
+		"tree", c, String.length c
+	    | Value.Tag tag ->
+		let c = Tag.pretty tag in
+		"tag", c, String.length c
+	  in
+	  if ty_flag then
+	    Printf.printf "%s%!" t;
+
+	  if sz_flag then
+	    Printf.printf "%d%!" s;
+
+	  if not ty_flag && not sz_flag then
+	    Printf.printf "%s%!" c;
+
+	  return_unit
+	end 
+    end
+  in
+  Term.(mk cat_file $ backend $ ty_flag $ sz_flag $ id)
 }
 
 (* LS-REMOTE *)
@@ -223,6 +271,66 @@ let ls_files = {
         return_unit
       end in
     Term.(mk ls $ backend $ debug)
+}
+
+(* LS-TREE *)
+let ls_tree = {
+  name = "ls-tree";
+  doc  = "List the contents of a tree object.";
+  man  = [];
+  term =
+  let recurse_flag = mk_flag ["r"] "Recurse into sub-trees." in
+  let oid =
+    let doc = Arg.info [] ~docv:"ID"
+        ~doc:"The id of the commit." 
+    in
+    Arg.(required & pos 0 (some string) None & doc ) 
+  in
+  let ls (module S: Store.S) recurse_flag oid =
+    run begin
+      S.create () >>= fun t ->
+
+        let get_kind = function
+          | `Dir    -> "tree",   true
+          | `Commit -> "commit", false
+          | _       -> "blob",   false
+        in
+
+        let rec walk recurse path sha1 =
+          S.read_exn t sha1 >>= fun v -> begin
+            match v with
+            | Value.Blob blob -> begin
+                printf "blob %s %s\n" (SHA.to_hex sha1) path;
+                return_unit
+            end
+            | Value.Tree tree -> begin
+                Lwt_list.iter_s
+                  (fun e -> 
+                    let path' = Filename.concat path e.Tree.name in
+                    let kind, is_dir = get_kind e.Tree.perm in
+                    let mode = Tree.string_of_perm e.Tree.perm in
+                    printf "%s %s %s\t%s\n" mode kind (SHA.to_hex e.Tree.node) path';
+                    if is_dir && recurse then
+                      walk recurse path' e.Tree.node
+                    else
+                      return_unit
+                  ) tree
+            end
+            | Value.Tag tag -> begin
+                printf "tag %s %s\n" (SHA.to_hex sha1) path;
+                return_unit
+            end
+            | Value.Commit commit -> begin
+                printf "commit %s %s\n" (SHA.to_hex sha1) path;
+                walk recurse path (SHA.of_tree commit.Commit.tree)
+            end
+          end
+        in
+        let sha1 = SHA.of_hex oid in
+        walk recurse_flag "" sha1
+    end 
+  in
+  Term.(mk ls $ backend $ recurse_flag $ oid)
 }
 
 (* READ-TREE *)
@@ -447,9 +555,10 @@ let default =
     ~man
 
 let commands = List.map command [
-    cat;
+    cat_file;
     ls_remote;
     ls_files;
+    ls_tree;
     read_tree;
     clone;
     fetch;

--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -321,7 +321,7 @@ let ls_tree = {
                   (fun e -> 
                     let path' = Filename.concat path e.Tree.name in
                     let kind, is_dir = get_kind e.Tree.perm in
-                    let mode = Tree.string_of_perm e.Tree.perm in
+                    let mode = Tree.fixed_length_string_of_perm e.Tree.perm in
                     let show =
                       if is_dir then
                         not recurse || show_tree || only_tree

--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -325,7 +325,7 @@ let ls_tree = {
                     let mode = Tree.string_of_perm e.Tree.perm in
                     let show =
                       if is_dir then
-                        show_tree || only_tree
+                        not recurse || show_tree || only_tree
                       else
                         not only_tree
                     in

--- a/bin/ogit.ml
+++ b/bin/ogit.ml
@@ -158,9 +158,8 @@ let run t =
   )
 
 (* CAT *)
-(*
 let cat = {
-  name = "cat-file";
+  name = "cat";
   doc  = "Provide content or type and size information for repository objects";
   man  = [];
   term =
@@ -178,7 +177,7 @@ let cat = {
       end in
     Term.(mk cat_file $ file)
 }
-*)
+
 (* CAT-FILE *)
 let cat_file = {
   name = "cat-file";
@@ -585,6 +584,7 @@ let default =
     ~man
 
 let commands = List.map command [
+    cat;
     cat_file;
     ls_remote;
     ls_files;

--- a/lib/FS.ml
+++ b/lib/FS.ml
@@ -350,7 +350,15 @@ module Make (IO: IO) = struct
       read_index_c t pack_sha1 >>= fun idx -> 
         Lwt.return (idx#mem sha1)
 
-    let pack_ba_cache = Hashtbl.create 1024
+    let pack_size_thresh = 10000000
+
+    let pack_ba_cache = Hashtbl.create 8
+
+    let cache_pack sha buf =
+      let ba = Cstruct.to_bigarray buf in
+      let sz = Bigarray.Array1.dim ba in
+      if sz < pack_size_thresh then
+        Hashtbl.add pack_ba_cache sha ba
 
     let read_in_pack t pack_sha1 sha1 =
       Log.debug "read_in_pack %s:%s"
@@ -381,7 +389,7 @@ module Make (IO: IO) = struct
                 IO.file_exists file >>= function
                   | true ->
 	              IO.read_file file >>= fun buf ->
-                        Hashtbl.add pack_ba_cache pack_sha1 (Cstruct.to_bigarray buf);
+                        cache_pack pack_sha1 buf;
 	                let v_opt = Pack.Raw.read (Mstruct.of_cstruct buf) index sha1 in
 	                return v_opt
                   | false ->

--- a/lib/FS.ml
+++ b/lib/FS.ml
@@ -120,10 +120,10 @@ module Make (IO: IO) = struct
   let create ?root ?(level=6) () =
     if level < 0 || level > 9 then failwith "level should be between 0 and 9";
     begin match root with
-    | None   -> IO.getcwd ()
-    | Some r ->
-      IO.mkdir r >>= fun () ->
-      IO.realpath r
+      | None   -> IO.getcwd ()
+      | Some r ->
+        IO.mkdir r >>= fun () ->
+        IO.realpath r
     end >>= fun root ->
     Lwt.return { root; level }
 
@@ -147,61 +147,61 @@ module Make (IO: IO) = struct
 
     let get_file { root; _ } sha1 =
       IO.directories (root / ".git" / "objects") >>= fun dirs ->
-        let hex = SHA.to_hex sha1 in
-        let len = String.length hex in
-        let len_le_2 = len <= 2 in
-        let dcands = 
-          if len_le_2 then
-            List.filter 
-              (fun d -> 
-                (String.sub (Filename.basename d) 0 len) = hex
-              ) dirs
-          else
-            List.filter (fun d -> (Filename.basename d) = (String.sub hex 0 2)) dirs 
-        in
-        match dcands with
-        | [] -> Lwt.return_none
-        | [dir] -> begin
-            Log.debug "get_file: %s" dir;
-            IO.files dir >>= fun files ->
-              let fcands =
-                if len_le_2 then
-                  files
-                else
-                  let len' = len - 2 in
-                  let suffix = String.sub hex 2 len' in
-                  List.filter 
-                    (fun f -> (String.sub (Filename.basename f) 0 len') = suffix) 
-                    files 
-              in
-              match fcands with
-              | [] -> Lwt.return_none
-              | [file] -> Lwt.return (Some file)
-              | _ -> raise SHA.Ambiguous
+      let hex = SHA.to_hex sha1 in
+      let len = String.length hex in
+      let len_le_2 = len <= 2 in
+      let dcands = 
+        if len_le_2 then
+          List.filter 
+            (fun d -> 
+               (String.sub (Filename.basename d) 0 len) = hex
+            ) dirs
+        else
+          List.filter (fun d -> (Filename.basename d) = (String.sub hex 0 2)) dirs 
+      in
+      match dcands with
+      | [] -> Lwt.return_none
+      | [dir] -> begin
+          Log.debug "get_file: %s" dir;
+          IO.files dir >>= fun files ->
+          let fcands =
+            if len_le_2 then
+              files
+            else
+              let len' = len - 2 in
+              let suffix = String.sub hex 2 len' in
+              List.filter 
+                (fun f -> (String.sub (Filename.basename f) 0 len') = suffix) 
+                files 
+          in
+          match fcands with
+          | [] -> Lwt.return_none
+          | [file] -> Lwt.return (Some file)
+          | _ -> raise SHA.Ambiguous
         end
-        | _ -> raise SHA.Ambiguous
+      | _ -> raise SHA.Ambiguous
 
     let read_file file =
       File_cache.read file >>= fun buf ->
-        try
-          let value = Value.input (Mstruct.of_cstruct buf) in
-          Lwt.return (Some value)
-        with Zlib.Error _ ->
-          Lwt.fail (Zlib.Error (file, (Cstruct.to_string buf)))
+      try
+        let value = Value.input (Mstruct.of_cstruct buf) in
+        Lwt.return (Some value)
+      with Zlib.Error _ ->
+        Lwt.fail (Zlib.Error (file, (Cstruct.to_string buf)))
 
     let read t sha1 =
       Log.debug "read %s" (SHA.to_hex sha1);
       if SHA.is_short sha1 then begin
         Log.debug "read: short sha1";
         get_file t sha1 >>= function
-          | Some file -> read_file file
-          | None -> Lwt.return_none
+        | Some file -> read_file file
+        | None -> Lwt.return_none
       end
       else begin
         let file = file t sha1 in
         IO.file_exists file >>= function
-          | false -> Lwt.return_none
-          | true  -> read_file file
+        | false -> Lwt.return_none
+        | true  -> read_file file
       end
 
     let write t value =
@@ -253,14 +253,14 @@ module Make (IO: IO) = struct
       Log.debug "list %s" root;
       let packs = root / ".git" / "objects" / "pack" in
       IO.files packs >>= fun packs ->
-        let packs = List.map Filename.basename packs in
-        let packs = List.filter (fun f -> Filename.check_suffix f ".idx") packs in
-        let packs = List.map (fun f ->
+      let packs = List.map Filename.basename packs in
+      let packs = List.filter (fun f -> Filename.check_suffix f ".idx") packs in
+      let packs = List.map (fun f ->
           let p = Filename.chop_suffix f ".idx" in
           let p = String.sub p 5 (String.length p - 5) in
           SHA.of_hex p
-                             ) packs in
-        Lwt.return packs
+        ) packs in
+      Lwt.return packs
 
     let index { root; _ } sha1 =
       let pack_dir = root / ".git" / "objects" / "pack" in
@@ -276,16 +276,16 @@ module Make (IO: IO) = struct
       match LRU.find index_c_lru sha1 with
       | Some i -> Log.debug "read_index_c cache hit!"; Lwt.return i
       | None ->
-          let file = index t sha1 in
-          IO.file_exists file >>= function
-            | true ->
-                IO.read_file file >>= fun buf ->
-                  let index = Pack_index.create (Cstruct.to_bigarray buf) in
-                  LRU.add index_c_lru sha1 index;
-                  Lwt.return index
-            | false ->
-                Log.error "%s does not exist." file;
-	        Lwt.fail (Failure "read_index_c")
+        let file = index t sha1 in
+        IO.file_exists file >>= function
+        | true ->
+          IO.read_file file >>= fun buf ->
+          let index = Pack_index.create (Cstruct.to_bigarray buf) in
+          LRU.add index_c_lru sha1 index;
+          Lwt.return index
+        | false ->
+          Log.error "%s does not exist." file;
+          Lwt.fail (Failure "read_index_c")
 
     let write_pack_index t sha1 idx =
       LRU.add index_lru sha1 idx;
@@ -368,7 +368,7 @@ module Make (IO: IO) = struct
     let mem_in_pack t pack_sha1 sha1 =
       Log.debug "mem_in_pack %s:%s" (SHA.to_hex pack_sha1) (SHA.to_hex sha1);
       read_index_c t pack_sha1 >>= fun idx -> 
-        Lwt.return (Pack_index.mem idx sha1)
+      Lwt.return (Pack_index.mem idx sha1)
 
     let pack_size_thresh = 10000000
 
@@ -384,31 +384,31 @@ module Make (IO: IO) = struct
       Log.debug "read_in_pack %s:%s"
         (SHA.to_hex pack_sha1) (SHA.to_hex sha1);
       read_index_c t pack_sha1 >>= fun index ->
-        if Pack_index.mem index sha1 then begin
-          try
-            let ba = Hashtbl.find pack_ba_cache pack_sha1 in
-            Log.debug "read_in_pack ba cache hit!";
-            let v_opt = Pack.Raw.read (Mstruct.of_bigarray ba) index sha1 in
-            Lwt.return v_opt
-          with
-            Not_found -> begin
-	      let file = file t pack_sha1 in
-              IO.file_exists file >>= function
-                | true ->
-	            IO.read_file file >>= fun buf ->
-                      cache_pack pack_sha1 buf;
-                      let v_opt = Pack.Raw.read (Mstruct.of_cstruct buf) index sha1 in
-                      Lwt.return v_opt
-                | false ->
-	            Log.error
-	              "No file associated with the pack object %s.\n" (SHA.to_hex pack_sha1);
-	            Lwt.fail (Failure "read_in_pack")
-            end
-        end
-        else begin
-          Log.debug "read_in_pack: not found";
-          Lwt.return_none
-        end
+      if Pack_index.mem index sha1 then begin
+        try
+          let ba = Hashtbl.find pack_ba_cache pack_sha1 in
+          Log.debug "read_in_pack ba cache hit!";
+          let v_opt = Pack.Raw.read (Mstruct.of_bigarray ba) index sha1 in
+          Lwt.return v_opt
+        with
+          Not_found -> begin
+            let file = file t pack_sha1 in
+            IO.file_exists file >>= function
+            | true ->
+              IO.read_file file >>= fun buf ->
+              cache_pack pack_sha1 buf;
+              let v_opt = Pack.Raw.read (Mstruct.of_cstruct buf) index sha1 in
+              Lwt.return v_opt
+            | false ->
+              Log.error
+                "No file associated with the pack object %s.\n" (SHA.to_hex pack_sha1);
+              Lwt.fail (Failure "read_in_pack")
+          end
+      end
+      else begin
+        Log.debug "read_in_pack: not found";
+        Lwt.return_none
+      end
 
     let read t sha1 =
       list t >>= fun packs ->

--- a/lib/SHA.ml
+++ b/lib/SHA.ml
@@ -48,10 +48,9 @@ let sha_to_string t =
 let get_upper c = (Char.code c) land 0xf0
 
 let sha_compare x y = 
-  Log.debugf "sha_compare: %s vs %s" (sha_to_string x) (sha_to_string y);
+  (*Log.debugf "sha_compare: %s vs %s" (sha_to_string x) (sha_to_string y);*)
   let nx = String.length x.raw in
   let ny = String.length y.raw in
-  let pad_same = x.padded && y.padded in
   let res =
     if nx = ny && not x.padded && not y.padded then
       String.compare x.raw y.raw
@@ -61,7 +60,7 @@ let sha_compare x y =
         if i = len then
           raise Ambiguous
         else
-          if pad_same || i < len then
+          if (x.padded && y.padded) || i < len then
             let x0 = x.raw.[i] in
             let y0 = y.raw.[i] in
             if x0 < y0 then
@@ -83,7 +82,7 @@ let sha_compare x y =
       scan 0
     end
   in
-  Log.debugf "sha_compare: result=%d" res;
+  (*Log.debugf "sha_compare: result=%d" res;*)
   res
 
 module SHA1_String = struct

--- a/lib/SHA.ml
+++ b/lib/SHA.ml
@@ -27,39 +27,123 @@ module type S = sig
   val input_hex: Mstruct.t -> t
   val add_hex: Buffer.t -> t -> unit
   val zero: t
+  val is_short: t -> bool
+  val lt: t -> t -> bool
+  val is_prefix: t -> t -> bool
   module Set: Misc.Set with type elt = t
   module Map: Misc.Map with type key = t
 end
 
+type sha_t = { raw    : string;
+               padded : bool;   (* for hex of odd length *)
+             }
+
+exception Ambiguous
+
+let sha_compare x y = 
+  let nx = String.length x.raw in
+  let ny = String.length y.raw in
+  let pad_same = x.padded && y.padded in
+  if nx = ny && not x.padded && not y.padded then
+    String.compare x.raw y.raw
+  else begin
+    let len = min nx ny in
+    let rec scan i =
+      if i = len then
+        raise Ambiguous
+      else
+        let x0 = x.raw.[i] in
+        let x1 = y.raw.[i] in
+        if x0 < x1 && pad_same then
+          -1
+        else if x0 > x1 && pad_same then
+          1
+        else
+          scan (i + 1)
+    in
+    scan 0
+  end
+
 module SHA1_String = struct
 
-  type t = string
+  type t = sha_t
+
+  let length x = (* 0 <= length <= 40 *)
+    let n = (String.length x.raw) * 2 in
+    if x.padded then
+      n - 1
+    else
+      n
+
+  let is_short x = (length x) < 40
 
   let equal x y = (x=y)
 
-  let hash x = Hashtbl.hash x
+  let hash x = Hashtbl.hash x.raw
 
-  let compare x y = String.compare x y
+  let compare = sha_compare
 
-  let to_raw x = x
+  let is_prefix p x =
+    let np = length p in
+    let nx = length x in
+    if np > nx then
+      false
+    else if np = nx then
+      equal p x
+    else 
+      let n =
+        if p.padded then
+          (String.length p.raw) - 1
+        else
+          String.length p.raw
+      in
+      try
+        for i = 0 to n - 1 do
+          if p.raw.[i] <> x.raw.[i] then
+            raise Exit
+        done;
+        if p.padded then
+          ((Char.code p.raw.[n]) land 0xf0) = ((Char.code x.raw.[n]) land 0xf0)
+        else
+          true
+      with
+        Exit -> false
 
-  let of_raw x = x
+  let lt x y = compare x y < 0
+
+  let to_raw x = x.raw
+
+  let of_raw x = { raw=x; padded=false; }
 
   let of_string str =
     Cstruct.of_string str
     |> Nocrypto.Hash.SHA1.digest
     |> Cstruct.to_string
+    |> fun x -> { raw=x; padded=false; }
 
   let of_cstruct c =
     Nocrypto.Hash.SHA1.digest c
     |> Cstruct.to_string
+    |> fun x -> { raw=x; padded=false; }
 
   let to_hex t =
-    let `Hex h = Hex.of_string t in
-    h
+    let `Hex h = Hex.of_string t.raw in
+    if t.padded then
+      String.sub h 0 ((String.length h) - 1)
+    else
+      h
 
   let of_hex h =
-    Hex.to_string (`Hex h)
+    let len = String.length h in
+    let h' =
+      if (len mod 2) = 1 then
+        h ^ "0"
+      else
+        h
+    in
+    { raw    = Hex.to_string (`Hex h');
+      padded = true;
+    }
 
   let zero =
     of_hex (String.make 40 '0')
@@ -69,10 +153,10 @@ module SHA1_String = struct
   let pp_hum ppf t = Format.fprintf ppf "%s" (pretty t)
 
   let input buf =
-    Mstruct.get_string buf 20
+    { raw=Mstruct.get_string buf 20; padded=false; }
 
   let add buf ?level:_ t =
-    Buffer.add_string buf t
+    Buffer.add_string buf t.raw
 
   let input_hex buf =
     of_hex (Mstruct.get_string buf (Mstruct.length buf))
@@ -81,8 +165,8 @@ module SHA1_String = struct
     Buffer.add_string buf (to_hex t)
 
   module X = struct
-    type t = string
-    let compare = String.compare
+    type t = sha_t
+    let compare = sha_compare
     let pretty = pretty
   end
   module Map = Misc.Map(X)

--- a/lib/SHA.ml
+++ b/lib/SHA.ml
@@ -27,6 +27,7 @@ module type S = sig
   val input_hex: Mstruct.t -> t
   val add_hex: Buffer.t -> t -> unit
   val zero: t
+  val length: t -> int
   val is_short: t -> bool
   val lt: t -> t -> bool
   val is_prefix: t -> t -> bool
@@ -39,7 +40,6 @@ type sha_t = { raw    : string;
              }
 
 exception Ambiguous
-exception Too_short
 
 let sha_to_string t =
   let `Hex h = Hex.of_string t.raw in
@@ -157,19 +157,16 @@ module SHA1_String = struct
 
   let of_hex h =
     let len = String.length h in
-    if len < 7 then
-      raise Too_short
-    else
-      let to_be_padded = (len mod 2) = 1 in
-      let h' =
-        if to_be_padded then
-          h ^ "0"
-        else
-          h
-      in
-      { raw    = Hex.to_string (`Hex h');
-        padded = to_be_padded;
-      }
+    let to_be_padded = (len mod 2) = 1 in
+    let h' =
+      if to_be_padded then
+        h ^ "0"
+      else
+        h
+    in
+    { raw    = Hex.to_string (`Hex h');
+      padded = to_be_padded;
+    }
 
   let zero =
     of_hex (String.make 40 '0')

--- a/lib/SHA.ml
+++ b/lib/SHA.ml
@@ -39,30 +39,52 @@ type sha_t = { raw    : string;
              }
 
 exception Ambiguous
+exception Too_short
+
+let sha_to_string t =
+  let `Hex h = Hex.of_string t.raw in
+  h^(if t.padded then "(PADDED)" else "")
+
+let get_upper c = (Char.code c) land 0xf0
 
 let sha_compare x y = 
+  Log.debugf "sha_compare: %s vs %s" (sha_to_string x) (sha_to_string y);
   let nx = String.length x.raw in
   let ny = String.length y.raw in
   let pad_same = x.padded && y.padded in
-  if nx = ny && not x.padded && not y.padded then
-    String.compare x.raw y.raw
-  else begin
-    let len = min nx ny in
-    let rec scan i =
-      if i = len then
-        raise Ambiguous
-      else
-        let x0 = x.raw.[i] in
-        let x1 = y.raw.[i] in
-        if x0 < x1 && pad_same then
-          -1
-        else if x0 > x1 && pad_same then
-          1
+  let res =
+    if nx = ny && not x.padded && not y.padded then
+      String.compare x.raw y.raw
+    else begin
+      let len = min nx ny in
+      let rec scan i =
+        if i = len then
+          raise Ambiguous
         else
-          scan (i + 1)
-    in
-    scan 0
-  end
+          if pad_same || i < len then
+            let x0 = x.raw.[i] in
+            let y0 = y.raw.[i] in
+            if x0 < y0 then
+              -1
+            else if x0 > y0 then
+              1
+            else
+              scan (i + 1)
+          else
+            let x0 = get_upper x.raw.[i] in
+            let y0 = get_upper y.raw.[i] in
+            if x0 < y0 then
+              -1
+            else if x0 > y0 then
+              1
+            else
+              raise Ambiguous
+      in
+      scan 0
+    end
+  in
+  Log.debugf "sha_compare: result=%d" res;
+  res
 
 module SHA1_String = struct
 
@@ -103,7 +125,7 @@ module SHA1_String = struct
             raise Exit
         done;
         if p.padded then
-          ((Char.code p.raw.[n]) land 0xf0) = ((Char.code x.raw.[n]) land 0xf0)
+          (get_upper p.raw.[n]) = (get_upper x.raw.[n])
         else
           true
       with
@@ -135,16 +157,19 @@ module SHA1_String = struct
 
   let of_hex h =
     let len = String.length h in
-    let to_be_padded = (len mod 2) = 1 in
-    let h' =
-      if to_be_padded then
-        h ^ "0"
-      else
-        h
-    in
-    { raw    = Hex.to_string (`Hex h');
-      padded = to_be_padded;
-    }
+    if len < 7 then
+      raise Too_short
+    else
+      let to_be_padded = (len mod 2) = 1 in
+      let h' =
+        if to_be_padded then
+          h ^ "0"
+        else
+          h
+      in
+      { raw    = Hex.to_string (`Hex h');
+        padded = to_be_padded;
+      }
 
   let zero =
     of_hex (String.make 40 '0')

--- a/lib/SHA.ml
+++ b/lib/SHA.ml
@@ -60,24 +60,24 @@ let sha_compare x y =
         if i = len then
           raise Ambiguous
         else
-          if (x.padded && y.padded) || i < len then
-            let x0 = x.raw.[i] in
-            let y0 = y.raw.[i] in
-            if x0 < y0 then
-              -1
-            else if x0 > y0 then
-              1
-            else
-              scan (i + 1)
+        if (x.padded && y.padded) || i < len then
+          let x0 = x.raw.[i] in
+          let y0 = y.raw.[i] in
+          if x0 < y0 then
+            -1
+          else if x0 > y0 then
+            1
           else
-            let x0 = get_upper x.raw.[i] in
-            let y0 = get_upper y.raw.[i] in
-            if x0 < y0 then
-              -1
-            else if x0 > y0 then
-              1
-            else
-              raise Ambiguous
+            scan (i + 1)
+        else
+          let x0 = get_upper x.raw.[i] in
+          let y0 = get_upper y.raw.[i] in
+          if x0 < y0 then
+            -1
+          else if x0 > y0 then
+            1
+          else
+            raise Ambiguous
       in
       scan 0
     end

--- a/lib/SHA.ml
+++ b/lib/SHA.ml
@@ -135,14 +135,15 @@ module SHA1_String = struct
 
   let of_hex h =
     let len = String.length h in
+    let to_be_padded = (len mod 2) = 1 in
     let h' =
-      if (len mod 2) = 1 then
+      if to_be_padded then
         h ^ "0"
       else
         h
     in
     { raw    = Hex.to_string (`Hex h');
-      padded = true;
+      padded = to_be_padded;
     }
 
   let zero =

--- a/lib/SHA.mli
+++ b/lib/SHA.mli
@@ -47,6 +47,9 @@ module type S = sig
   val zero: t
   (** A SHA1 full of zero. Useful for padding. *)
 
+  val length: t -> int
+  (** The number of hex digits in the SHA1. *)
+
   val is_short: t -> bool
   (** Check if the SHA1 is abbreviated. *)
 

--- a/lib/SHA.mli
+++ b/lib/SHA.mli
@@ -47,6 +47,15 @@ module type S = sig
   val zero: t
   (** A SHA1 full of zero. Useful for padding. *)
 
+  val is_short: t -> bool
+  (** Check if the SHA1 is abbreviated. *)
+
+  val lt: t -> t -> bool
+  (** (<) relation between SHA1s. *)
+
+  val is_prefix: t -> t -> bool
+  (** Check if a SHA1 is a prefix of another SHA1. *)
+
   module Set: Misc.Set with type elt = t
   module Map: Misc.Map with type key = t
 
@@ -82,3 +91,5 @@ val of_blob: Blob.t -> t
 
 val to_blob: t -> Blob.t
 (** A node might be a blob node. *)
+
+exception Ambiguous

--- a/lib/pack.ml
+++ b/lib/pack.ml
@@ -155,7 +155,7 @@ module Raw = struct
     let version, count = input_header buf in
     Log.debug "read: version=%d count=%d" version count;
     begin
-      match index#find_offset sha1 with
+      match Pack_index.find_offset index sha1 with
       | Some offset -> begin
           Log.debug "read: offset=%d" offset;
           let orig_off = Mstruct.offset buf in

--- a/lib/pack.ml
+++ b/lib/pack.ml
@@ -161,13 +161,13 @@ module Raw = struct
           let orig_off = Mstruct.offset buf in
           let orig_len = Mstruct.length buf in
           Log.debug "read: buf: orig_off=%d orig_len=%d" orig_off orig_len;
-	  let ba = Mstruct.to_bigarray buf in
+          let ba = Mstruct.to_bigarray buf in
           Mstruct.shift buf (offset - orig_off);
           Log.debug "read: buf: off=%d len=%d (after shift:%d)" (Mstruct.offset buf) (Mstruct.length buf) (offset-orig_off);
           let packed_v = input_packed_value ~version buf in
           Log.debug "read: buf: off=%d len=%d (after input_packed_value)" (Mstruct.offset buf) (Mstruct.length buf);
-	  Some (Packed_value.to_value ~version ~index ~ba (offset-orig_off, packed_v))
-      end
+          Some (Packed_value.to_value ~version ~index ~ba (offset-orig_off, packed_v))
+        end
       | None -> None
     end
 

--- a/lib/pack.ml
+++ b/lib/pack.ml
@@ -164,7 +164,7 @@ module Raw = struct
 	  let ba = Mstruct.to_bigarray buf in
           Mstruct.shift buf (offset - orig_off);
           Log.debug "read: buf: off=%d len=%d (after shift:%d)" (Mstruct.offset buf) (Mstruct.length buf) (offset-orig_off);
-          let packed_v = input_packed_value version buf in
+          let packed_v = input_packed_value ~version buf in
           Log.debug "read: buf: off=%d len=%d (after input_packed_value)" (Mstruct.offset buf) (Mstruct.length buf);
 	  Some (Packed_value.to_value ~version ~index ~ba (offset-orig_off, packed_v))
       end

--- a/lib/pack.mli
+++ b/lib/pack.mli
@@ -62,6 +62,9 @@ module Raw: sig
   val keys: t -> SHA.Set.t
   (** Return the keys present in the raw pack. *)
 
+  val read: Mstruct.t -> Pack_index.c_t -> SHA.t -> Value.t option
+  (** Same as the top-level [read] function but for raw packs. *)
+
 end
 
 val to_pic: Raw.t -> t

--- a/lib/pack_index.ml
+++ b/lib/pack_index.ml
@@ -259,89 +259,6 @@ class offset_cache size = object (self)
 end (* of class Pack_index.offset_cache *)
 
 
-module Oid = struct
-  type t =
-    | SHA1 of SHA.t
-    | Abbrev of string (* hex *)
-
-  let length = function
-    | SHA1 _ -> 40
-    | Abbrev h -> String.length h
-
-  let of_hex h =
-    let len = String.length h in
-    if len = 40 then
-      SHA1 (SHA.of_hex h)
-    else if len > 40 then
-      SHA1 (SHA.of_hex (String.sub h 0 40))
-    else
-      Abbrev h
-
-  let to_hex = function
-    | SHA1 sha -> SHA.to_hex sha
-    | Abbrev h -> h
-
-  let of_sha1 sha1 = SHA1 sha1
-
-  let sstartswith s s0 =
-    let len = String.length s in
-    let len0 = String.length s0 in
-    if len < len0 then
-      false
-    else
-      try
-        for i = 0 to len0 - 1 do
-	  if s.[i] != s0.[i] then
-	    raise Exit
-        done;
-        true
-      with 
-      | Exit -> false
-
-  let pair_to_str_pair = function
-    | SHA1 sha, SHA1 sha0 -> SHA.to_raw sha, SHA.to_raw sha0
-    | SHA1 sha, Abbrev h0 -> SHA.to_hex sha, h0
-    | Abbrev h, SHA1 sha0 -> h, SHA.to_hex sha0
-    | Abbrev h, Abbrev h0 -> h, h0
-
-  let startswith oid oid0 =
-    let s, s0 = pair_to_str_pair (oid, oid0) in
-    sstartswith s s0
-
-  exception Ambiguous
-
-  let slt s0 s1 =
-    let len0 = String.length s0 in
-    let len1 = String.length s1 in
-    let len = min len0 len1 in
-    let same = len0 = len1 in
-
-    let rec scan i =
-      if i = len then
-        if same then
-          false
-        else
-          raise Ambiguous
-      else
-        let x0 = s0.[i] in
-        let x1 = s1.[i] in
-        if x0 < x1 then
-          true
-        else if x0 > x1 then
-          false
-        else
-          scan (i + 1)
-    in
-    let b = scan 1 in
-    Log.debugf "Oid.slt: -> %B" b;
-    b
-
-  let lt oid oid0 =
-    let s, s0 = pair_to_str_pair (oid, oid0) in
-    slt s s0
-
-end
-
 exception Idx_found of int
 
 class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
@@ -507,7 +424,14 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
 
   (* implements binary search *)
   method private scan_sha1s fo_idx idx_ofs ofs n sha1 =
+<<<<<<< HEAD
     Log.debug "c#scan_sha1s: fo_idx:%d idx_ofs:%d ofs:%d n:%d" fo_idx idx_ofs ofs n;
+=======
+    let short_sha = SHA.is_short sha1 in
+    Log.debugf "c#scan_sha1s: fo_idx:%d idx_ofs:%d ofs:%d n:%d sha1:%s" 
+      fo_idx idx_ofs ofs n (if short_sha then "short" else "full");
+
+>>>>>>> experimental support of abbreviated SHA1
     let len = n * 20 in
     let buf = Mstruct.of_bigarray ~off:ofs ~len ba in
 
@@ -518,12 +442,43 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
       let len' = p * 20 in
       Mstruct.shift buf len';
       let s = SHA.input buf in
+
       if s = sha1 then begin
         let idx = idx_ofs + p in
+<<<<<<< HEAD
         Log.debug "c#scan_sha1s: idx -> %d" idx;
+=======
+        Log.debugf "c#scan_sha1s: idx -> %d (full)" idx;
+>>>>>>> experimental support of abbreviated SHA1
         raise (Idx_found idx)
       end
-      else if self#lt_sha1 sha1 s then
+      else if short_sha && SHA.is_prefix sha1 s then begin
+        let cur_ofs = ofs + len' in
+        let prev_ok =
+          if cur_ofs > sha1s_ofs then begin
+            Mstruct.shift buf 40;
+            not (SHA.is_prefix sha1 (SHA.input buf))
+          end
+          else
+            true
+        in
+        let next_ok = 
+          if cur_ofs < crcs_ofs - 20 then begin
+            Mstruct.shift buf 20;
+            not (SHA.is_prefix sha1 (SHA.input buf))
+          end
+          else
+            true
+        in
+        if prev_ok && next_ok then begin
+          let idx = idx_ofs + p in
+          Log.debugf "c#scan_sha1s: idx -> %d (short)" idx;
+          raise (Idx_found idx)
+        end
+        else
+          raise SHA.Ambiguous
+      end
+      else if SHA.lt sha1 s then
         self#scan_sha1s fo_idx idx_ofs ofs p sha1
       else
         let d = p + 1 in
@@ -533,26 +488,6 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
       Log.debug "c#scan_sha1s: scanning...";
       self#scan_sub idx_ofs sha1 buf 0 (n - 1)
     end
-
-  method private lt_sha1 sha1_0 sha1_1 =
-    let s0 = SHA.to_raw sha1_0 in
-    let s1 = SHA.to_raw sha1_1 in
-    let rec scan i =
-      let x0 = s0.[i] in
-      let x1 = s1.[i] in
-      if x0 < x1 then
-        true
-      else if x0 > x1 then
-        false
-      else
-        scan (i + 1)
-    in
-    try
-      let b = scan 1 in
-      Log.debugf "c#lt_sha1: -> %B" b;
-      b
-    with
-      Invalid_argument _ -> assert false
 
   method private scan_sub idx_ofs sha1 buf i m =
     if i > m then 

--- a/lib/pack_index.ml
+++ b/lib/pack_index.ml
@@ -334,7 +334,7 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
   method mem sha1 =
     Log.debug "c#mem: %s" (SHA.to_hex sha1);
     match self#find_offset sha1 with
-    | Some o -> 
+    | Some _ -> 
         Log.debug "c#mem: true"; 
         true
     | None -> 
@@ -419,7 +419,7 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
     ofs64_size <- Some !count;
     !count
 
-  method private get_fanout_idx ?(verbose=true) sha1 =
+  method private get_fanout_idx sha1 =
     let s = SHA.to_raw sha1 in
     let fanout_idx = int_of_char s.[0] in
     fanout_idx

--- a/lib/pack_index.ml
+++ b/lib/pack_index.ml
@@ -263,7 +263,7 @@ end (* of class Pack_index.offset_cache *)
 
 exception Idx_found of int
 
-class c ?(scan_thresh=8) ?(cache_size=0) (ba : Cstruct.buffer) = object (self)
+class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
 
   val cache = new offset_cache cache_size
 
@@ -427,24 +427,26 @@ class c ?(scan_thresh=8) ?(cache_size=0) (ba : Cstruct.buffer) = object (self)
   (* implements binary search *)
   method private scan_sha1s fo_idx idx_ofs ofs n sha1 =
     let short_sha = SHA.is_short sha1 in
+(*
     Log.debug "c#scan_sha1s: fo_idx:%d idx_ofs:%d ofs:%d n:%d sha1:%s" 
       fo_idx idx_ofs ofs n (if short_sha then "short" else "full");
+*)
     let len = n * 20 in
     let buf = Mstruct.of_bigarray ~off:ofs ~len ba in
 
     if n > scan_thresh then begin
-      Log.debug "c#scan_sha1s: %d > scan_thresh(=%d)" n scan_thresh;
+      (*Log.debug "c#scan_sha1s: %d > scan_thresh(=%d)" n scan_thresh;*)
       let p = n / 2 in
-      Log.debug "c#scan_sha1s: p:%d" p;
+      (*Log.debug "c#scan_sha1s: p:%d" p;*)
       let len' = p * 20 in
       Mstruct.shift buf len';
       let s = SHA.input buf in
 
-      Log.debug "c#scan_sha1s: s=%s" (SHA.to_hex s);
+      (*Log.debug "c#scan_sha1s: s=%s" (SHA.to_hex s);*)
 
       if s = sha1 then begin
         let idx = idx_ofs + p in
-        Log.debug "c#scan_sha1s: idx -> %d (full)" idx;
+        (*Log.debug "c#scan_sha1s: idx -> %d (full)" idx;*)
         raise (Idx_found idx)
       end
       else if short_sha && SHA.is_prefix sha1 s then begin
@@ -465,10 +467,10 @@ class c ?(scan_thresh=8) ?(cache_size=0) (ba : Cstruct.buffer) = object (self)
           else
             true
         in
-        Log.debug "prev_ok:%B next_ok:%B" prev_ok next_ok;
+        (*Log.debug "prev_ok:%B next_ok:%B" prev_ok next_ok;*)
         if prev_ok && next_ok then begin
           let idx = idx_ofs + p in
-          Log.debug "c#scan_sha1s: idx -> %d (short)" idx;
+          (*Log.debug "c#scan_sha1s: idx -> %d (short)" idx;*)
           raise (Idx_found idx)
         end
         else
@@ -481,15 +483,17 @@ class c ?(scan_thresh=8) ?(cache_size=0) (ba : Cstruct.buffer) = object (self)
         self#scan_sha1s fo_idx (idx_ofs + d) (ofs + d * 20) (n - p - 1) sha1
     end
     else begin
-      Log.debug "c#scan_sha1s: scanning...";
+      (*Log.debug "c#scan_sha1s: scanning...";*)
       self#scan_sub idx_ofs sha1 short_sha buf 0 (n - 1)
     end
 
   method private scan_sub idx_ofs sha1 short_sha ?(cands=[]) buf i m =
+(*
     Log.debug "c#scan_sub: idx_ofs=%d short_sha=%B cands=[%s] i=%d m=%d" 
       idx_ofs short_sha 
       (List.fold_left (fun s i -> s^(if s = "" then "" else ",")^(string_of_int i)) "" cands)
       i m;
+*)
     if i > m then begin
       match cands with
       | [idx] -> raise (Idx_found idx)
@@ -499,7 +503,7 @@ class c ?(scan_thresh=8) ?(cache_size=0) (ba : Cstruct.buffer) = object (self)
       let s = SHA.input buf in
       if s = sha1 then begin
         let idx = idx_ofs + i in
-        Log.debug "c#scan_sub: idx -> %d" idx;
+        (*Log.debug "c#scan_sub: idx -> %d" idx;*)
         raise (Idx_found idx)
       end
       else begin

--- a/lib/pack_index.ml
+++ b/lib/pack_index.ml
@@ -258,6 +258,90 @@ class offset_cache size = object (self)
 
 end (* of class Pack_index.offset_cache *)
 
+
+module Oid = struct
+  type t =
+    | SHA1 of SHA.t
+    | Abbrev of string (* hex *)
+
+  let length = function
+    | SHA1 _ -> 40
+    | Abbrev h -> String.length h
+
+  let of_hex h =
+    let len = String.length h in
+    if len = 40 then
+      SHA1 (SHA.of_hex h)
+    else if len > 40 then
+      SHA1 (SHA.of_hex (String.sub h 0 40))
+    else
+      Abbrev h
+
+  let to_hex = function
+    | SHA1 sha -> SHA.to_hex sha
+    | Abbrev h -> h
+
+  let of_sha1 sha1 = SHA1 sha1
+
+  let sstartswith s s0 =
+    let len = String.length s in
+    let len0 = String.length s0 in
+    if len < len0 then
+      false
+    else
+      try
+        for i = 0 to len0 - 1 do
+	  if s.[i] != s0.[i] then
+	    raise Exit
+        done;
+        true
+      with 
+      | Exit -> false
+
+  let pair_to_str_pair = function
+    | SHA1 sha, SHA1 sha0 -> SHA.to_raw sha, SHA.to_raw sha0
+    | SHA1 sha, Abbrev h0 -> SHA.to_hex sha, h0
+    | Abbrev h, SHA1 sha0 -> h, SHA.to_hex sha0
+    | Abbrev h, Abbrev h0 -> h, h0
+
+  let startswith oid oid0 =
+    let s, s0 = pair_to_str_pair (oid, oid0) in
+    sstartswith s s0
+
+  exception Ambiguous
+
+  let slt s0 s1 =
+    let len0 = String.length s0 in
+    let len1 = String.length s1 in
+    let len = min len0 len1 in
+    let same = len0 = len1 in
+
+    let rec scan i =
+      if i = len then
+        if same then
+          false
+        else
+          raise Ambiguous
+      else
+        let x0 = s0.[i] in
+        let x1 = s1.[i] in
+        if x0 < x1 then
+          true
+        else if x0 > x1 then
+          false
+        else
+          scan (i + 1)
+    in
+    let b = scan 1 in
+    Log.debugf "Oid.slt: -> %B" b;
+    b
+
+  let lt oid oid0 =
+    let s, s0 = pair_to_str_pair (oid, oid0) in
+    slt s s0
+
+end
+
 exception Idx_found of int
 
 class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
@@ -391,7 +475,8 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
         failwith "Pack_index.c#get_sha1_idx"
     in
     try
-      self#scan_sha1s fo_idx sz0 (sha1s_ofs + (sz0 * 20)) n sha1
+      let ofs = sha1s_ofs + (sz0 * 20) in
+      self#scan_sha1s fo_idx sz0 ofs n sha1
     with
       Idx_found i -> 
         Log.debug "c#get_sha1_idx: found:%d" i;
@@ -438,7 +523,7 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
         Log.debug "c#scan_sha1s: idx -> %d" idx;
         raise (Idx_found idx)
       end
-      else if self#le_sha1 sha1 s then
+      else if self#lt_sha1 sha1 s then
         self#scan_sha1s fo_idx idx_ofs ofs p sha1
       else
         let d = p + 1 in
@@ -449,6 +534,25 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
       self#scan_sub idx_ofs sha1 buf 0 (n - 1)
     end
 
+  method private lt_sha1 sha1_0 sha1_1 =
+    let s0 = SHA.to_raw sha1_0 in
+    let s1 = SHA.to_raw sha1_1 in
+    let rec scan i =
+      let x0 = s0.[i] in
+      let x1 = s1.[i] in
+      if x0 < x1 then
+        true
+      else if x0 > x1 then
+        false
+      else
+        scan (i + 1)
+    in
+    try
+      let b = scan 1 in
+      Log.debugf "c#lt_sha1: -> %B" b;
+      b
+    with
+      Invalid_argument _ -> assert false
 
   method private scan_sub idx_ofs sha1 buf i m =
     if i > m then 
@@ -462,23 +566,5 @@ class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
       end
       else
         self#scan_sub idx_ofs sha1 buf (i + 1) m
-
-
-  method private le_sha1 sha1_0 sha1_1 =
-    let s0 = SHA.to_raw sha1_0 in
-    let s1 = SHA.to_raw sha1_1 in
-    let rec scan i =
-      let x0 = int_of_char s0.[i] in
-      let x1 = int_of_char s1.[i] in
-      if x0 < x1 then
-        true
-      else if x0 > x1 then
-        false
-      else
-        scan (i + 1)
-    in
-    let b = scan 1 in
-    Log.debug "c#le_sha1: -> %B" b;
-    b
 
 end (* Pack_index.c *)

--- a/lib/pack_index.ml
+++ b/lib/pack_index.ml
@@ -299,7 +299,7 @@ class c ?(cache_size=default_cache_size) (ba : Cstruct.buffer) = object (self)
             Mstruct.shift buf (idx * 4);
 
             let is64 =
-	      match Mstruct.get_uint8 buf land 128 with
+              match Mstruct.get_uint8 buf land 128 with
               | 0 -> false
               | _ -> true 
             in
@@ -312,7 +312,7 @@ class c ?(cache_size=default_cache_size) (ba : Cstruct.buffer) = object (self)
                 | None -> self#create_ofs64_tbl
               in
               let buf64 = Mstruct.of_bigarray ~off:ofs64_ofs ~len:(size64 * 8) ba in
-              
+
               try
                 let idx64 = Hashtbl.find ofs64_tbl idx in
                 Mstruct.shift buf64 (idx64 * 8);
@@ -330,7 +330,7 @@ class c ?(cache_size=default_cache_size) (ba : Cstruct.buffer) = object (self)
               cache#add sha1 o;
               Some o
             end
-        end
+          end
         | None -> None
       end
 
@@ -338,11 +338,11 @@ class c ?(cache_size=default_cache_size) (ba : Cstruct.buffer) = object (self)
     Log.debug "c#mem: %s" (SHA.to_hex sha1);
     match self#find_offset sha1 with
     | Some _ -> 
-        Log.debug "c#mem: true"; 
-        true
+      Log.debug "c#mem: true"; 
+      true
     | None -> 
-        Log.debug "c#mem: false"; 
-        false
+      Log.debug "c#mem: false"; 
+      false
 
 
   initializer
@@ -385,13 +385,13 @@ class c ?(cache_size=default_cache_size) (ba : Cstruct.buffer) = object (self)
     let buf = Mstruct.of_bigarray ~off:fanout_ofs ~len:(256 * 4) ba in
     let sz0, n =
       if fo_idx = 0 then begin
-	0, Int32.to_int (Mstruct.get_be_uint32 buf)
+        0, Int32.to_int (Mstruct.get_be_uint32 buf)
       end
       else if fo_idx > 0 then begin
-	Mstruct.shift buf ((fo_idx - 1) * 4);
-	let sz0 = Int32.to_int (Mstruct.get_be_uint32 buf) in
-	let sz1 = Int32.to_int (Mstruct.get_be_uint32 buf) in
-	 sz0, sz1 - sz0
+        Mstruct.shift buf ((fo_idx - 1) * 4);
+        let sz0 = Int32.to_int (Mstruct.get_be_uint32 buf) in
+        let sz1 = Int32.to_int (Mstruct.get_be_uint32 buf) in
+        sz0, sz1 - sz0
       end 
       else
         failwith "Pack_index.c#get_sha1_idx"
@@ -401,8 +401,8 @@ class c ?(cache_size=default_cache_size) (ba : Cstruct.buffer) = object (self)
       self#scan_sha1s ~scan_thresh fo_idx sz0 ofs n sha1
     with
       Idx_found i -> 
-        Log.debug "c#get_sha1_idx: found:%d" i;
-        Some i
+      Log.debug "c#get_sha1_idx: found:%d" i;
+      Some i
 
   method private create_ofs64_tbl =
     Log.debug "c#create_ofs64_tbl";
@@ -413,9 +413,9 @@ class c ?(cache_size=default_cache_size) (ba : Cstruct.buffer) = object (self)
         match Mstruct.get_uint8 buf land 128 with
         | 0 -> ()
         | _ -> 
-            let _ = Hashtbl.add ofs64_tbl i !count in
-            Log.debug "c#create_ofs64_tbl: %d -> %d" i !count;
-            incr count
+          let _ = Hashtbl.add ofs64_tbl i !count in
+          Log.debug "c#create_ofs64_tbl: %d -> %d" i !count;
+          incr count
       end;
       Mstruct.shift buf 3
     done;

--- a/lib/pack_index.ml
+++ b/lib/pack_index.ml
@@ -239,17 +239,19 @@ class offset_cache size = object (self)
   val tbl = Hashtbl.create 0
 
   method add (sha1 : SHA.t) (offset : int) =
-    Log.debug "offset_cache#add: %s -> %d" (SHA.to_hex sha1) offset;
-    Queue.add sha1 keyq;
-    let _ = Hashtbl.add tbl sha1 offset in
-    let qsz = Queue.length keyq in
-    if qsz > size then begin
-      try
-        let k = Queue.take keyq in
+    if size >= 1 then begin
+      Log.debug "offset_cache#add: %s -> %d" (SHA.to_hex sha1) offset;
+      Queue.add sha1 keyq;
+      let _ = Hashtbl.add tbl sha1 offset in
+      let qsz = Queue.length keyq in
+      if qsz > size then begin
+        try
+          let k = Queue.take keyq in
           Log.debug "offset_cache#add: qsz=%d shrinking..." qsz;
           Hashtbl.remove tbl k
-      with
-        Queue.Empty -> ()
+        with
+          Queue.Empty -> ()
+      end
     end
 
   method find (sha1 : SHA.t) =
@@ -261,7 +263,7 @@ end (* of class Pack_index.offset_cache *)
 
 exception Idx_found of int
 
-class c ?(scan_thresh=8) ?(cache_size=1) (ba : Cstruct.buffer) = object (self)
+class c ?(scan_thresh=8) ?(cache_size=0) (ba : Cstruct.buffer) = object (self)
 
   val cache = new offset_cache cache_size
 

--- a/lib/pack_index.mli
+++ b/lib/pack_index.mli
@@ -41,3 +41,10 @@ val lengths: t -> int option SHA.Map.t
 
 val empty: ?pack_checksum:SHA.t -> unit -> t
 (** The empty pack index. *)
+
+class type c_t = object
+  method find_offset : SHA.t -> int option
+  method mem         : SHA.t -> bool
+end
+
+class c : ?scan_thresh:int -> ?cache_size:int -> Cstruct.buffer -> c_t

--- a/lib/pack_index.mli
+++ b/lib/pack_index.mli
@@ -42,9 +42,17 @@ val lengths: t -> int option SHA.Map.t
 val empty: ?pack_checksum:SHA.t -> unit -> t
 (** The empty pack index. *)
 
-class type c_t = object
-  method find_offset : SHA.t -> int option
-  method mem         : SHA.t -> bool
-end
+type c_t
+(** Abstract type of pack index. *)
 
-class c : ?scan_thresh:int -> ?cache_size:int -> Cstruct.buffer -> c_t
+val create: ?cache_size:int -> Cstruct.buffer -> c_t
+(** Create a pack index object. The results of [find_offset] are cached
+    for upto [cache_size] SHA objects *)
+
+val find_offset: ?scan_thresh:int -> c_t -> SHA.t -> int option
+(** [find_offset] searches the index for the offset of the SHA object.
+    Binary search is performed until the candidates are narrowed down to
+    [scan_thresh] or less. *)
+
+val mem: c_t -> SHA.t -> bool
+(** [mem] checks if the SHA object is contained in the index object *)

--- a/lib/packed_value.ml
+++ b/lib/packed_value.ml
@@ -453,15 +453,15 @@ let rec unpack ?(lv=0) ~version ~index ~ba (pos, t) =
     | 2 -> V2.input
     | 3 -> V3.input
     | _ -> 
-	eprintf "pack version should be 2 or 3";
-	failwith "Packed_value.unpack"
+      eprintf "pack version should be 2 or 3";
+      failwith "Packed_value.unpack"
   in
   let unpacked = 
     match t with
     | Raw_value x -> begin
         Log.debug "unpack[%d]: Raw_value" lv; 
         x
-    end
+      end
     | Ref_delta d -> begin 
         Log.debug "unpack[%d]: Ref_delta: d.source=%s" lv (SHA.to_hex d.source);
         match Pack_index.find_offset index d.source with
@@ -470,25 +470,25 @@ let rec unpack ?(lv=0) ~version ~index ~ba (pos, t) =
             let offset = offset - 12 in (* header skipped *) 
             let buf = Mstruct.of_bigarray ~off:offset ~len:(ba_len-offset) ba in
             let packed_v = input_packed_value buf in
-	    let u = unpack ~lv:(lv+1) ~version ~index ~ba (offset, packed_v) in
-	    Misc.with_buffer (fun b -> add_delta b {d with source = u})
-        end
+            let u = unpack ~lv:(lv+1) ~version ~index ~ba (offset, packed_v) in
+            Misc.with_buffer (fun b -> add_delta b {d with source = u})
+          end
         | None -> begin
             eprintf
               "Packed_value.unpack: shallow pack are not supported.\n%s is not in the pack file!\n"
               (SHA.to_hex d.source);
             failwith "Packed_value.unpack";
-        end
-    end
+          end
+      end
     | Off_delta d -> begin
         Log.debug "unpack[%d]: Off_delta: d.source=%d" lv d.source;
         let offset = pos - d.source in
         Log.debug "unpack[%d]: offset=%d-%d=%d" lv pos d.source offset;
         let buf = Mstruct.of_bigarray ~off:offset ~len:(ba_len-offset) ba in
         let packed_v = input_packed_value buf in
-	let u = unpack ~lv:(lv+1) ~version ~index ~ba (offset, packed_v) in
-	Misc.with_buffer (fun b -> add_delta b {d with source = u})
-    end
+        let u = unpack ~lv:(lv+1) ~version ~index ~ba (offset, packed_v) in
+        Misc.with_buffer (fun b -> add_delta b {d with source = u})
+      end
   in
   unpacked
 

--- a/lib/packed_value.ml
+++ b/lib/packed_value.ml
@@ -464,7 +464,7 @@ let rec unpack ?(lv=0) ~version ~index ~ba (pos, t) =
     end
     | Ref_delta d -> begin 
         Log.debug "unpack[%d]: Ref_delta: d.source=%s" lv (SHA.to_hex d.source);
-        match index#find_offset d.source with
+        match Pack_index.find_offset index d.source with
         | Some offset -> begin
             Log.debug "unpack[%d]: offset=%d" lv offset;
             let offset = offset - 12 in (* header skipped *) 

--- a/lib/packed_value.mli
+++ b/lib/packed_value.mli
@@ -25,8 +25,8 @@ type copy = {
 type hunk =
   | Insert of string
   | Copy of copy
-(** A delta hunk can either insert a string of copy the contents of a
-    base object. *)
+  (** A delta hunk can either insert a string of copy the contents of a
+      base object. *)
 
 type 'a delta = {
   source       : 'a;
@@ -40,7 +40,7 @@ type t =
   | Raw_value of string
   | Ref_delta of SHA.t delta
   | Off_delta of int delta
-(** Packed values. *)
+  (** Packed values. *)
 
 val pp_hum: Format.formatter -> t -> unit
 (** Human readable representation of a packed value. *)

--- a/lib/packed_value.mli
+++ b/lib/packed_value.mli
@@ -132,3 +132,6 @@ val to_pic: PIC.t Misc.IntMap.t -> PIC.t SHA.Map.t -> (int * SHA.t * t) -> PIC.t
 val of_pic: int PIC.Map.t -> pos:int -> PIC.t -> t
 (** Position dependent packed value. Convert a [PIC.Link] into to the
     corresponding [Off_delta], using the provided indexes. *)
+
+val to_value: version:int -> index:Pack_index.c_t -> ba:Cstruct.buffer -> (int * t) -> Value.t
+(** Unpack the packed value using the provided indexes. *)

--- a/lib/tree.ml
+++ b/lib/tree.ml
@@ -69,6 +69,13 @@ let string_of_perm = function
   | `Normal -> "100644"
   | `Exec   -> "100755"
   | `Link   -> "120000"
+  | `Dir    -> "40000"
+  | `Commit -> "160000"
+
+let fixed_length_string_of_perm = function
+  | `Normal -> "100644"
+  | `Exec   -> "100755"
+  | `Link   -> "120000"
   | `Dir    -> "040000"
   | `Commit -> "160000"
 

--- a/lib/tree.ml
+++ b/lib/tree.ml
@@ -73,7 +73,7 @@ let string_of_perm = function
   | `Normal -> "100644"
   | `Exec   -> "100755"
   | `Link   -> "120000"
-  | `Dir    -> "40000"
+  | `Dir    -> "040000"
   | `Commit -> "160000"
 
 let escape = Char.chr 42

--- a/lib/tree.ml
+++ b/lib/tree.ml
@@ -65,7 +65,7 @@ let perm_of_string buf = function
   | "100644" -> `Normal
   | "100755" -> `Exec
   | "120000" -> `Link
-  | "040000" -> `Dir
+  | "40000"  -> `Dir
   | "160000" -> `Commit
   | x        -> Mstruct.parse_error_buf buf "%S is not a valid permission." x
 
@@ -73,7 +73,7 @@ let string_of_perm = function
   | `Normal -> "100644"
   | `Exec   -> "100755"
   | `Link   -> "120000"
-  | `Dir    -> "040000"
+  | `Dir    -> "40000"
   | `Commit -> "160000"
 
 let escape = Char.chr 42

--- a/lib/tree.ml
+++ b/lib/tree.ml
@@ -22,7 +22,11 @@ type perm = [
   | `Link
   | `Dir
   | `Commit
+<<<<<<< HEAD
 ]
+=======
+] with sexp
+>>>>>>> modified to mimic git-cat-file and git-ls-tree of the original Git
 
 type entry = {
   perm: perm;
@@ -61,7 +65,7 @@ let perm_of_string buf = function
   | "100644" -> `Normal
   | "100755" -> `Exec
   | "120000" -> `Link
-  | "40000"  -> `Dir
+  | "040000" -> `Dir
   | "160000" -> `Commit
   | x        -> Mstruct.parse_error_buf buf "%S is not a valid permission." x
 
@@ -69,7 +73,7 @@ let string_of_perm = function
   | `Normal -> "100644"
   | `Exec   -> "100755"
   | `Link   -> "120000"
-  | `Dir    -> "40000"
+  | `Dir    -> "040000"
   | `Commit -> "160000"
 
 let escape = Char.chr 42

--- a/lib/tree.mli
+++ b/lib/tree.mli
@@ -46,5 +46,4 @@ type t = entry list
 (** A tree is an hierarchical data-store. NB: data (eg. blobs) are
     only carried on the leafs. *)
 
-
 include Object.S with type t := t

--- a/lib/tree.mli
+++ b/lib/tree.mli
@@ -43,7 +43,5 @@ type t = entry list
 (** A tree is an hierarchical data-store. NB: data (eg. blobs) are
     only carried on the leafs. *)
 
-val string_of_perm : perm -> string
-
 
 include Object.S with type t := t

--- a/lib/tree.mli
+++ b/lib/tree.mli
@@ -43,4 +43,7 @@ type t = entry list
 (** A tree is an hierarchical data-store. NB: data (eg. blobs) are
     only carried on the leafs. *)
 
+val string_of_perm : perm -> string
+
+
 include Object.S with type t := t

--- a/lib/tree.mli
+++ b/lib/tree.mli
@@ -30,6 +30,9 @@ val pretty_perm: perm -> string
 val string_of_perm : perm -> string
 (** Raw represention of a permission, using the [Git] format. *)
 
+val fixed_length_string_of_perm : perm -> string
+(** Fixed-length raw represention of a permission, using the [Git] format (6 characters long). *)
+
 type entry = {
   perm: perm;
   name: string;


### PR DESCRIPTION
I have modified the original to achieve the following:
* to allow short SHA1s for specifying Git objects, and 
* to mimic git-ls-tree and git-cat-file.

The latter is implemented based on binary search for a SHA1 within an index file, as seen in Git.

The patches could be better by catching up with the evolution of the original; The actual modifications have been performed several months ago...