### PR TITLE
Bug to generate a PACK file

### DIFF
--- a/src/git/collector.ml
+++ b/src/git/collector.ml
@@ -47,6 +47,12 @@ module Make (S: STORE) = struct
     include (val Logs.src_log src : Logs.LOG)
   end
 
+  let cstruct_copy cs =
+    let ln = Cstruct.len cs in
+    let rs = Cstruct.create ln in
+    Cstruct.blit cs 0 rs 0 ln;
+    rs
+
   let delta ?(window = `Object 10) ?(depth = 50) git objects =
     let names = Hashtbl.create 1024 in
     let memory, window = match window with `Memory v -> true, v | `Object v -> false, v in
@@ -102,7 +108,7 @@ module Make (S: STORE) = struct
           Log.debug (fun l -> l ~header:"delta" "Ask to try to delta-ify the object %a." S.Hash.pp hash);
 
           Store.read_inflated git hash >|= function
-          | Some (_, raw) -> Some raw
+          | Some (_, raw) -> Some (cstruct_copy raw)
           | None -> None)
       (fun _ -> false)
       window depth

--- a/src/git/revision.ml
+++ b/src/git/revision.ml
@@ -110,7 +110,7 @@ module Make
       match rest with
       | [] -> Lwt.return acc
       | hash :: rest ->
-        if E.exists ((=) hash) close
+        if E.mem hash close
         then walk git close rest to_visit fadd fcompute acc
         else begin
           fcompute hash acc >>= fun acc' ->

--- a/src/git/tree.ml
+++ b/src/git/tree.ml
@@ -43,6 +43,7 @@ sig
   val hashes: t -> Hash.t list
   val to_list: t -> entry list
   val of_list: entry list -> t
+  val iter: (entry -> unit) -> t -> unit
 end
 
 module Make (H: S.HASH with type Digest.buffer = Cstruct.t
@@ -100,6 +101,9 @@ module Make (H: S.HASH with type Digest.buffer = Cstruct.t
     | _ -> raise (Invalid_argument "perm_of_string")
 
   external to_list: t -> entry list = "%identity"
+
+  let iter f tree =
+    List.iter f tree
 
   type value =
     | Contents: string -> value

--- a/src/git/tree.mli
+++ b/src/git/tree.mli
@@ -82,6 +82,7 @@ module type S = sig
 
   val to_list : t -> entry list
   val of_list : entry list -> t
+  val iter: (entry -> unit) -> t -> unit
 end
 
 module Make (H : S.HASH): S with module Hash = H


### PR DESCRIPTION
This PR is a merge of #252 and #253 plus a fix about the PACK file.

Again it's about the ownership of the `Cstruct.t` send to the PACK algorithm. Then, this function take care to not delta-ify multiple times the same object. About the last change, may be it's more useful to expect from the client a `Set` of objects instead a list.