### PR TITLE
add ocplib-endian to dependencies of git (already in opam, missing in jbuild)

### DIFF
--- a/src/git/jbuild
+++ b/src/git/jbuild
@@ -4,4 +4,4 @@
  ((name        git)
   (public_name git)
   (libraries   (cstruct fmt lwt mstruct uri ocamlgraph logs astring hex
-                decompress))))
+                decompress ocplib-endian ocplib-endian.bigstring))))


### PR DESCRIPTION
this used to work since cstruct used to require ocplib-endian, see https://github.com/mirage/ocaml-cstruct/pull/177