### PR TITLE
Use digestif instead of nocrypto

### DIFF
--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -23,7 +23,6 @@ depends: [
   "alcotest"       {test}
   "mtime"          {test & >= "1.0.0"}
   "mirage-fs-unix" {test & >= "1.3.0"}
-  "nocrypto"       {test & >= "0.5.4"}
   "io-page"        {test & >= "1.6.1"}
 ]
 

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -16,7 +16,6 @@ depends: [
   "logs"
   "git-http" {>= "1.10.0"}
   "conduit"  {>= "0.8.4"}
-  "nocrypto" {>= "0.2.0"}
   "mtime"    {>= "1.0.0"}
   "base-unix"
   "alcotest" {test}

--- a/git.opam
+++ b/git.opam
@@ -21,8 +21,8 @@ depends: [
   "hex"
   "astring"
   "decompress" {>= "0.6"}
+  "digestif"
   "alcotest" {test}
-  "nocrypto" {test}
   "mtime"    {test & >= "1.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -467,40 +467,6 @@ module IO_FS = struct
 
 end
 
-module Zlib = Git.Inflate.M
-
-module SHA1 = struct
-
-  let cstruct buf =
-    buf
-    |> Nocrypto.Hash.SHA1.digest
-    |> Cstruct.to_string
-    |> fun x -> Hash.of_raw x
-
-  let string str =
-    Cstruct.of_string str
-    |> cstruct
-
-  let length = Nocrypto.Hash.SHA1.digest_size
-
-end
-
-module SHA256 = struct
-
-  let cstruct buf =
-    buf
-    |> Nocrypto.Hash.SHA256.digest
-    |> Cstruct.to_string
-    |> fun x -> Hash.of_raw x
-
-  let string str =
-    Cstruct.of_string str
-    |> cstruct
-
-  let length = Nocrypto.Hash.SHA256.digest_size
-
-end
-
 module Make (D: Git.Hash.DIGEST) (I: Git.Inflate.S) = struct
 
   module Sync = struct
@@ -523,7 +489,7 @@ module Make (D: Git.Hash.DIGEST) (I: Git.Inflate.S) = struct
 
 end
 
-module M = Make(SHA1)(Zlib)
+module M = Make(Git.Hash.SHA1)(Git.Inflate.M)
 include M
 
 module type S = sig

--- a/src/git-unix/git_unix.mli
+++ b/src/git-unix/git_unix.mli
@@ -64,15 +64,3 @@ module Make (D: Git.Hash.DIGEST) (I: Git.Inflate.S): S
 (** Parameterize the Git implementation with different inflate and hash
     algorithms. {b Note:} this might cause your implementation to not
     be compatible with Git anymore! *)
-
-module Zlib: Inflate.S
-(** Implementation of the inflate signature using [camlzip]'s zlib
-    bindings. *)
-
-module SHA1: Git.Hash.DIGEST
-(** Implementation of the digest signature using [ocaml-nocrypto]'s
-    Hash1 algorithm. *)
-
-module SHA256: Git.Hash.DIGEST
-(** Implementation of the digest signature using [ocaml-nocrypto]'s
-    Hash256 algorithm. *)

--- a/src/git-unix/jbuild
+++ b/src/git-unix/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name        git_unix)
   (public_name git-unix)
-  (libraries   (git conduit.lwt-unix git-http cohttp.lwt nocrypto))))
+  (libraries   (git conduit.lwt-unix git-http cohttp.lwt))))

--- a/src/git/git.mli
+++ b/src/git/git.mli
@@ -208,6 +208,12 @@ module Hash: sig
     val length: int
   end
 
+  module SHA1: DIGEST
+  (** SHA1 digests. *)
+
+  module SHA256: DIGEST
+  (** SHA256 digests. *)
+
   module IO (D: DIGEST): IO
 
   module Array (D: DIGEST): sig
@@ -1381,7 +1387,7 @@ end
 (** Store Git objects in memory. *)
 module Mem: sig
 
-  module Make (D: Hash.DIGEST) (I: Inflate.S): sig
+  module type S =sig
 
     include Store.S
 
@@ -1393,6 +1399,11 @@ module Mem: sig
     (** Remove all the contents store in memory for all roots. *)
 
   end
+
+  module Make (D: Hash.DIGEST) (I: Inflate.S): S
+
+  include S
+  (** Default Git implementation. *)
 
 end
 

--- a/src/git/hash.ml
+++ b/src/git/hash.ml
@@ -243,3 +243,39 @@ module Array (D: DIGEST) = struct
     aux buf
 
 end
+
+module SHA1 = struct
+
+  let string buf =
+    buf
+    |> Rakia.SHA1.Bytes.digest
+    |> of_raw
+
+  let cstruct buf =
+    buf
+    |> Cstruct.to_bigarray
+    |> Rakia.SHA1.Bigstring.digest
+    |> Rakia.Bi.to_string
+    |> of_raw
+
+  let length = Rakia.SHA1.digest_size
+
+end
+
+module SHA256 = struct
+
+  let string buf =
+    buf
+    |> Rakia.SHA256.Bytes.digest
+    |> of_raw
+
+  let cstruct buf =
+    buf
+    |> Cstruct.to_bigarray
+    |> Rakia.SHA256.Bigstring.digest
+    |> Rakia.Bi.to_string
+    |> of_raw
+
+  let length = Rakia.SHA256.digest_size
+
+end

