### PR TITLE
Decompress (follow #210)

### DIFF
--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -23,7 +23,6 @@ depends: [
   "alcotest"       {test}
   "mtime"          {test & >= "1.0.0"}
   "mirage-fs-unix" {test & >= "1.3.0"}
-  "camlzip"        {test & >= "1.07"}
   "nocrypto"       {test & >= "0.5.4"}
   "io-page"        {test & >= "1.6.1"}
 ]

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -16,7 +16,6 @@ depends: [
   "logs"
   "git-http" {>= "1.10.0"}
   "conduit"  {>= "0.8.4"}
-  "camlzip"  {>= "1.06"}
   "nocrypto" {>= "0.2.0"}
   "mtime"    {>= "1.0.0"}
   "base-unix"

--- a/git.opam
+++ b/git.opam
@@ -20,7 +20,7 @@ depends: [
   "fmt"
   "hex"
   "astring"
-  "decompress"
+  "decompress" {>= "0.6"}
   "alcotest" {test}
   "nocrypto" {test}
   "mtime"    {test & >= "1.0.0"}

--- a/git.opam
+++ b/git.opam
@@ -20,8 +20,8 @@ depends: [
   "fmt"
   "hex"
   "astring"
+  "decompress"
   "alcotest" {test}
-  "camlzip"  {test}
   "nocrypto" {test}
   "mtime"    {test & >= "1.0.0"}
 ]

--- a/src/git-http/jbuild
+++ b/src/git-http/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name        git_http)
   (public_name git-http)
-  (libraries   (git cohttp uri))))
+  (libraries   (git cohttp uri sexplib))))

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -467,7 +467,7 @@ module IO_FS = struct
 
 end
 
-module Zlib = Git.Inflate.Make(Zlib)
+module Zlib = Git.Inflate.M
 
 module SHA1 = struct
 

--- a/src/git-unix/jbuild
+++ b/src/git-unix/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name        git_unix)
   (public_name git-unix)
-  (libraries   (git conduit.lwt-unix git-http cohttp.lwt camlzip nocrypto))))
+  (libraries   (git conduit.lwt-unix git-http cohttp.lwt nocrypto))))

--- a/src/git/git.mli
+++ b/src/git/git.mli
@@ -432,6 +432,10 @@ module Inflate: sig
   module None: S
   (** No compression. *)
 
+  module M: S
+  (** Default Zlib compression in pure OCaml, provided by
+      [Decompress]. *)
+
   (** Minimaal signature provided by Zlib. *)
   module type ZLIB = sig
     exception Error of string * string

--- a/src/git/inflate.ml
+++ b/src/git/inflate.ml
@@ -33,6 +33,62 @@ module None = struct
 
 end
 
+module M = struct
+
+  open Decompress
+
+  exception Deflate_error of Deflate.error
+
+  let deflate ?(level = 4) data =
+    let input_buffer = Bytes.create 0xFFFF in
+    let output_buffer = Bytes.create 0xFFFF in
+    let pos = ref 0 in
+    let res = Buffer.create (Cstruct.len data) in
+    Deflate.bytes input_buffer output_buffer (fun input_buffer -> function
+        | Some max ->
+          let n = min max (min 0xFFFF (Cstruct.len data - !pos)) in
+          Cstruct.blit_to_string data !pos input_buffer 0 n;
+          pos := !pos + n;
+          n
+        | None ->
+          let n = min 0xFFFF (Cstruct.len data - !pos) in
+          Cstruct.blit_to_string data !pos input_buffer 0 n;
+          pos := !pos + n;
+          n
+      ) (fun output_buffer len ->
+        Buffer.add_subbytes res output_buffer 0 len;
+        0xFFFF)
+      (Deflate.default ~proof:B.proof_bytes level)
+    |> function
+    | Ok _ -> Buffer.contents res |> Cstruct.of_string
+    | Error exn -> raise (Deflate_error exn)
+
+  let inflate ?output_size (data:Mstruct.t) =
+    let data = Mstruct.clone data in
+    let input_buffer = Bytes.create 0xFFFF in
+    let output_buffer = Bytes.create 0xFFFF in
+    let window = Window.create ~proof:B.proof_bytes in
+    let pos = ref 0 in
+    let res = match output_size with
+      | None   -> Buffer.create (Mstruct.length data)
+      | Some n -> Buffer.create n
+    in
+    Inflate.bytes input_buffer output_buffer (fun input_buffer ->
+        let n = min 0xFFFF (Mstruct.length data - !pos) in
+        let i = Mstruct.get_string data n in
+        Bytes.blit i 0 input_buffer 0 n;
+        pos := !pos + n;
+        n
+      ) (fun output_buffer len ->
+        Buffer.add_subbytes res output_buffer 0 len;
+        0xFFFF)
+      (Inflate.default window)
+    |> function
+    | Ok _    -> Some (Mstruct.of_string (Buffer.contents res))
+    | Error _ -> None
+
+end
+
 module type ZLIB = sig
 
   exception Error of string * string

--- a/src/git/inflate.mli
+++ b/src/git/inflate.mli
@@ -20,6 +20,7 @@ module type S = sig
 end
 
 module None: S
+module M: S
 
 module type ZLIB = sig
   exception Error of string * string

--- a/src/git/jbuild
+++ b/src/git/jbuild
@@ -3,4 +3,5 @@
 (library
  ((name        git)
   (public_name git)
-  (libraries   (cstruct fmt lwt mstruct uri ocamlgraph logs astring hex))))
+  (libraries   (cstruct fmt lwt mstruct uri ocamlgraph logs astring hex
+                decompress))))

--- a/test/common/jbuild
+++ b/test/common/jbuild
@@ -3,5 +3,4 @@
 (library
   ((name      test)
    (wrapped   false)
-   (libraries (git mtime mtime.clock.os alcotest nocrypto camlzip lwt.unix
-               logs.fmt))))
+   (libraries (git mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))))

--- a/test/git-mirage/test.ml
+++ b/test/git-mirage/test.ml
@@ -81,7 +81,7 @@ module M = struct
 
 end
 
-module S = FS(M)(SHA1_slow)(Git.Inflate.Make(Zlib))
+module S = FS(M)(SHA1_slow)(Git.Inflate.M)
 
 let suite =
   {

--- a/test/git/test.ml
+++ b/test/git/test.ml
@@ -18,9 +18,9 @@ open Git
 open Lwt.Infix
 open Test_common
 
-(* To avoid depending on git-unix *)
-module Zlib = Git.Inflate.Make(Zlib)
+module Zlib = Git.Inflate.M
 
+(* To avoid depending on git-unix *)
 module SHA1 = struct
 
   let cstruct buf =


### PR DESCRIPTION
Better implementation of `inflate`/`deflate` function. We allocate only one time the needed buffer (`input` and `output`) used to `inflate` __and__ `deflate`.  Because these functions is used in a _stop the world_ context, it's safe to use the same global buffer - otherwise, it's needed to have these buffer per serialization/deserialization contexts (and it's this case in `sirodepac`).