### PR TITLE
Improve logging performance: only build arguments when needed

### DIFF
--- a/lib/FS.ml
+++ b/lib/FS.ml
@@ -22,7 +22,7 @@ let fail fmt = Printf.ksprintf failwith ("Git.FS." ^^ fmt)
 
 let err_not_found n k = fail "%s: %s not found" n k
 
-module LogMake = Log.Make
+module LogMake = Misc.Log_make
 
 module Log = LogMake(struct let section = "fs" end)
 

--- a/lib/SHA.ml
+++ b/lib/SHA.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "sha1" end)
+module Log = Misc.Log_make(struct let section = "sha1" end)
 
 module type S = sig
   include Object.S

--- a/lib/blob.ml
+++ b/lib/blob.ml
@@ -15,7 +15,7 @@
  *)
 
 open Printf
-module Log = Log.Make(struct let section = "blob" end)
+module Log = Misc.Log_make(struct let section = "blob" end)
 
 (* FIXME: might want to have an option type with string|cstruct *)
 include Misc.S

--- a/lib/commit.ml
+++ b/lib/commit.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "commit" end)
+module Log = Misc.Log_make(struct let section = "commit" end)
 
 module T = struct
 

--- a/lib/global_graph.ml
+++ b/lib/global_graph.ml
@@ -138,7 +138,8 @@ module Make (Store: Store.S) = struct
       if has_mark key then Lwt.return ()
       else (
         mark key;
-        Log.debug "ADD %s" (SHA.to_hex key);
+        Log.debugk "ADD %s" (fun log ->
+            log (SHA.to_hex key));
         Store.mem t key >>= function
         | false -> Lwt.return_unit
         | true  ->

--- a/lib/global_graph.ml
+++ b/lib/global_graph.ml
@@ -64,7 +64,7 @@ module KO = Graph.Oper.I(K)
 
 module Make (Store: Store.S) = struct
 
-  module Log = Log.Make(struct let section = "graph" end)
+  module Log = Misc.Log_make(struct let section = "graph" end)
 
   module Search = struct
     include Search.Make(Store)

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "index" end)
+module Log = Misc.Log_make(struct let section = "index" end)
 
 type time = {
   lsb32: int32;

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -247,8 +247,8 @@ module IO (D: SHA.DIGEST) = struct
       | 0 -> 0
       | n -> 8-n in
     Mstruct.shift buf padding;
-    Log.debug "name:%s id:%s bytes:%d padding:%d"
-      name (SHA.Blob.to_hex id) bytes padding;
+    Log.debugk "name:%s id:%s bytes:%d padding:%d" (fun log ->
+        log name (SHA.Blob.to_hex id) bytes padding);
     { stats; id; stage; name }
 
   let add_entry buf t =

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -16,7 +16,7 @@
 
 open Lwt.Infix
 
-module Log = Log.Make(struct let section = "memory" end)
+module Log = Misc.Log_make(struct let section = "memory" end)
 
 let err_not_found n k =
   let str = Printf.sprintf "Git.Memory.%s: %s not found" n k in

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -14,6 +14,27 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+module Log_make(S: sig val section: string end) =
+struct
+  include Log.Make(S)
+      
+  let int_of_level = function
+    | Log.FATAL -> 4
+    | Log.ERROR -> 3
+    | Log.WARN  -> 2
+    | Log.INFO  -> 1
+    | Log.DEBUG -> 0
+
+  let logk level fmt k =
+    if int_of_level level >= int_of_level (Log.get_log_level ())
+    then k (log level fmt)
+  let fatalk fmt k = logk Log.FATAL fmt k
+  let errork fmt k = logk Log.ERROR fmt k
+  let warnk  fmt k = logk Log.WARN  fmt k
+  let infok  fmt k = logk Log.INFO  fmt k
+  let debugk fmt k = logk Log.DEBUG fmt k
+end
+
 module Log = Log.Make(struct let section = "misc" end)
 
 let sp  = '\x20'

--- a/lib/misc.ml
+++ b/lib/misc.ml
@@ -35,7 +35,7 @@ struct
   let debugk fmt k = logk Log.DEBUG fmt k
 end
 
-module Log = Log.Make(struct let section = "misc" end)
+module Log = Log_make(struct let section = "misc" end)
 
 let sp  = '\x20'
 let nul = '\x00'

--- a/lib/misc.mli
+++ b/lib/misc.mli
@@ -93,3 +93,16 @@ module OP: sig
 end
 
 val pretty: (Format.formatter -> 'a -> unit) -> 'a -> string
+
+module Log_make(S: sig val section: string end) :
+sig
+  include Log.S
+
+  val logk : Log.log_level -> ('a, out_channel, unit, unit) format4 ->
+             ('a -> unit) -> unit
+  val fatalk : ('a, out_channel, unit) format -> ('a -> unit) -> unit
+  val errork : ('a, out_channel, unit) format -> ('a -> unit) -> unit
+  val warnk  : ('a, out_channel, unit) format -> ('a -> unit) -> unit
+  val infok  : ('a, out_channel, unit) format -> ('a -> unit) -> unit
+  val debugk : ('a, out_channel, unit) format -> ('a -> unit) -> unit
+end

--- a/lib/object_type.ml
+++ b/lib/object_type.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "object-type" end)
+module Log = Misc.Log_make(struct let section = "object-type" end)
 
 type t =
   | Blob

--- a/lib/pack_index.ml
+++ b/lib/pack_index.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "pack-index" end)
+module Log = Misc.Log_make(struct let section = "pack-index" end)
 
 type f = SHA.t -> int option
 

--- a/lib/pack_index.ml
+++ b/lib/pack_index.ml
@@ -152,7 +152,8 @@ module Make (D: SHA.DIGEST) = struct
     | Some y -> Some (x + y)
 
   let get_sha1_idx t sha1 =
-    Log.debug "get_sha1_idx: %s" (SHA.pretty sha1);
+    Log.debugk "get_sha1_idx: %s" (fun log ->
+        log (SHA.pretty sha1));
     let fanout_idx = fanout_of_sha1 sha1 in
     let offsets = fanout t in
     let get_int buf = Int32.to_int (Mstruct.get_be_uint32 buf) in
@@ -173,7 +174,8 @@ module Make (D: SHA.DIGEST) = struct
     offset ++ A.binary_search buf sha1
 
   let find_offset t sha1 =
-    Log.debug "find_offset: %s" (SHA.pretty sha1);
+    Log.debugk "find_offset: %s" (fun log ->
+        log (SHA.pretty sha1));
     match Offset_cache.find t.cache sha1 with
     | Some _ as x -> Log.debug "find_offset: cache hit!"; x
     | None ->
@@ -200,7 +202,8 @@ module Make (D: SHA.DIGEST) = struct
         )
 
   let mem t sha1 =
-    Log.debug "mem: %s" (SHA.to_hex sha1);
+    Log.debugk "mem: %s" (fun log ->
+        log (SHA.to_hex sha1));
     match find_offset t sha1 with
     | Some _ -> Log.debug "mem: true" ; true
     | None   -> Log.debug "mem: false"; false

--- a/lib/packed_value.ml
+++ b/lib/packed_value.ml
@@ -17,7 +17,7 @@
 open Lwt.Infix
 open Printf
 
-module Log = Log.Make(struct let section = "packed-value" end)
+module Log = Misc.Log_make(struct let section = "packed-value" end)
 
 type copy = { copy_offset: int; copy_length: int; }
 

--- a/lib/reference.ml
+++ b/lib/reference.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "reference" end)
+module Log = Misc.Log_make(struct let section = "reference" end)
 
 type t = string
 

