### PR TITLE
Better windows support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
     EXTRA_REMOTES: "https://github.com/mirage/mirageos-3-beta.git"
     PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
+    ALCOTEST_SHOW_ERRORS: "true"
   matrix:
   - PACKAGE: "git-mirage.dev"
   - PACKAGE: "git-unix.dev"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   global:
     CYG_ROOT: "C:\\cygwin"
     CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
-    TESTS: "false"
     EXTRA_REMOTES: "https://github.com/mirage/mirageos-3-beta.git"
     PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
   matrix:
@@ -15,6 +14,7 @@ environment:
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
   - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core"
+  - curl -L -o C:/cygwin/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/test/test_mirage.ml
+++ b/test/test_mirage.ml
@@ -50,8 +50,9 @@ let mkdir dirname =
 
 let command fmt =
   Printf.ksprintf (fun str ->
-      Printf.printf "[exec] %s\n" str;
-      let _ = Sys.command str in
+      Printf.printf "[exec] %s\n%!" str;
+      let i = Sys.command str in
+      if i <> 0 then Printf.printf "[exec] error %d\n%!" i;
       ()
     ) fmt
 
@@ -72,10 +73,7 @@ module M = struct
 
   let init () =
     rmdir root;
-    mkdir root >>= fun () ->
-    FS_unix.connect root  >>= fun t ->
-    FS_unix.mkdir t "/" >>| fun () ->
-    Lwt.return_unit
+    mkdir root
 
   include FS_unix
 
@@ -87,7 +85,7 @@ module S = FS(M)(SHA1_slow)(Git.Inflate.Make(Zlib))
 
 let suite =
   {
-    name  = "MIRAGE-FS";
+    name  = "MIRAGE";
     init  = M.init;
     clean = unit;
     store = (module S);

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -348,7 +348,8 @@ module Make (Store: Store.S) = struct
   let test_packs x () =
     if x.name = "FS" then
       let test () =
-        files "../test/data/" >>= fun files ->
+        let (/) = Filename.concat in
+        files (".."/"test"/"data") >>= fun files ->
         if files = [] then
           failwith "Please run that test in _build/";
         let files = List.filter (fun file ->


### PR DESCRIPTION
This involves:
- running the tests in the CI
- rewriting the references to be valid windows path (the issue was mentioned by @talex5 but I can't find where anymore)
- fixing the glue scripts to init MirageOS tests (this should probably be moved somewhere else, possibly in `mirage-fs-unix`)