### PR TITLE
Remove the obsolete ~digest argument to to_pic.

### DIFF
--- a/lib/pack.ml
+++ b/lib/pack.ml
@@ -176,7 +176,7 @@ module IO (D: SHA.DIGEST) (I: Inflate.S) = struct
           let get_offsets = get Misc.IntMap.find offsets in
           let get_sha1s   = get SHA.Map.find sha1s in
           if Packed_value.is_delta v then (incr d; pp ());
-          Packed_value_IO.to_pic ~digest:D.string
+          Packed_value_IO.to_pic
             ~read ~offsets:get_offsets ~sha1s:get_sha1s v
           >|= fun pic ->
           let sha1 = Packed_value.PIC.sha1 pic in

--- a/lib/packed_value.ml
+++ b/lib/packed_value.ml
@@ -469,7 +469,7 @@ module IO (D: SHA.DIGEST) (I: Inflate.S) = struct
   let err_sha1_not_found n sha1 = fail "%s: cannot read %s" n (SHA.pretty sha1)
   let err_offset_not_found = fail "%s: cannot find any object at offset %d"
 
-  let to_pic ~digest ~read ~offsets ~sha1s t =
+  let to_pic ~read ~offsets ~sha1s t =
     let kind = match t.kind with
       | Raw_value x -> Lwt.return (PIC.Raw x)
       | Ref_delta d ->
@@ -492,7 +492,7 @@ module IO (D: SHA.DIGEST) (I: Inflate.S) = struct
     in
     kind >|= fun kind ->
     let raw  = PIC.unpack_kind kind in
-    let sha1 = digest raw in
+    let sha1 = D.string raw in
     Log.debug "to_pic(%s) -> %s:%s"
       (Misc.pretty pp_kind t.kind) (SHA.pretty sha1) (PIC.pretty_kind kind);
     PIC.create ~raw sha1 kind

--- a/lib/packed_value.mli
+++ b/lib/packed_value.mli
@@ -152,7 +152,7 @@ module IO (D: SHA.DIGEST) (I: Inflate.S): sig
   (** [to_value p] unpacks the packed position-independant value
       [p]. *)
 
-  val to_pic: digest:string SHA.digest -> read:Value.read_inflated ->
+  val to_pic: read:Value.read_inflated ->
     offsets:(int -> pic option) -> sha1s:(SHA.t -> pic option) ->
     t -> pic Lwt.t
   (** [to_pic t] is the position-independant representation of the


### PR DESCRIPTION
Use D.string instead.  See #129.