### PR TITLE
Remove unnecessary pins in CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. angstrom:https://github.com/dinosaure/angstrom.git#fix-peek-char digestif.dev:https://github.com/mirage/digestif.git#link"
+    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. angstrom:https://github.com/dinosaure/angstrom.git#fix-peek-char"
   matrix:
     - OCAML_VERSION=4.06 PACKAGE="git.dev"
     - OCAML_VERSION=4.04 PACKAGE="git-unix.dev"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     FORK_USER: ocaml
     FORK_BRANCH: master
     CYG_ROOT: C:\cygwin64
-    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. angstrom:https://github.com/dinosaure/angstrom.git#fix-peek-char digestif.dev:https://github.com/mirage/digestif.git#link farfadet.0.2:--dev alcotest"
+    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. angstrom:https://github.com/dinosaure/angstrom.git#fix-peek-char"
   matrix:
   - PACKAGE: "git-mirage.dev"
   - PACKAGE: "git-unix.dev"

--- a/git.opam
+++ b/git.opam
@@ -22,7 +22,7 @@ depends: [
   "farfadet"   {>= "0.2"}
   "faraday"    {>= "0.5.0"}
   "fpath"      {>= "0.7.0"}
-  "digestif"   {>= "0.5.0"}
+  "digestif"   {>= "0.5"}
   "lru"        {>= "0.2.0"}
   "decompress" {>= "0.7"}
   "hex"


### PR DESCRIPTION
The only remaining one (on both Linux and Windows) is `angstrom`.

Note the tests are still failing on Windows, I am planning to investigate these this week.