### PR TITLE
Update to conduit.1.0 and cohttp.0.99

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.11.2 (2017-08-02)
+
+- Update to conduit.1.0 and cohttp.0.99 (#226, @samoht)
+
 ### 1.11.1 (2017-07-25)
 
 - [git-unix] Fix linking issue of the `ogit` binary on some package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,18 +3,16 @@ platform:
 
 environment:
   global:
-    CYG_ROOT: "C:\\cygwin"
-    CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+    FORK_USER: ocaml
+    FORK_BRANCH: master
+    CYG_ROOT: C:\cygwin64
     PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
-    ALCOTEST_SHOW_ERRORS: "true"
   matrix:
   - PACKAGE: "git-mirage.dev"
   - PACKAGE: "git-unix.dev"
 
 install:
-  - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P make -P git -P perl -P mingw64-x86_64-gcc-core"
-  - curl -L -o C:/cygwin/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))
 
 build_script:
-  - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"
+  - call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\appveyor-opam.sh

--- a/git-http.opam
+++ b/git-http.opam
@@ -10,8 +10,8 @@ doc:          "https://mirage.github.io/ocaml-git/"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
-  "jbuilder" {build}
-  "git"      {>= "1.11.0"}
-  "cohttp"   {>= "0.19.1" & < "0.99.0"}
+  "jbuilder"   {build}
+  "git"        {>= "1.11.0"}
+  "cohttp-lwt" {>= "0.99.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -16,7 +16,7 @@ depends: [
   "mirage-flow-lwt"
   "mirage-channel-lwt"
   "mirage-fs-lwt"
-  "mirage-conduit" {>= "2.3.0" & < "3.0.0"}
+  "mirage-conduit" {>= "3.0.0"}
   "result"
   "git-http" {>= "1.11.0"}
   "git"      {>= "1.11.0"}

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -18,7 +18,8 @@ depends: [
   "cmdliner"
   "logs"
   "git-http" {>= "1.11.0"}
-  "conduit"  {>= "0.8.4" < "1.0.0"}
+  "conduit-lwt-unix" {>= "1.0.0"}
+  "cohttp-lwt-unix"  {>= "0.99.0"}
   "nocrypto" {>= "0.2.0"}
   "mtime"    {>= "1.0.0"}
   "base-unix"

--- a/src/git-http/jbuild
+++ b/src/git-http/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name        git_http)
   (public_name git-http)
-  (libraries   (git cohttp uri sexplib))))
+  (libraries   (git cohttp-lwt uri sexplib))))

--- a/src/git-mirage/jbuild
+++ b/src/git-mirage/jbuild
@@ -4,4 +4,4 @@
  ((name        git_mirage)
   (public_name git-mirage)
   (libraries   (git mirage-flow-lwt mirage-fs-lwt mirage-channel-lwt
-                conduit.mirage mirage-http git-http))))
+                mirage-conduit mirage-http git-http))))

--- a/src/git-unix/jbuild
+++ b/src/git-unix/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name        git_unix)
   (public_name git-unix)
-  (libraries   (git conduit.lwt-unix git-http cohttp.lwt nocrypto))))
+  (libraries   (git conduit-lwt-unix git-http cohttp-lwt-unix nocrypto))))


### PR DESCRIPTION
This needs https://github.com/mirage/ocaml-conduit/pull/232 to link the tests properly