--- a/lib/sync.ml
+++ b/lib/sync.ml
@@ -17,7 +17,7 @@
 open Lwt.Infix
 open Printf
 
-module Log = Log.Make(struct let section = "sync" end)
+module Log = Misc.Log_make(struct let section = "sync" end)
 
 type protocol = [ `SSH | `Git | `Smart_HTTP ]
 

--- a/lib/sync.ml
+++ b/lib/sync.ml
@@ -381,7 +381,8 @@ module Make (IO: IO) (Store: Store.S) = struct
           with Failure _ -> err_invalid_integer "PacketLine.input" str
         in
         IO.read_exactly ic size >>= fun payload ->
-        Log.debug "RECEIVED: %s (%d)" (truncate payload) size;
+        Log.debugk "RECEIVED: %s (%d)" (fun log ->
+            log (truncate payload) size);
         Lwt.return (Some payload)
 
     let input_raw ic =
@@ -478,8 +479,8 @@ module Make (IO: IO) (Store: Store.S) = struct
       | `Smart_HTTP -> Some (smart_http t)
 
     let create request ~discover gri =
-      Log.debug "Init.create request=%s discover=%b gri=%s"
-        (string_of_request request) discover (Gri.to_string gri);
+      Log.debugk "Init.create request=%s discover=%b gri=%s" (fun log ->
+      log (string_of_request request) discover (Gri.to_string gri));
       let protocol = protocol_exn (Gri.to_uri gri) in
       let gri = match protocol with
         | `SSH | `Git -> gri
@@ -489,7 +490,8 @@ module Make (IO: IO) (Store: Store.S) = struct
           let request = string_of_request request in
           Gri.of_string (sprintf "%s/%s%s" url service request)
       in
-      Log.debug "computed-gri: %s" (Gri.to_string gri);
+      Log.debugk "computed-gri: %s" (fun log ->
+          log (Gri.to_string gri));
       { request; discover; gri }
 
     let upload_pack = create Upload_pack
@@ -503,7 +505,8 @@ module Make (IO: IO) (Store: Store.S) = struct
     include Listing
 
     let input ic protocol =
-      Log.debug "Listing.input (protocol=%s)" (pretty_protocol protocol);
+      Log.debugk "Listing.input (protocol=%s)" (fun log ->
+          log (pretty_protocol protocol));
       let error fmt = error ("[SMART-HTTP] Listing.input:" ^^ fmt) in
       let skip_smart_http () =
         match protocol with
@@ -1014,7 +1017,8 @@ module Make (IO: IO) (Store: Store.S) = struct
       IO.with_connection ?ctx uri ?init (fun (ic, oc) ->
           Listing.input ic protocol >>= fun listing ->
           (* XXX: check listing.capabilities *)
-          Log.debug "listing:\n %s" (Listing.pretty listing);
+          Log.debugk "listing:\n %s" (fun log ->
+          log (Listing.pretty listing));
           Store.read_reference t branch    >>= fun new_obj ->
           let old_obj = Listing.find_reference listing branch in
           let command = match old_obj, new_obj with
@@ -1040,13 +1044,15 @@ module Make (IO: IO) (Store: Store.S) = struct
           Graph.pack t ~min ~max >>= fun values ->
           let pack = Pack_IO.create values in
           let request = { Update_request.capabilities; commands; pack } in
-          Log.debug "request:\n%s" (Update_request.pretty request);
+          Log.debugk "request:\n%s" (fun log ->
+              log (Update_request.pretty request));
           Update_request.output oc request >>= fun () ->
           Report_status.input ic
         )
 
   let fetch_commits t (ic, oc) ?(progress=fun _ -> ()) f listing wants =
-    Log.debug "Sync.fetch_commits %s" (pretty_list SHA.Commit.pretty wants);
+    Log.debugk "Sync.fetch_commits %s" (fun log ->
+        log (pretty_list SHA.Commit.pretty wants));
     let f =
       let server_caps = Listing.capabilities listing in
       (* The client MUST NOT ask for capabilities the server did not
@@ -1145,7 +1151,8 @@ module Make (IO: IO) (Store: Store.S) = struct
       let init = Init.to_string init in
       IO.with_connection ?ctx uri ?init (fun (ic, oc) ->
           Listing.input ic protocol >>= fun listing ->
-          Log.debug "listing:\n %s" (Listing.pretty listing);
+          Log.debugk "listing:\n %s" (fun log ->
+              log (Listing.pretty listing));
           k (protocol, ic, oc) listing
         )
 
@@ -1219,7 +1226,8 @@ module Make (IO: IO) (Store: Store.S) = struct
       )
 
   let ls ?ctx t gri =
-    Log.debug "ls %s" (Gri.to_string gri);
+    Log.debugk "ls %s" (fun log ->
+        log (Gri.to_string gri));
     fetch_pack ?ctx t gri Ls >|= fun r ->
     Result.references r
 
@@ -1227,7 +1235,8 @@ module Make (IO: IO) (Store: Store.S) = struct
       ?ctx ?deepen ?(unpack=false) ?(capabilities=Capabilities.default)
       ?wants ?(update=false) ?progress
       t gri =
-    Log.debug "fetch %s wants=%s" (Gri.to_string gri) (pretty_wants wants);
+    Log.debugk "fetch %s wants=%s" (fun log ->
+        log (Gri.to_string gri) (pretty_wants wants));
     Store.references t >>= fun refs ->
     Lwt_list.fold_left_s (fun haves r ->
         Store.read_reference t r >|= function

--- a/lib/tag.ml
+++ b/lib/tag.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "tag" end)
+module Log = Misc.Log_make(struct let section = "tag" end)
 
 module T = struct
 

--- a/lib/tree.ml
+++ b/lib/tree.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "tree" end)
+module Log = Misc.Log_make(struct let section = "tree" end)
 
 type perm = [
     `Normal

--- a/lib/user.ml
+++ b/lib/user.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "user" end)
+module Log = Misc.Log_make(struct let section = "user" end)
 
 type tz_offset = {
   sign: [`Plus | `Minus];

--- a/lib/value.ml
+++ b/lib/value.ml
@@ -116,7 +116,8 @@ module IO (D: SHA.DIGEST) (I: Inflate.S) = struct
     | Object_type.Tree   -> Tree_IO.input buf   |> tree
 
   let add buf ?level t =
-    Log.debug "add %s" (pretty t);
+    Log.debugk "add %s" (fun log ->
+        log (pretty t));
     let inflated = Misc.with_buffer' (fun buf -> add_inflated buf t) in
     let deflated = I.deflate ?level inflated in
     Buffer.add_string buf (Cstruct.to_string deflated)

--- a/lib/value.ml
+++ b/lib/value.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Log = Log.Make(struct let section = "value" end)
+module Log = Misc.Log_make(struct let section = "value" end)
 
 module T = struct
 


### PR DESCRIPTION
### Background 

Here's a typical piece of logging code with a simple performance problem:

```ocaml
Log.debug "received %s (%s)" (pretty k) (pretty v)
```

The problem is as follows: even if debug printing is turned off, the (possibly-expensive) function `pretty` is still called, although its output is discarded.

There are various approaches to avoiding the call to `pretty`, including

* syntax extensions (as in [Bolt](http://bolt.x9c.fr/)): we might introduce new syntax using Camlp4 that expands into code that is not executed when the logging level is too low:

  ```ocaml
    LOG "received %s (%s)" (pretty k) (pretty v) LEVEL DEBUG;
  ```

* a lazy wrapper around the logging call which is only forced when the logging level is sufficiently high

  ```ocaml
    Log.debug_force
     (lazy 
        (Log.debug "received %s (%s)" (pretty k) (pretty v)))
  ```

* a thunk around the logging call which is only called when the logging level is sufficiently high

  ```ocaml
    Log.debug_force
     (lazy 
        (Log.debug "received %s (%s)" (pretty k) (pretty v)))
  ```

* writing conditionals around each logging call

  ```ocaml
    if Log.debug_on () then
       (Log.debug "received %s (%s)" (pretty k) (pretty v))
  ```

None of these is entirely satisfactory.  Syntax extensions are rather heavyweight, and the other solutions involve an unfortunate repitition of the logging logic, since they all involve one call to decide whether to perform debug logging, and a second call to format and write the debug log entry.

An alternative solution, implemented in this pull request, is to change the logging interface to use CPS.  Rather than passing the arguments directly to `Log.debug`, we pass the context that expects the arguments to a thunk, and execute that thunk conditionally, as follows:

```ocaml
Log.debugk "received %s (%s)" @@ fun k ->
   k (pretty k) (pretty v)
```

This shares the advantage of the solutions above: the calls to `pretty` only occur if debug printing is enabled.  However, unlike those solutions there's no repetition of the logging level logic (and no need for a syntax extension).  The implementation of `debugk` is very simple; given a function `log` (e.g. [Dolog.log](https://github.com/UnixJunkie/dolog/blob/26e22e5b11f221623a72d9051a483937103213ba/lib/log.mli#L50)), we can write:

```ocaml
let debugk fmt k = 
  if Log.DEBUG >= get_log_level () then k (log level fmt)
```

### Performance improvements

This pull request adds CPS logging functions to the Dolog interface used in `ocaml-git` (3d6a0b8), switches the internal loggers over to the extended interface (37cccec) and rewrites debug logging calls that build arguments dynamically to use the new style (df8477b).  On the example #125 with the [optimised ocaml-hex](https://github.com/mirage/ocaml-hex/pull/13) implementation the new logging code results in 227MB less allocation overall.  With the unoptimised `ocaml-hex` the improvement is 320MB.
