### PR TITLE
s/bits/bytes/ in docstring for read_exactly

### DIFF
--- a/lib/mirage/git_mirage.ml
+++ b/lib/mirage/git_mirage.ml
@@ -252,7 +252,7 @@ end
 (* Cohttp IO with functional input/channel constructors *)
 module FIO = Cohttp_mirage_io.Make(Fchannel)
 
-(* hanlde the git:// connections *)
+(* handle the git:// connections *)
 module Git_protocol = struct
 
   module Flow = Conduit_mirage.Flow
@@ -292,7 +292,7 @@ module Git_protocol = struct
 
 end
 
-(* hanlde the http(s):// connections *)
+(* handle the http(s):// connections *)
 module Smart_HTTP = struct
 
   module Conduit_channel = Channel.Make(Conduit_mirage.Flow)

--- a/lib/mirage/git_mirage.mli
+++ b/lib/mirage/git_mirage.mli
@@ -22,7 +22,7 @@ module type FS = sig
   include V1_LWT.FS with type page_aligned_buffer = Cstruct.t
 
   val connect: unit -> [`Error of error | `Ok of t ] Lwt.t
-  (** Every [S] define how to connect to a peticular [t]. *)
+  (** Every [S] define how to connect to a particular [t]. *)
 
   val string_of_error: error -> string
   (** Pretty-print errors. *)
@@ -30,7 +30,7 @@ module type FS = sig
 end
 
 module FS (FS: FS): Git.FS.S
-(** Create a Irmin store from raw block devices hanlder. *)
+(** Create a Irmin store from raw block devices handler. *)
 
 module Sync: sig
   module IO: Git.Sync.IO with type ctx = Resolver_lwt.t * Conduit_mirage.t

--- a/lib/sync.mli
+++ b/lib/sync.mli
@@ -120,7 +120,7 @@ module type IO = sig
       the other side). *)
 
   val read_exactly: ic -> int -> string Lwt.t
-  (** Read a given number of bits. *)
+  (** Read a given number of bytes. *)
 
   val write: oc -> string -> unit Lwt.t
   (** Write a string on a channel. *)


### PR DESCRIPTION
Judging by git_mirage.ml and the channel API it calls, "bytes" is meant here rather than "bits".