### PR TITLE
Cache more files in the filesystem when reading a pack file

### DIFF
--- a/lib/git.mli
+++ b/lib/git.mli
@@ -752,14 +752,16 @@ module Packed_value: sig
         buffer. *)
 
     val to_value:
-      index:Pack_index.f -> read:Value.read_inflated -> version:int ->
+      index:Pack_index.f ->
+      read:Value.read_inflated -> write:Value.write_inflated -> version:int ->
       ba:Cstruct.buffer -> t -> Value.t Lwt.t
     (** Unpack the packed value using the provided indexes. *)
 
     (** {2 Position independant packed values} *)
 
     val unpack:
-      index:Pack_index.f -> read:Value.read_inflated -> version:int ->
+      index:Pack_index.f ->
+      read:Value.read_inflated -> write:Value.write_inflated -> version:int ->
       ba:Cstruct.buffer -> t -> string Lwt.t
     (** Same as {!to_value} but for inflated raw buffers. *)
 
@@ -870,11 +872,13 @@ module Pack: sig
       (** Unpack a whole pack file on disk (by calling [write] on every
           values) and return the Hash1s of the written objects. *)
 
-      val read: index:Pack_index.f -> read:Value.read_inflated ->
+      val read: index:Pack_index.f ->
+        read:Value.read_inflated -> write:Value.write_inflated ->
         Mstruct.t -> Hash.t -> Value.t option Lwt.t
       (** Same as the top-level [read] function but for raw packs. *)
 
-      val read_inflated: index:Pack_index.f -> read:Value.read_inflated ->
+      val read_inflated: index:Pack_index.f ->
+        read:Value.read_inflated -> write:Value.write_inflated ->
         Mstruct.t -> Hash.t -> string option Lwt.t
       (** Same as {!read} but for inflated values. *)
 

--- a/lib/git_pack.ml
+++ b/lib/git_pack.ml
@@ -143,18 +143,18 @@ module IO (D: Git_hash.DIGEST) (I: Git_inflate.S) = struct
         let v = Git_packed_value.create ~kind ~offset:shift in
         Some (version, ba, v)
 
-    let read ~index ~read buf hash =
+    let read ~index ~read ~write buf hash =
       match read_packed_value "read" ~index buf hash with
       | None                  -> Lwt.return_none
       | Some (version, ba, v) ->
-        Packed_value_IO.to_value ~version ~read ~index ~ba v >|=
+        Packed_value_IO.to_value ~version ~read ~write ~index ~ba v >|=
         fun x -> Some x
 
-    let read_inflated ~index ~read buf hash =
+    let read_inflated ~index ~read ~write buf hash =
       match read_packed_value "read_inflated" ~index buf hash with
       | None                  -> Lwt.return_none
       | Some (version, ba, v) ->
-        Packed_value_IO.unpack ~version ~read ~index ~ba v >|=
+        Packed_value_IO.unpack ~version ~read ~write ~index ~ba v >|=
         fun x -> Some x
 
     let size ~index buf hash =
@@ -433,9 +433,11 @@ module type IO = sig
       Mstruct.t -> t Lwt.t
     val unpack: ?progress:(string -> unit) -> write:Git_value.write_inflated ->
       t -> Git_hash.Set.t Lwt.t
-    val read: index:Git_pack_index.f -> read:Git_value.read_inflated ->
+    val read: index:Git_pack_index.f ->
+      read:Git_value.read_inflated -> write:Git_value.write_inflated ->
       Mstruct.t -> Git_hash.t -> Git_value.t option Lwt.t
-    val read_inflated: index:Git_pack_index.f -> read:Git_value.read_inflated ->
+    val read_inflated: index:Git_pack_index.f ->
+      read:Git_value.read_inflated -> write:Git_value.write_inflated ->
       Mstruct.t -> Git_hash.t -> string option Lwt.t
     val size: index:Git_pack_index.f -> Mstruct.t -> Git_hash.t -> int option Lwt.t
   end

--- a/lib/git_pack.mli
+++ b/lib/git_pack.mli
@@ -49,9 +49,11 @@ module type IO = sig
       Mstruct.t -> t Lwt.t
     val unpack: ?progress:(string -> unit) -> write:Git_value.write_inflated ->
       t -> Git_hash.Set.t Lwt.t
-    val read: index:Git_pack_index.f -> read:Git_value.read_inflated ->
+    val read: index:Git_pack_index.f ->
+      read:Git_value.read_inflated -> write:Git_value.write_inflated ->
       Mstruct.t -> Git_hash.t -> Git_value.t option Lwt.t
-    val read_inflated: index:Git_pack_index.f -> read:Git_value.read_inflated ->
+    val read_inflated: index:Git_pack_index.f ->
+      read:Git_value.read_inflated -> write:Git_value.write_inflated ->
       Mstruct.t -> Git_hash.t -> string option Lwt.t
     val size: index:Git_pack_index.f -> Mstruct.t -> Git_hash.t -> int option Lwt.t
   end

--- a/lib/git_packed_value.mli
+++ b/lib/git_packed_value.mli
@@ -83,12 +83,14 @@ module IO (D: Git_hash.DIGEST) (I: Git_inflate.S): sig
     Buffer.t -> t -> unit Lwt.t
 
   val to_value:
-    index:Git_pack_index.f -> read:Git_value.read_inflated -> version:int ->
-    ba:Cstruct.buffer -> t -> Git_value.t Lwt.t
+    index:Git_pack_index.f ->
+    read:Git_value.read_inflated -> write:Git_value.write_inflated ->
+    version:int -> ba:Cstruct.buffer -> t -> Git_value.t Lwt.t
 
   val unpack:
-    index:Git_pack_index.f -> read:Git_value.read_inflated -> version:int ->
-    ba:Cstruct.buffer -> t -> string Lwt.t
+    index:Git_pack_index.f ->
+    read:Git_value.read_inflated -> write:Git_value.write_inflated ->
+    version:int -> ba:Cstruct.buffer -> t -> string Lwt.t
 
   val value_of_pic: pic -> Git_value.t
 


### PR DESCRIPTION
This speeds-up reads in a big pack file. Related to docker/datakit#287

On one example where where I have 2 pack files and:

```
$ du -h .git/objects/pack/
592M    .git/objects/pack/
```

the full application start-time passed from:

```
real    3m41.018s
user    0m2.101s
sys     0m1.614s
```

to

```
real    0m46.003s
user    0m1.566s
sys     0m1.284s
```