### PR TITLE
Add Store.size

### DIFF
--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -145,6 +145,11 @@ module Make (D: Hash.DIGEST) (I: Inflate.S) = struct
   let mem t h =
     Lwt.return (Hashtbl.mem t.values h)
 
+  let size t h =
+    read t h >|= function
+    | Some (Value.Blob v) -> Some (String.length (Blob.to_raw v))
+    | _ -> None
+
   let read_exn t h =
     read t h >>= function
     | None   -> err_not_found "read_exn" (Hash.to_hex h)

--- a/lib/pack.mli
+++ b/lib/pack.mli
@@ -109,6 +109,8 @@ module type IO = sig
       Mstruct.t -> Hash.t -> string option Lwt.t
     (** Same as {!read} but for inflated values. *)
 
+    val size: index:Pack_index.f -> Mstruct.t -> Hash.t -> int option Lwt.t
+    (** [size ~index buf h] is the (uncompressed) size of [h]. *)
   end
 
   type raw = Raw.t

--- a/lib/packed_value.mli
+++ b/lib/packed_value.mli
@@ -120,7 +120,13 @@ type pic = PIC.t
 
 module IO (D: Hash.DIGEST) (I: Inflate.S): sig
 
-  module type IO = Object.IO with type t = kind
+  module type IO = sig
+    include Object.IO with type t = kind
+
+    val size: Mstruct.t -> int
+    (** Get size of the value that [input] would return, without actually
+        decompressing the value. *)
+  end
 
   module V2: IO
   (** Packed values version 2. *)

--- a/lib/store.mli
+++ b/lib/store.mli
@@ -51,6 +51,9 @@ module type S = sig
 
   (** {2 Objects} *)
 
+  val size: t -> Hash.t -> int option Lwt.t
+  (** Return the size of the blob having the given Hash name. *)
+
   val read: t -> Hash.t -> Value.t option Lwt.t
   (** Return the object having the given Hash name. *)
 


### PR DESCRIPTION
Before, the only way to get the size of a file was to decompress the whole thing.

The main win comes from getting the size of raw packed objects without decompressing. There are a couple of further improvements possible:

- Calculate the size of loose objects without loading them.

- For deltas in packs, only decompress the first few bytes (to get `result_size`).

This reduces the time to scan a large tree from 35s to 30s on my test repository. It's not a huge improvement, but probably the right thing to do. Still trying to work out what takes the rest of the time. For reference, Git manages to decompress and check out all the files into the working tree in 4.9s :-/