### PR TITLE
Cohttp 0.18.0 compatibility

### DIFF
--- a/lib/http/git_http.mli
+++ b/lib/http/git_http.mli
@@ -46,8 +46,10 @@
 module type CLIENT = sig
   include Cohttp_lwt.Client
     with type 'a IO.t = 'a Lwt.t               (* FIMXE in cohttp *)
-     and type 'a Request.IO.t = 'a Lwt.t       (* FIXME in cohttp *)
-     and type 'a Response.IO.t = 'a Lwt.t      (* FIXME in cohttp *)
+
+  module Request : Cohttp.S.Http_io with module IO = IO and type t = Cohttp.Request.t
+  module Response : Cohttp.S.Http_io with module IO = IO and type t = Cohttp.Response.t
+
   val close_out: IO.oc -> unit                 (* FIXME in cohttp *)
   val close_in: IO.ic -> unit                  (* FIXME in cohttp *)
   val oc: IO.oc -> Request.IO.oc               (* FIXME in cohttp *)

--- a/lib/mirage/git_mirage.ml
+++ b/lib/mirage/git_mirage.ml
@@ -290,7 +290,9 @@ module Smart_HTTP (Conduit: Conduit_mirage.S) = struct
   module Request = Cohttp_lwt.Make_request(HTTP_IO)
   module Response = Cohttp_lwt.Make_response(HTTP_IO)
   module HTTP = struct
-    include Cohttp_lwt.Make_client(HTTP_IO)(Request)(Response)(Net)
+    include Cohttp_lwt.Make_client(HTTP_IO)(Net)
+    module Request = Request
+    module Response = Response
     let oc x = x
     let ic x = x
     let close_in = Net.close_in

--- a/lib/unix/git_unix.ml
+++ b/lib/unix/git_unix.ml
@@ -97,6 +97,8 @@ module M = struct
   module Client = struct
     (* FIXME in cohttp *)
     include Cohttp_lwt_unix.Client
+    module Request = Cohttp_lwt_unix.Request
+    module Response = Cohttp_lwt_unix.Response
     let ic x = x
     let oc x = x
     let close_in x = Lwt.ignore_result (Lwt_io.close x)


### PR DESCRIPTION
This is just quick fix in case you want to make a release that unbreaks
everyone.

@samoht I'm just curious, why does ocaml-git need such low level access to
cohttp internals anyway? I would like to understand the use case.