### PR TITLE
git-unix: use larger buffer for large files

### DIFF
--- a/lib/unix/git_unix.ml
+++ b/lib/unix/git_unix.ml
@@ -225,17 +225,16 @@ module IO_FS = struct
   let write_file file ?temp_dir b =
     with_write_file file ?temp_dir (fun fd -> write_cstruct fd b)
 
-  (* [read_into ~off buf ch] reads from [ch] into [buf] until
+  (* [read_into ~chunk_size ~off buf ch] reads from [ch] into [buf] until
      either [buf] is full or [ch] is exhausted. It returns the
      subset of [buf] that was filled. *)
-  let read_into buf ch =
-    let len = 4 * 4096 in
-    let data = Bytes.create len in
+  let read_into ~chunk_size buf ch =
+    let data = Bytes.create chunk_size in
     let rec aux off =
       match Cstruct.len buf - off with
       | 0     -> Lwt.return buf   (* Buffer full *)
       | avail ->
-        Lwt_io.read_into ch data 0 (min len avail) >>= fun read ->
+        Lwt_io.read_into ch data 0 (min chunk_size avail) >>= fun read ->
         Cstruct.blit_from_string data 0 buf off read;
         aux (off + read)
     in
@@ -244,10 +243,15 @@ module IO_FS = struct
   let read_file file =
     Lwt_pool.use openfile_pool (fun () ->
         Log.info "Reading %s" file;
-        Lwt_io.(with_file ~mode:input) ~flags:[Unix.O_RDONLY] file (fun ch ->
-            Lwt_io.length ch >|= Int64.to_int >|= Cstruct.create >>= fun buf ->
-            read_into buf ch
-          )
+        Lwt_unix.stat file >>= fun stats ->
+        (* There are really too many buffers here. First we copy from the FS to the Lwt_io buffer,
+           then from there into our own string buffer, then blit from there into a Cstruct. *)
+        let chunk_size = max 4096 (min stats.Lwt_unix.st_size 0x100000) in
+        let lwt_buffer = Lwt_bytes.create chunk_size in
+        Lwt_io.(with_file ~buffer:lwt_buffer ~mode:input) ~flags:[Unix.O_RDONLY] file (fun ch ->
+          let buf = Cstruct.create stats.Lwt_unix.st_size in
+          read_into ~chunk_size buf ch
+        )
       )
 
   let realdir dir =


### PR DESCRIPTION
Reading a 100 MB pack file went from 0.40s to 0.06s (there's still too much copying though - Python reads the same file in 0.05s).