### PR TITLE
Compatibilty with cohttp 0.19.1

### DIFF
--- a/lib/http/git_http.mli
+++ b/lib/http/git_http.mli
@@ -44,16 +44,10 @@
 *)
 
 module type CLIENT = sig
-  include Cohttp_lwt.Client
-    with type 'a IO.t = 'a Lwt.t               (* FIMXE in cohttp *)
-
-  module Request : Cohttp.S.Http_io with module IO = IO and type t = Cohttp.Request.t
-  module Response : Cohttp.S.Http_io with module IO = IO and type t = Cohttp.Response.t
+  module IO : Cohttp_lwt_s.IO
 
   val close_out: IO.oc -> unit                 (* FIXME in cohttp *)
   val close_in: IO.ic -> unit                  (* FIXME in cohttp *)
-  val oc: IO.oc -> Request.IO.oc               (* FIXME in cohttp *)
-  val ic: IO.ic -> Response.IO.ic              (* FIXME in cohttp *)
 end
 
 module type CHAN = sig

--- a/lib/mirage/git_mirage.ml
+++ b/lib/mirage/git_mirage.ml
@@ -286,22 +286,15 @@ module Smart_HTTP = struct
       let ch = Conduit_channel.create flow in
       Lwt.return (flow, ch, ch)
     let close_in _ = ()
-    let close_out oc = Lwt.async (fun () -> Conduit_channel.close oc)
     let close _ oc = Lwt.async (fun () -> Conduit_channel.close oc)
   end
-  module Request = Cohttp_lwt.Make_request(HTTP_IO)
-  module Response = Cohttp_lwt.Make_response(HTTP_IO)
   module HTTP = struct
-    include Cohttp_lwt.Make_client(HTTP_IO)(Net)
-    module Request = Request
-    module Response = Response
-    let oc x = x
-    let ic x = x
+    module IO = HTTP_IO
     let close_in = Net.close_in
     let close_out oc = Net.close () oc
   end
 
-  type ctx = HTTP.ctx
+  type ctx = Net.ctx
 
   include IO_helper(Fchannel)
 

--- a/lib/unix/git_unix.ml
+++ b/lib/unix/git_unix.ml
@@ -95,11 +95,7 @@ module IO_Sync = struct
 
   module Client = struct
     (* FIXME in cohttp *)
-    include Cohttp_lwt_unix.Client
-    module Request = Cohttp_lwt_unix.Request
-    module Response = Cohttp_lwt_unix.Response
-    let ic x = x
-    let oc x = x
+    module IO = Cohttp_lwt_unix_io
     let close_in x = Lwt.ignore_result (Lwt_io.close x)
     let close_out x = Lwt.ignore_result (Lwt_io.close x)
   end


### PR DESCRIPTION
* I've simplified the definition of CLIENT. I'm not sure why it needs
Cohttp_lwt.Client at all if it's doing request/response processing by
itself :)

* write_footer has been added here because it shouldn't be part of
cohttp's api.