### PR TITLE
Restore top level index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>index</title><link rel="stylesheet" href="./odoc.css"/><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><meta name="generator" content="doc-ock-html v1.0.0-1-g1fc9bf0"/></head><body><p>
+<table class="indextable">
+<tr><td class="module"><a href="git/Git/index.html">Git</a></td><td>
+Implementation of the Git protocol in pure OCaml
+</td></tr>
+<tr><td class="module"><a href="git-unix/Git_unix/index.html">Git_unix</a></td><td>
+Unix backend.
+</td></tr>
+<tr><td class="module"><a href="git-mirage/Git_mirage/index.html">Git_mirage</a></td><td>
+Mirage backend.
+</td></tr>
+<tr><td class="module"><a href="git-http/Git_http/index.html">Git_http</a></td><td>
+HTTP helpers to implement Git's Smart-HTTP protocol.
+</td></tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
I'm not sure if you have removed this index accidentally or on purpose, but now the link to the API from the README file is broken. Also, "up" navigation from git-unix/index.html and other pages is broken too.

So I've restored a part of the old index file (removed the part that links to the other removed indexes, like modules index, etc..). You may want to add it some style.