### PR TITLE
Update to latest cohttp versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
+    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. cohttp-mirage.dev"
   matrix:
     - OCAML_VERSION=4.04 PACKAGE="git-unix.dev"
     - OCAML_VERSION=4.03 PACKAGE="git-unix.dev"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.11.4 (2018-01-03)
+
+- support cohttp 1.0 (#249, @samoht)
+
 ### 1.11.3 (2017-11-20)
 
 - add ocplib-endian to dependencies of git (#233, @hannesm)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     FORK_USER: ocaml
     FORK_BRANCH: master
     CYG_ROOT: C:\cygwin64
-    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
+    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. cohttp-mirage.dev"
   matrix:
   - PACKAGE: "git-mirage.dev"
   - PACKAGE: "git-unix.dev"

--- a/git-http.opam
+++ b/git-http.opam
@@ -12,6 +12,6 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder"   {build}
   "git"        {>= "1.11.0"}
-  "cohttp-lwt" {>= "0.99.0"}
+  "cohttp-lwt" {>= "1.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -12,7 +12,7 @@ build-test: ["jbuilder" "runtest" "test/git-mirage"]
 
 depends: [
   "jbuilder" {build}
-  "cohttp-mirage"
+  "cohttp-mirage" {>= "1.0.1"}
   "mirage-flow-lwt"
   "mirage-channel-lwt"
   "mirage-fs-lwt"

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -12,7 +12,7 @@ build-test: ["jbuilder" "runtest" "test/git-mirage"]
 
 depends: [
   "jbuilder" {build}
-  "mirage-http"
+  "cohttp-mirage"
   "mirage-flow-lwt"
   "mirage-channel-lwt"
   "mirage-fs-lwt"

--- a/src/git-http/git_http.ml
+++ b/src/git-http/git_http.ml
@@ -22,7 +22,7 @@ module Log = struct
 end
 
 module type CLIENT = sig
-  module IO : Cohttp_lwt_s.IO with type 'a t = 'a Lwt.t
+  module IO : Cohttp_lwt.S.IO with type 'a t = 'a Lwt.t
 
   val close_out: IO.oc -> unit                 (* FIXME in cohttp *)
   val close_in: IO.ic -> unit                  (* FIXME in cohttp *)

--- a/src/git-http/git_http.mli
+++ b/src/git-http/git_http.mli
@@ -44,7 +44,7 @@
 *)
 
 module type CLIENT = sig
-  module IO : Cohttp_lwt_s.IO
+  module IO : Cohttp_lwt.S.IO
 
   val close_out: IO.oc -> unit                 (* FIXME in cohttp *)
   val close_in: IO.ic -> unit                  (* FIXME in cohttp *)

--- a/src/git-mirage/git_mirage.ml
+++ b/src/git-mirage/git_mirage.ml
@@ -322,7 +322,7 @@ end
 module Smart_HTTP = struct
 
   module Conduit_channel = Mirage_channel_lwt.Make(Conduit_mirage.Flow)
-  module HTTP_IO = Cohttp_mirage_io.Make(Conduit_channel)
+  module HTTP_IO = Cohttp_mirage.IO(Conduit_channel)
   module Net = struct
     type ctx = { resolver: Resolver_lwt.t; conduit: Conduit_mirage.t; }
     let default_ctx = {

--- a/src/git-mirage/jbuild
+++ b/src/git-mirage/jbuild
@@ -4,4 +4,4 @@
  ((name        git_mirage)
   (public_name git-mirage)
   (libraries   (git mirage-flow-lwt mirage-fs-lwt mirage-channel-lwt
-                mirage-conduit mirage-http git-http))))
+                mirage-conduit cohttp-mirage git-http))))

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -201,7 +201,7 @@ module IO_Sync = struct
 
   module Client = struct
     (* FIXME in cohttp *)
-    module IO = Cohttp_lwt_unix_io
+    module IO = Cohttp_lwt_unix.IO
     let close_in x = Lwt.ignore_result (Lwt_io.close x)
     let close_out x = Lwt.ignore_result (Lwt_io.close x)
   end


### PR DESCRIPTION
This needs https://github.com/mirage/ocaml-cohttp/pull/594 to be merged and released first.