### PR TITLE
Add IO.test_and_set for FS implementations

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,6 @@
 PKG cstruct logs ocamlgraph re zip uri lwt mstruct cmdliner mirage-fs-lwt
 PKG nocrypto hex cohttp.lwt mirage-flow-lwt tcpip mirage-http alcotest fmt
-PKG mirage-fs-unix astring mtime.os mirage-channel-lwt
+PKG mirage-fs-unix astring mtime.os mirage-channel-lwt git git-unix
 B _build/**
 S src/
 S test/

--- a/.merlin
+++ b/.merlin
@@ -3,4 +3,8 @@ PKG nocrypto hex cohttp.lwt mirage-flow-lwt tcpip mirage-http alcotest fmt
 PKG mirage-fs-unix astring mtime.os mirage-channel-lwt git git-unix
 B _build/**
 S src/
+S src-top/
+S src-mirage/
+S src-http/
+S src-unix/
 S test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ script: bash -ex .travis-opam.sh
 env:
   global:
     - EXTRA_REMOTES="https://github.com/mirage/mirageos-3-beta.git"
-    - PINS="git.1.10.0:. git-http.1.10.0:. git-unix.1.10.0:. git-mirage.1.10.0:."
+    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
   matrix:
-    - OCAML_VERSION=4.02 PACKAGE="git-unix"
-    - OCAML_VERSION=4.03 PACKAGE="git-unix"
-    - OCAML_VERSION=4.04 PACKAGE="git-mirage"
-    - OCAML_VERSION=4.03 PACKAGE="git" REVDEPS=*
+    - OCAML_VERSION=4.02 PACKAGE="git-unix.dev"
+    - OCAML_VERSION=4.03 PACKAGE="git-unix.dev"
+    - OCAML_VERSION=4.04 PACKAGE="git-mirage.dev"
+    - OCAML_VERSION=4.03 PACKAGE="git.dev" REVDEPS=*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+    - EXTRA_REMOTES="https://github.com/mirage/mirageos-3-beta.git"
     - PINS="git.1.10.0:. git-http.1.10.0:. git-unix.1.10.0:. git-mirage.1.10.0:."
   matrix:
     - OCAML_VERSION=4.02 PACKAGE="git-unix"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ env:
   matrix:
     - OCAML_VERSION=4.02 PACKAGE="git-unix"
     - OCAML_VERSION=4.03 PACKAGE="git-unix"
-    - OCAML_VERSION=4.04 PACKAGE="git-unix"
+    - OCAML_VERSION=4.04 PACKAGE="git-mirage"
     - OCAML_VERSION=4.03 PACKAGE="git" REVDEPS=*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
     - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-    - PINS="git.2.0.0:. git-http.2.0.0:. git-unix.2.0.0:. git-mirage.2.0.0:."
+    - PINS="git.1.10.0:. git-http.1.10.0:. git-unix.1.10.0:. git-mirage.1.10.0:."
   matrix:
     - OCAML_VERSION=4.02 PACKAGE="git-unix"
     - OCAML_VERSION=4.03 PACKAGE="git-unix"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,20 @@
 all:
+	$(MAKE) core
+	$(MAKE) http
+	$(MAKE) mirage
+	$(MAKE) unix
+
+core:
 	ocaml pkg/pkg.ml build -n git
+
+http:
 	ocaml pkg/pkg.ml build -n git-http
-	ocaml pkg/pkg.ml build -n git-mirage
+
+mirage:
+	ocaml pkg/pkg.ml build -n git-mirage --tests true
+	ocaml pkg/pkg.ml test
+
+unix:
 	ocaml pkg/pkg.ml build -n git-unix --tests true
 	ocaml pkg/pkg.ml test
 

--- a/_tags
+++ b/_tags
@@ -3,19 +3,19 @@ true: warn_error(+1..49+60), warn(A-4-41-44)
 
 true: package(cstruct astring fmt hex logs lwt ocamlgraph re uri mstruct)
 
-<src-unix>: include
 <test/*>: package(alcotest logs.fmt mtime.os nocrypto)
 <test/*>: package(mirage-fs-unix io-page.unix)
-<test/*>: package(git git-mirage git-http result camlzip)
+<test/*>: package(result camlzip)
 
 <src-top/*>: package(compiler-libs.toplevel)
 
-<src-http/*>: package(git cohttp.lwt uri)
+<src-http/*>: package(cohttp.lwt uri)
 
-<src-unix/*>: package(git git-http lwt.unix conduit.lwt-unix camlzip nocrypto)
+<src-unix/*>: package(lwt.unix conduit.lwt-unix camlzip nocrypto)
 <src-unix/ogit.*>: package(cmdliner fmt.cli logs.fmt fmt.tty mtime.os lwt.unix)
 <src-unix/ogit.*>: package(logs.cli)
 
 <src-mirage/*>: package(mirage-flow-lwt mirage-channel-lwt mirage-fs-lwt)
-<src-mirage/*>: package(conduit.mirage result)
-<src-mirage/*>: package(git git-http mirage-http)
+<src-mirage/*>: package(conduit.mirage result mirage-http)
+<test/test_mirage.*>: package(mirage-flow-lwt mirage-channel-lwt)
+<test/test_mirage.*>: package(mirage-channel-lwt conduit.mirage mirage-http)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     CYG_ROOT: "C:\\cygwin"
     CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
     TESTS: "false"
-    EXTRA_REMOTES: "https://github.com/mirage/mirage-dev.git"
+    EXTRA_REMOTES: "https://github.com/mirage/mirageos-3-beta.git"
     PINS: "git.1.10.0:. git-http.1.10.0:. git-unix.1.10.0:. git-mirage.1.10.0:."
   matrix:
   - PACKAGE: "git-mirage"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,10 @@ environment:
     CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
     TESTS: "false"
     EXTRA_REMOTES: "https://github.com/mirage/mirageos-3-beta.git"
-    PINS: "git.1.10.0:. git-http.1.10.0:. git-unix.1.10.0:. git-mirage.1.10.0:."
+    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
   matrix:
-  - PACKAGE: "git-mirage"
-  - PACKAGE: "git-unix"
+  - PACKAGE: "git-mirage.dev"
+  - PACKAGE: "git-unix.dev"
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
   TESTS: "false"
   EXTRA_REMOTES: "https://github.com/mirage/mirage-dev.git"
-  PINS: "git.2.0.0:. git-http.2.0.0:. git-unix.2.0.0:. git-mirage.2.0.0:."
+  PINS: "git.1.10.0:. git-http.1.10.0:. git-unix.1.10.0:. git-mirage.1.10.0:."
   PACKAGE: "git-unix"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,15 @@ platform:
   - x86
 
 environment:
-  CYG_ROOT: "C:\\cygwin"
-  CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
-  TESTS: "false"
-  EXTRA_REMOTES: "https://github.com/mirage/mirage-dev.git"
-  PINS: "git.1.10.0:. git-http.1.10.0:. git-unix.1.10.0:. git-mirage.1.10.0:."
-  PACKAGE: "git-unix"
+  global:
+    CYG_ROOT: "C:\\cygwin"
+    CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+    TESTS: "false"
+    EXTRA_REMOTES: "https://github.com/mirage/mirage-dev.git"
+    PINS: "git.1.10.0:. git-http.1.10.0:. git-unix.1.10.0:. git-mirage.1.10.0:."
+  matrix:
+  - PACKAGE: "git-mirage"
+  - PACKAGE: "git-unix"
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh

--- a/git-http.opam
+++ b/git-http.opam
@@ -10,7 +10,7 @@ doc:          "https://mirage.github.io/ocaml-git/"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 
 depends: [
-  "git"        {>= "2.0.0"}
+  "git"        {>= "1.10.0"}
   "cohttp"     {>= "0.19.1"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -21,8 +21,8 @@ depends: [
   "mirage-fs-lwt"
   "mirage-conduit" {>= "2.3.0"}
   "result"
-  "git-http" {>= "2.0.0"}
-  "git"      {>= "2.0.0"}
+  "git-http" {>= "1.10.0"}
+  "git"      {>= "1.10.0"}
   "alcotest"       {test}
   "mirage-fs-unix" {test & >= "1.3.0"}
 ]

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -7,7 +7,12 @@ bug-reports:  "https://github.com/mirage/ocaml-git/issues"
 dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"]
+
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "true"]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
 
 depends: [
   "mirage-http"
@@ -18,6 +23,8 @@ depends: [
   "result"
   "git-http" {>= "2.0.0"}
   "git"      {>= "2.0.0"}
+  "alcotest"       {test}
+  "mirage-fs-unix" {test & >= "1.3.0"}
 ]
 
 available: [ocaml-version >= "4.02.3"]

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -24,8 +24,6 @@ depends: [
   "mtime"
   "base-unix"
   "alcotest"       {test}
-  "git-mirage"     {test & >= "2.0.0"}
-  "mirage-fs-unix" {test & >= "1.3.0"}
 ]
 
 available: [ocaml-version >= "4.02.3"]

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -17,7 +17,7 @@ build-test: [
 
 depends: [
   "cmdliner"
-  "git-http" {>= "2.0.0"}
+  "git-http" {>= "1.10.0"}
   "conduit"  {>= "0.8.4"}
   "camlzip"  {>= "1.06"}
   "nocrypto" {>= "0.2.0"}

--- a/src-mirage/git_mirage.mli
+++ b/src-mirage/git_mirage.mli
@@ -26,7 +26,10 @@ module type FS = sig
 end
 
 module FS (FS: FS) (D: Git.Hash.DIGEST) (I: Git.Inflate.S): Git.FS.S
-(** Create a Irmin store from raw block devices handler. *)
+(** Create a Irmin store from raw block devices handler. The Irmin
+    process should have full and exclusive access to the block device
+    to ensure atomicity of [test_and_set_file], as it uses in-memory
+    locks. *)
 
 module Sync: sig
   module IO: Git.Sync.IO with type ctx = Resolver_lwt.t * Conduit_mirage.t

--- a/src-unix/ogit.ml
+++ b/src-unix/ogit.ml
@@ -189,7 +189,7 @@ let cat_file = {
     in
     let cat_file (module S: Store.S) ty_flag sz_flag id =
       run begin
-        S.create () >>= fun t ->
+        S.create ~root:(Sys.getcwd ()) () >>= fun t ->
         catch_ambiguous (fun () ->
             S.read_exn t (Hash_IO.of_short_hex id) >>= fun v ->
             let t, c, s = match v with
@@ -224,7 +224,7 @@ let ls_remote = {
     let ls (module S: Store.S) remote =
       let module Sync = Sync.Make(S) in
       run begin
-        S.create ()  >>= fun t ->
+        S.create ~root:(Sys.getcwd ()) ()  >>= fun t ->
         Sync.ls t remote >>= fun references ->
         Printf.printf "From %s\n" (Gri.to_string remote);
         let print r h =
@@ -249,7 +249,7 @@ let ls_files = {
     in
     let ls (module S: Store.S) debug =
       run begin
-        S.create ()    >>= fun t ->
+        S.create ~root:(Sys.getcwd ()) ()    >>= fun t ->
         S.read_index t >>= fun cache ->
         if debug then
           Fmt.(pf stdout) "%a" Index.pp cache
@@ -316,7 +316,7 @@ let ls_tree = {
             ) tree
       in
       run begin
-        S.create () >>= fun t ->
+        S.create ~root:(Sys.getcwd ()) () >>= fun t ->
         let h = Hash_IO.of_short_hex oid in
         catch_ambiguous (fun () -> walk t "" h)
       end in
@@ -337,7 +337,7 @@ let read_tree = {
       Arg.(required & pos 0 (some string) None & doc ) in
     let read (module S: Store.S) commit_str =
       run begin
-        S.create ()    >>= fun t ->
+        S.create ~root:(Sys.getcwd ()) ()    >>= fun t ->
         S.references t >>= fun refs ->
         begin
           let (/) = Filename.concat in
@@ -439,7 +439,7 @@ let fetch = {
     let fetch (module S: Store.S) unpack remote =
       let module Sync = Sync.Make(S) in
       run begin
-        S.create ()                 >>= fun t ->
+        S.create ~root:(Sys.getcwd ()) ()     >>= fun t ->
         Sync.fetch t ~unpack ~progress remote >>= fun _ ->
         Lwt.return_unit
       end in
@@ -455,7 +455,7 @@ let pull = {
     let pull (module S: Store.S) unpack remote =
       let module Sy = Sync.Make(S) in
       run begin
-        S.create ()   >>= fun t ->
+        S.create ~root:(Sys.getcwd ()) () >>= fun t ->
         S.read_head t >>= fun h ->
         Sy.fetch t ~unpack remote >>= fun r ->
         match h with
@@ -485,8 +485,8 @@ let push = {
       let module Result = Sync.Result in
       let module Sync = Sync.Make(S) in
       run begin
-        S.create ()                 >>= fun t ->
-        S.read_reference t branch   >>= fun b ->
+        S.create ~root:(Sys.getcwd ()) () >>= fun t ->
+        S.read_reference t branch >>= fun b ->
         let branch = match b with
           | None   -> reference_of_raw branch
           | Some _ -> branch in
@@ -509,7 +509,7 @@ let graph = {
     let graph (module S: Store.S) file =
       let module Graph = Git.Graph.Make(S) in
       run begin
-        S.create () >>= fun t ->
+        S.create ~root:(Sys.getcwd ()) () >>= fun t ->
         let buf = Buffer.create 1024 in
         Graph.to_dot t buf >>= fun () ->
         Lwt_io.with_file ~mode:Lwt_io.output file (fun oc ->

--- a/src/git_store.ml
+++ b/src/git_store.ml
@@ -16,8 +16,7 @@
 
 module type S = sig
   type t
-  val create: ?root:string -> ?dot_git:string -> ?level:int ->
-    unit -> t Lwt.t
+  val create: ?root:string -> ?dot_git:string -> ?level:int -> unit -> t Lwt.t
   val dot_git: t -> string
   val root: t -> string
   val level: t -> int
@@ -38,6 +37,8 @@ module type S = sig
   val read_head: t -> Git_reference.head_contents option Lwt.t
   val write_reference: t -> Git_reference.t -> Git_hash.t -> unit Lwt.t
   val remove_reference: t -> Git_reference.t -> unit Lwt.t
+  val test_and_set_reference: t -> Git_reference.t ->
+    test:Git_hash.t option -> set:Git_hash.t option -> bool Lwt.t
   val read_index: t -> Git_index.t Lwt.t
   val write_index: t -> ?index:Git_index.t -> Git_hash.Commit.t -> unit Lwt.t
   val kind: [`Memory | `Disk]

--- a/test/test.ml
+++ b/test/test.ml
@@ -14,9 +14,244 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+open Git
+open Lwt.Infix
+open Test_common
+
+module Make (Store: Store.S) = struct
+
+  module Sync = Git_unix.Sync.Make(Store)
+  module T = Test_store.Make(Store)
+  include T
+
+  let test_basic_remote x () =
+    let test () =
+      let gri = Gri.of_string "git://localhost/" in
+      create () >>= fun t ->
+      Store.read_head t >>= fun head ->
+      Alcotest.(check (option head_contents)) "no head" None head;
+      Sync.fetch t gri >>= fun _ ->
+      Sync.push t gri ~branch:Reference.master >>= fun _ ->
+      Lwt.return_unit
+    in
+    run x test
+
+  let test_clone x () =
+    let test () =
+      Store.create ~root () >>= fun t ->
+      let clone ?depth ?(bare=true) ?branch gri =
+        x.init () >>= fun () ->
+        Store.list t >>= fun l ->
+        Alcotest.(check (list sha1))
+          (Printf.sprintf "empty depth=%s branch=%s uri=%s"
+             (match depth with None -> "<none>" | Some d -> string_of_int d)
+             (match branch with
+              | None   -> "<none>"
+              | Some h -> Fmt.to_to_string Git.Sync.pp_want h)
+             (Gri.to_string gri))
+          l [];
+        Sync.clone t ?deepen:depth ?branch ~checkout:(not bare) gri >>= fun _ ->
+        if x.shell then (
+          let cmd = Printf.sprintf "cd %s && git fsck" @@ Store.root t in
+          Alcotest.(check int) "fsck" 0 (Sys.command cmd)
+        );
+        let master = Reference.master in
+        let e = match branch with
+          | None             -> Reference.Ref master
+          | Some (`Ref b)    -> Reference.Ref b
+          | Some (`Commit h) -> Reference.Hash h
+        in
+        Store.list t >>= fun sha1s ->
+        Lwt_list.iter_s (fun sha1 ->
+            Store.read_exn t sha1 >>= fun _v ->
+            Lwt.return_unit
+          ) sha1s
+        >>= fun () ->
+        Store.read_head t >>= function
+        | None   -> Alcotest.fail "empty clone!"
+        | Some h ->
+          Alcotest.(check head_contents) "correct head contents" e h;
+          Lwt.return_unit
+      in
+      let git = Gri.of_string "git://github.com/mirage/ocaml-git.git" in
+      let https = Gri.of_string "https://github.com/mirage/ocaml-git.git" in
+      (* let large = Gri.of_string "https://github.com/ocaml/opam-repository.git" in *)
+      let gh_pages = `Ref (Reference.of_raw "refs/heads/gh-pages") in
+      let commit =
+        `Commit (Hash_IO.Commit.of_hex "f7a8f077e4d880db173f3f48a74d5a3fc9210b4e")
+      in
+      clone git   >>= fun () ->
+      clone https >>= fun () ->
+      clone git   ~branch:gh_pages >>= fun () ->
+      clone https ~branch:gh_pages >>= fun () ->
+      clone https ~depth:1 ~branch:commit   >>= fun () ->
+      clone git   ~depth:3 ~branch:gh_pages >>= fun () ->
+      (* clone large ~bare:false  >>= fun () -> *)
+
+      Lwt.return_unit
+    in
+    run x test
+
+  let test_fetch x () =
+    let test_one gri c0 c1 ?(update=false) diff =
+      x.init () >>= fun () ->
+      Store.create ~root () >>= fun t ->
+      Store.list t >>= fun l ->
+      Alcotest.(check (list sha1)) "empty" [] l;
+      let fetch gri (branch, commit) =
+        let b = Reference.of_raw ("refs/heads/" ^ branch) in
+        let c = Hash_IO.of_hex commit in
+        Sync.clone t ~branch:(`Commit (Hash.to_commit c)) ~checkout:false gri
+        >>= fun r ->
+        Store.write_reference t b c >>= fun () ->
+        if x.shell then (
+          let cmd = Printf.sprintf "cd %s && git fsck" @@ Store.root t in
+          Alcotest.(check int) "fsck" 0 (Sys.command cmd)
+        );
+        begin if update then (
+            Store.read_exn t c >>= function
+            | Value.Commit parent ->
+              let parents = [Hash.to_commit c] in
+              let c' = { parent with Commit.message = "foo"; parents } in
+              Store.write t (Value.Commit c') >>= fun k ->
+              Store.write_reference t b k
+            | _ -> assert false
+          ) else
+            Lwt.return_unit
+        end >|= fun () ->
+        Git.Sync.Result.hashes r
+      in
+      fetch gri c0 >>= fun _ ->
+      fetch gri c1 >>= fun r ->
+      Alcotest.(check sha1s) "diff" diff r;
+      Lwt.return_unit
+    in
+    let test () =
+      let git   = Gri.of_string "git://github.com/mirage/irmin-rt.git" in
+      let https = Gri.of_string "https://github.com/mirage/irmin-rt.git" in
+      let c1 = "test-fetch-2", "64beec7402efc772363f4e0a7dfeb0ad2a667367" in
+      let c0 = "test-fetch-1", "348199320dc33614bc5d101b1e0e22eaea25b36b" in
+      let diff  =
+        let x = Hash_IO.of_hex in
+        Hash.Set.of_list [
+          x (snd c1); (* commit *)
+          x "1700d5cbd2ac8f5faf491a3c07c4562f9e43f016"; (* / *)
+          x "2c6368156f499eaee397c5c2d698fabcb1b3114c"; (* overhead/ *)
+          x "54e0af2928da25353fb2a9ecc87530202e940580"; (* overhead/overhead.ml *)
+        ] in
+      test_one git c0 c1 diff   >>= fun () ->
+      test_one https c0 c1 diff >>= fun () ->
+      test_one https ~update:true c0 c1 diff >>= fun () ->
+      Lwt.return_unit
+    in
+    run x test
+
+  let test_leaks x () =
+    let runs =
+      try int_of_string (Sys.getenv "TESTRUNS")
+      with Not_found -> 10_000
+    in
+    let test () =
+      create () >>= fun t ->
+      let rec aux = function
+        | 0 -> Lwt.return_unit
+        | i ->
+          check_write t "v1" kv1 v1 >>= fun () ->
+          check_write t "v2" kv2 v2 >>= fun () ->
+          aux (i-1)
+      in
+      aux runs
+    in
+    run x test
+
+
+  let test_index x () =
+    let test () =
+      let test_fs () =
+        (* scan the local filesystem *)
+        if x.name = "FS" then (
+          if Filename.basename (Sys.getcwd ()) <> "_build" then
+            failwith "Tests should run in _build/";
+          files "." >>= fun files ->
+          Git_unix.FS.create ~root () >>= fun t ->
+          Lwt_list.map_s (fun file ->
+              Git_unix.FS.IO.read_file file >>= fun str ->
+              let blob = Blob.of_raw (Cstruct.to_string str) in
+              let sha1 = Hash.to_blob (Value_IO.name (Value.Blob blob)) in
+              let mode =
+                let p = (Unix.stat file).Unix.st_perm in
+                if p land 0o100 = 0o100 then `Exec else `Normal
+              in
+              Git_unix.FS.entry_of_file t Index.empty file mode sha1 blob
+            ) files >>= fun entries ->
+          let entries = list_filter_map (fun x -> x) entries in
+          let cache = Index.create entries in
+          let buf = with_buffer' (fun buf -> Index_IO.add buf cache) in
+          let cache2 = Index_IO.input (Mstruct.of_cstruct buf) in
+          Common.assert_index_equal "index" cache cache2;
+          Lwt.return_unit
+        ) else
+          Lwt.return_unit
+      in
+      test_fs () >>= fun () ->
+
+      (* test random entries *)
+      create ~index:true () >>= fun t ->
+      Store.write_index t (Hash.to_commit kc2) >>= fun () ->
+      Store.read_index t >>= fun _ ->
+      Lwt.return_unit
+    in
+    run x test
+
+end
+
+let test_read_writes () =
+  Lwt_main.run begin
+    let file = "/tmp/test-git" in
+    let payload = Cstruct.of_string "boo!" in
+    let rec write = function
+      | 0 -> Lwt.return_unit
+      | i -> Git_unix.FS.IO.write_file file payload <&> write (i-1)
+    in
+    let rec read = function
+      | 0 -> Lwt.return_unit
+      | i ->
+        Git_unix.FS.IO.read_file file >>= fun r ->
+        Alcotest.(check string) "concurrent read/write"
+          (Cstruct.to_string payload) (Cstruct.to_string r);
+        read (i-1)
+    in
+    write 1
+    >>= fun () -> Lwt.join [ write 500; read 1000; write 1000; read 500; ]
+  end
+
+let suite (speed, x) =
+  let (module S) = x.store in
+  let module T = Make(S) in
+  x.name,
+  [
+    "Operations on blobs"       , speed, T.test_blobs x;
+    "Operations on trees"       , speed, T.test_trees x;
+    "Operations on commits"     , speed, T.test_commits x;
+    "Operations on tags"        , speed, T.test_tags x;
+    "Operations on references"  , speed, T.test_refs x;
+    "Operations on index"       , speed, T.test_index x;
+    "Operations on pack files"  , speed, T.test_packs x;
+    "Search"                    , speed, T.test_search x;
+    "Resource leaks"            , `Slow, T.test_leaks x;
+    "Basic Remote operations"   , `Slow, T.test_basic_remote x;
+    "Fetching remote repos"     , `Slow, T.test_fetch x;
+    "Cloning remote repos"      , `Slow, T.test_clone x;
+  ]
+
+let extra = [
+  "OPS"        , ["Concurrent read/writes", `Quick, test_read_writes];
+  "SHA1-unix"  , Test_store.array (module Git_unix.SHA1);
+  "SHA256-unix", Test_store.array (module Git_unix.SHA256);
+]
+
 let () =
-  Test_store.run "git" [
+  Test_store.run ~extra "git" [
     `Quick, Test_memory.suite;
     `Quick, Test_fs.suite;
-    `Quick, Test_mirage.suite;
   ]

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -159,3 +159,31 @@ let sha1s =
     let pp = Hash.Set.pp
   end
   in (module M: Alcotest.TESTABLE with type t = M.t)
+
+type t = {
+  name  : string;
+  init  : unit -> unit Lwt.t;
+  clean : unit -> unit Lwt.t;
+  store : (module Store.S);
+  shell : bool;
+}
+
+let unit () = Lwt.return_unit
+
+(* From Git_misc *)
+
+let list_filter_map f l =
+  List.fold_left (fun l elt ->
+      match f elt with
+      | None   -> l
+      | Some x -> x :: l
+    ) [] l
+  |> List.rev
+
+let with_buffer fn =
+  let buf = Buffer.create 1024 in
+  fn buf;
+  Buffer.contents buf
+
+let with_buffer' fn =
+  Cstruct.of_string (with_buffer fn)

--- a/test/test_fs.ml
+++ b/test/test_fs.ml
@@ -15,7 +15,7 @@
  *)
 
 open Lwt.Infix
-open Test_store
+open Test_common
 
 let root = "test-db"
 

--- a/test/test_fs.ml
+++ b/test/test_fs.ml
@@ -24,7 +24,7 @@ module M = Git_unix.FS
 let init () =
   M.clear ();
   M.create ~root () >>= fun t ->
-  M.remove t
+  M.reset t
 
 let suite =
   {

--- a/test/test_memory.ml
+++ b/test/test_memory.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Test_store
+open Test_common
 
 module Memory = Git.Memory.Make(Git_unix.SHA1)(Git_unix.Zlib)
 

--- a/test/test_mirage.ml
+++ b/test/test_mirage.ml
@@ -15,7 +15,7 @@
  *)
 
 open Lwt.Infix
-open Test_store
+open Test_common
 open Git_mirage
 open Result
 
@@ -30,23 +30,25 @@ module M = struct
 
   include FS_unix
 
+  let root = "test-db"
+
   let (>>|) x f =
     x >>= function
     | Ok x    -> f x
     | Error e -> Lwt.fail_with @@ Fmt.strf "%a" FS_unix.pp_write_error e
 
-  let connect () = connect Test_fs.root
+  let connect () = connect root
 
   let init () =
-    command "rm -rf %s" Test_fs.root;
-    command "mkdir %s" Test_fs.root;
+    command "rm -rf %s" root;
+    command "mkdir %s" root;
     connect ()  >>= fun t ->
     mkdir t "/" >>| fun () ->
     Lwt.return_unit
 
 end
 
-module S = FS(M)(SHA1_slow)(Git_unix.Zlib)
+module S = FS(M)(SHA1_slow)(Git.Inflate.Make(Zlib))
 
 let suite =
   {
@@ -56,3 +58,12 @@ let suite =
     store = (module S);
     shell = true;
   }
+
+let extra = [
+  "SHA1-mirage", Test_store.array (module Git_mirage.SHA1_slow);
+]
+
+let () =
+  Test_store.run ~extra "git-mirage" [
+    `Quick, suite;
+  ]

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -19,35 +19,7 @@ open Lwt.Infix
 open Git
 open Astring
 
-(* From Git_misc *)
-
-let list_filter_map f l =
-  List.fold_left (fun l elt ->
-      match f elt with
-      | None   -> l
-      | Some x -> x :: l
-    ) [] l
-  |> List.rev
-
-let with_buffer fn =
-  let buf = Buffer.create 1024 in
-  fn buf;
-  Buffer.contents buf
-
-let with_buffer' fn =
-  Cstruct.of_string (with_buffer fn)
-
 (*****************)
-
-type t = {
-  name  : string;
-  init  : unit -> unit Lwt.t;
-  clean : unit -> unit Lwt.t;
-  store : (module Store.S);
-  shell : bool;
-}
-
-let unit () = Lwt.return_unit
 
 let long_random_string () =
   let t  = Unix.gettimeofday () in
@@ -373,44 +345,6 @@ module Make (Store: Store.S) = struct
     in
     run x test
 
-  let test_index x () =
-    let test () =
-      let test_fs () =
-        (* scan the local filesystem *)
-        if x.name = "FS" then (
-          if Filename.basename (Sys.getcwd ()) <> "_build" then
-            failwith "Tests should run in _build/";
-          files "." >>= fun files ->
-          Git_unix.FS.create ~root () >>= fun t ->
-          Lwt_list.map_s (fun file ->
-              Git_unix.FS.IO.read_file file >>= fun str ->
-              let blob = Blob.of_raw (Cstruct.to_string str) in
-              let sha1 = Hash.to_blob (Value_IO.name (Value.Blob blob)) in
-              let mode =
-                let p = (Unix.stat file).Unix.st_perm in
-                if p land 0o100 = 0o100 then `Exec else `Normal
-              in
-              Git_unix.FS.entry_of_file t Index.empty file mode sha1 blob
-            ) files >>= fun entries ->
-          let entries = list_filter_map (fun x -> x) entries in
-          let cache = Index.create entries in
-          let buf = with_buffer' (fun buf -> Index_IO.add buf cache) in
-          let cache2 = Index_IO.input (Mstruct.of_cstruct buf) in
-          assert_index_equal "index" cache cache2;
-          Lwt.return_unit
-        ) else
-          Lwt.return_unit
-      in
-      test_fs () >>= fun () ->
-
-      (* test random entries *)
-      create ~index:true () >>= fun t ->
-      Store.write_index t (Hash.to_commit kc2) >>= fun () ->
-      Store.read_index t >>= fun _ ->
-      Lwt.return_unit
-    in
-    run x test
-
   let test_packs x () =
     if x.name = "FS" then
       let test () =
@@ -471,169 +405,7 @@ module Make (Store: Store.S) = struct
       in
       run x test
 
-  module Sync = Git_unix.Sync.Make(Store)
-
-  let test_basic_remote x () =
-    let test () =
-      let gri = Gri.of_string "git://localhost/" in
-      create () >>= fun t ->
-      Store.read_head t >>= fun head ->
-      Alcotest.(check (option head_contents)) "no head" None head;
-      Sync.fetch t gri >>= fun _ ->
-      Sync.push t gri ~branch:Reference.master >>= fun _ ->
-      Lwt.return_unit
-    in
-    run x test
-
-  let test_clone x () =
-    let test () =
-      Store.create ~root () >>= fun t ->
-      let clone ?depth ?(bare=true) ?branch gri =
-        x.init () >>= fun () ->
-        Store.list t >>= fun l ->
-        Alcotest.(check (list sha1))
-          (Printf.sprintf "empty depth=%s branch=%s uri=%s"
-             (match depth with None -> "<none>" | Some d -> string_of_int d)
-             (match branch with
-              | None   -> "<none>"
-              | Some h -> Fmt.to_to_string Git.Sync.pp_want h)
-             (Gri.to_string gri))
-          l [];
-        Sync.clone t ?deepen:depth ?branch ~checkout:(not bare) gri >>= fun _ ->
-        if x.shell then (
-          let cmd = Printf.sprintf "cd %s && git fsck" @@ Store.root t in
-          Alcotest.(check int) "fsck" 0 (Sys.command cmd)
-        );
-        let master = Reference.master in
-        let e = match branch with
-          | None             -> Reference.Ref master
-          | Some (`Ref b)    -> Reference.Ref b
-          | Some (`Commit h) -> Reference.Hash h
-        in
-        Store.list t >>= fun sha1s ->
-        Lwt_list.iter_s (fun sha1 ->
-            Store.read_exn t sha1 >>= fun _v ->
-            Lwt.return_unit
-          ) sha1s
-        >>= fun () ->
-        Store.read_head t >>= function
-        | None   -> Alcotest.fail "empty clone!"
-        | Some h ->
-          Alcotest.(check head_contents) "correct head contents" e h;
-          Lwt.return_unit
-      in
-      let git = Gri.of_string "git://github.com/mirage/ocaml-git.git" in
-      let https = Gri.of_string "https://github.com/mirage/ocaml-git.git" in
-      (* let large = Gri.of_string "https://github.com/ocaml/opam-repository.git" in *)
-      let gh_pages = `Ref (Reference.of_raw "refs/heads/gh-pages") in
-      let commit =
-        `Commit (Hash_IO.Commit.of_hex "f7a8f077e4d880db173f3f48a74d5a3fc9210b4e")
-      in
-      clone git   >>= fun () ->
-      clone https >>= fun () ->
-      clone git   ~branch:gh_pages >>= fun () ->
-      clone https ~branch:gh_pages >>= fun () ->
-      clone https ~depth:1 ~branch:commit   >>= fun () ->
-      clone git   ~depth:3 ~branch:gh_pages >>= fun () ->
-      (* clone large ~bare:false  >>= fun () -> *)
-
-      Lwt.return_unit
-    in
-    run x test
-
-  let test_fetch x () =
-    let test_one gri c0 c1 ?(update=false) diff =
-      x.init () >>= fun () ->
-      Store.create ~root () >>= fun t ->
-      Store.list t >>= fun l ->
-      Alcotest.(check (list sha1)) "empty" [] l;
-      let fetch gri (branch, commit) =
-        let b = Reference.of_raw ("refs/heads/" ^ branch) in
-        let c = Hash_IO.of_hex commit in
-        Sync.clone t ~branch:(`Commit (Hash.to_commit c)) ~checkout:false gri
-        >>= fun r ->
-        Store.write_reference t b c >>= fun () ->
-        if x.shell then (
-          let cmd = Printf.sprintf "cd %s && git fsck" @@ Store.root t in
-          Alcotest.(check int) "fsck" 0 (Sys.command cmd)
-        );
-        begin if update then (
-            Store.read_exn t c >>= function
-            | Value.Commit parent ->
-              let parents = [Hash.to_commit c] in
-              let c' = { parent with Commit.message = "foo"; parents } in
-              Store.write t (Value.Commit c') >>= fun k ->
-              Store.write_reference t b k
-            | _ -> assert false
-          ) else
-            Lwt.return_unit
-        end >|= fun () ->
-        Git.Sync.Result.hashes r
-      in
-      fetch gri c0 >>= fun _ ->
-      fetch gri c1 >>= fun r ->
-      Alcotest.(check sha1s) "diff" diff r;
-      Lwt.return_unit
-    in
-    let test () =
-      let git   = Gri.of_string "git://github.com/mirage/irmin-rt.git" in
-      let https = Gri.of_string "https://github.com/mirage/irmin-rt.git" in
-      let c1 = "test-fetch-2", "64beec7402efc772363f4e0a7dfeb0ad2a667367" in
-      let c0 = "test-fetch-1", "348199320dc33614bc5d101b1e0e22eaea25b36b" in
-      let diff  =
-        let x = Hash_IO.of_hex in
-        Hash.Set.of_list [
-          x (snd c1); (* commit *)
-          x "1700d5cbd2ac8f5faf491a3c07c4562f9e43f016"; (* / *)
-          x "2c6368156f499eaee397c5c2d698fabcb1b3114c"; (* overhead/ *)
-          x "54e0af2928da25353fb2a9ecc87530202e940580"; (* overhead/overhead.ml *)
-        ] in
-      test_one git c0 c1 diff   >>= fun () ->
-      test_one https c0 c1 diff >>= fun () ->
-      test_one https ~update:true c0 c1 diff >>= fun () ->
-      Lwt.return_unit
-    in
-    run x test
-
-  let test_leaks x () =
-    let runs =
-      try int_of_string (Sys.getenv "TESTRUNS")
-      with Not_found -> 10_000
-    in
-    let test () =
-      create () >>= fun t ->
-      let rec aux = function
-        | 0 -> Lwt.return_unit
-        | i ->
-          check_write t "v1" kv1 v1 >>= fun () ->
-          check_write t "v2" kv2 v2 >>= fun () ->
-          aux (i-1)
-      in
-      aux runs
-    in
-    run x test
-
 end
-
-let test_read_writes () =
-  Lwt_main.run begin
-    let file = "/tmp/test-git" in
-    let payload = Cstruct.of_string "boo!" in
-    let rec write = function
-      | 0 -> Lwt.return_unit
-      | i -> Git_unix.FS.IO.write_file file payload <&> write (i-1)
-    in
-    let rec read = function
-      | 0 -> Lwt.return_unit
-      | i ->
-        Git_unix.FS.IO.read_file file >>= fun r ->
-        Alcotest.(check string) "concurrent read/write"
-          (Cstruct.to_string payload) (Cstruct.to_string r);
-        read (i-1)
-    in
-    write 1
-    >>= fun () -> Lwt.join [ write 500; read 1000; write 1000; read 500; ]
-  end
 
 module Test_array (D: Hash.DIGEST) = struct
 
@@ -709,22 +481,10 @@ let suite (speed, x) =
     "Operations on commits"     , speed, T.test_commits x;
     "Operations on tags"        , speed, T.test_tags x;
     "Operations on references"  , speed, T.test_refs x;
-    "Operations on index"       , speed, T.test_index x;
     "Operations on pack files"  , speed, T.test_packs x;
     "Search"                    , speed, T.test_search x;
-    "Resource leaks"            , `Slow, T.test_leaks x;
-    "Basic Remote operations"   , `Slow, T.test_basic_remote x;
-    "Fetching remote repos"     , `Slow, T.test_fetch x;
-    "Cloning remote repos"      , `Slow, T.test_clone x;
   ]
 
-let generic = [
-  "OPS"        , ["Concurrent read/writes", `Quick, test_read_writes];
-  "SHA1-unix"  , array (module Git_unix.SHA1);
-  "SHA1-mirage", array (module Git_mirage.SHA1_slow);
-  "SHA256-unix", array (module Git_unix.SHA256);
-]
-
-let run name tl =
+let run name ?(extra=[]) tl =
   verbose ();
-  Alcotest.run name (generic @ List.map suite tl)
+  Alcotest.run name (extra @ List.map suite tl)


### PR DESCRIPTION
Also remove over-specifice realpath/getcwd functions from the signature. This
should be implemented by the unix tools, not by the library.