--- a/src/git/hash.mli
+++ b/src/git/hash.mli
@@ -77,3 +77,6 @@ module Array (D: DIGEST): sig
   val linear_search: Cstruct.t -> t -> int option
   val binary_search: Cstruct.t -> t ->  int option
 end
+
+module SHA1: DIGEST
+module SHA256: DIGEST

--- a/src/git/jbuild
+++ b/src/git/jbuild
@@ -4,4 +4,4 @@
  ((name        git)
   (public_name git)
   (libraries   (cstruct fmt lwt mstruct uri ocamlgraph logs astring hex
-                decompress))))
+                decompress digestif.rakia))))

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -16,6 +16,12 @@
 
 open Lwt.Infix
 
+module type S = sig
+  include Store.S
+  val clear: ?root:string -> unit -> unit
+  val clear_all: unit -> unit
+end
+
 module Log = (val Misc.src_log "memory" : Logs.LOG)
 
 let err_not_found n k =
@@ -226,3 +232,5 @@ module Make (D: Hash.DIGEST) (I: Inflate.S) = struct
   module Digest = D
   module Inflate = I
 end
+
+include Make (Hash.SHA1)(Inflate.M)

--- a/src/git/mem.mli
+++ b/src/git/mem.mli
@@ -14,8 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (D: Hash.DIGEST) (I: Inflate.S): sig
+module type S = sig
   include Store.S
   val clear: ?root:string -> unit -> unit
   val clear_all: unit -> unit
 end
+
+module Make (D: Hash.DIGEST) (I: Inflate.S): S
+include S

--- a/test/common/jbuild
+++ b/test/common/jbuild
@@ -3,4 +3,4 @@
 (library
   ((name      test)
    (wrapped   false)
-   (libraries (git mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))))
+   (libraries (git mtime mtime.clock.os alcotest lwt.unix logs.fmt))))

--- a/test/common/test_store.ml
+++ b/test/common/test_store.ml
@@ -21,12 +21,10 @@ open Astring
 
 (*****************)
 
+let () = Random.self_init ()
+
 let long_random_string () =
-  let t  = Unix.gettimeofday () in
-  let cs = Cstruct.create 8 in
-  Cstruct.BE.set_uint64 cs 0 Int64.(of_float (t *. 1000.)) ;
-  Nocrypto.Rng.reseed cs;
-  Cstruct.to_string (Nocrypto.Rng.generate 1024)
+  Bytes.init 1024 (fun _ -> Char.of_byte (Random.int 255))
 
 module Make (Store: Store.S) = struct
 

--- a/test/git-unix/test.ml
+++ b/test/git-unix/test.ml
@@ -250,44 +250,26 @@ let suite (speed, x) =
   ]
 
 let extra = [
-  "OPS"        , ["Concurrent read/writes", `Quick, test_read_writes];
-  "SHA1-unix"  , Test_store.array (module Git_unix.SHA1);
-  "SHA256-unix", Test_store.array (module Git_unix.SHA256);
+  "OPS", ["Concurrent read/writes", `Quick, test_read_writes];
 ]
-
-module Memory = Git.Mem.Make(Git_unix.SHA1)(Git_unix.Zlib)
-
-let mem_init () =
-  Git.Value.Cache.clear ();
-  Memory.clear_all ();
-  Lwt.return_unit
-
-let mem_suite = {
-  name  = "MEM";
-  init  = mem_init;
-  clean = unit;
-  store = (module Memory);
-  shell = false;
-}
 
 module FS = Git_unix.FS
 
-let fs_init () =
+let init () =
   FS.clear ();
   FS.create ~root () >>= fun t ->
   FS.reset t
 
-let fs_suite =
+let suite =
   {
     name  = "FS";
-    init  = fs_init;
+    init;
     clean = unit;
     store = (module FS);
     shell = true;
   }
 
 let () =
-  Test_store.run ~extra "git" [
-    `Quick, mem_suite;
-    `Quick, fs_suite;
+  Test_store.run ~extra "git-unix" [
+    `Quick, suite;
   ]

--- a/test/git/test.ml
+++ b/test/git/test.ml
@@ -18,41 +18,25 @@ open Git
 open Lwt.Infix
 open Test_common
 
-module Zlib = Git.Inflate.M
-
-(* To avoid depending on git-unix *)
-module SHA1 = struct
-
-  let cstruct buf =
-    buf
-    |> Nocrypto.Hash.SHA1.digest
-    |> Cstruct.to_string
-    |> fun x -> Git.Hash.of_raw x
-
-  let string str =
-    Cstruct.of_string str
-    |> cstruct
-
-  let length = Nocrypto.Hash.SHA1.digest_size
-
-end
-
-module Memory = Git.Mem.Make(SHA1)(Zlib)
-
 let init () =
   Git.Value.Cache.clear ();
-  Memory.clear_all ();
+  Git.Mem.clear_all ();
   Lwt.return_unit
 
 let suite = {
   name  = "MEM";
   init  = init;
   clean = unit;
-  store = (module Memory);
+  store = (module Git.Mem);
   shell = false;
 }
 
+let extra = [
+  "SHA1-unix"  , Test_store.array (module Git.Hash.SHA1);
+  "SHA256-unix", Test_store.array (module Git.Hash.SHA256);
+]
+
 let () =
-  Test_store.run "git" [
+  Test_store.run ~extra "git" [
     `Quick, suite;
   ]


### PR DESCRIPTION
This removes the dependency towards libgmp and give some simple defaults to use
the library (e.g. Git.Mem is a full implementation of the Git protocol).