### PR TITLE
Fix push

### DIFF
--- a/src/git/smart.ml
+++ b/src/git/smart.ml
@@ -91,7 +91,7 @@ sig
     | NegociationResult      : negociation_result transaction
     | PACK                   : side_band -> flow transaction
     | ReportStatus           : side_band -> report_status transaction
-    | HttpReportStatus       : side_band -> report_status transaction
+    | HttpReportStatus       : string list * side_band -> report_status transaction
   and ack_mode =
     [ `Ack
     | `Multi_ack
@@ -949,12 +949,14 @@ struct
     ignore @@ p_string "unpack" decoder;
     p_space decoder;
     let msg = p_while1 (fun _ -> true) decoder in
+
     match Cstruct.to_string msg with
     | "ok" -> Ok ()
     | err  -> Error err
 
   let p_command_status decoder : (string, string * string) result =
     let status = p_while1 (function ' ' -> false | _ -> true) decoder in
+
     match Cstruct.to_string status with
     | "ok" ->
       p_space decoder;
@@ -968,59 +970,83 @@ struct
       Error (refname, msg)
     | _ -> raise (Leave (err_unexpected_char '\000' decoder))
 
-  (* XXX(dinosaure): The Smart protocol is a shit. *)
-  let rec p_http_report_status ~pkt ~unpack ~commands ~sideband decoder =
-    let rec go ~pkt k unpack commands decoder = match pkt, unpack, commands with
-      | `Malformed, _, _ -> raise (Leave (err_malformed_pkt_line decoder))
-      | `Flush, Some unpack, Some (_ :: _ as commands) -> k { unpack; commands; } decoder
-      | `Flush, _, _ -> raise (Leave (err_unexpected_flush_pkt_line decoder))
-      | `Empty, _, _ -> raise (Leave (err_unexpected_empty_pkt_line decoder))
-      | `Line _, _, _ ->
+  (* XXX(dinosaure): The Smart protocol is a shit. Le fin mot de
+     l'histoire c'est que comme ils ont eu la flemme de faire un vrai
+     truc, ils ont decide de mettre un PKT dans un PKT pour le fun si on
+     a une sideband. C'est super drole. *)
+  let rec p_http_report_status ~pkt ?unpack ?(commands = []) ~sideband ~references decoder =
+    let go_unpack ~pkt k decoder =
+      match pkt with
+      | `Malformed -> raise (Leave (err_malformed_pkt_line decoder))
+      | `Flush -> raise (Leave (err_unexpected_flush_pkt_line decoder))
+      | `Empty -> raise (Leave (err_unexpected_empty_pkt_line decoder))
+      | `Line _ ->
         match p_peek_char decoder with
         | Some 'u' ->
           let unpack = p_unpack decoder in
-          p_pkt_line (go k (Some unpack) commands) decoder
-        | Some ('o' | 'n') ->
-          let command = p_command_status decoder in
-          let commands = match commands with
-            | Some rest -> Some (command :: rest)
-            | None -> Some [ command ]
-          in
-
-          p_pkt_line (go k unpack commands) decoder
+          k unpack decoder
         | Some chr -> raise (Leave (err_unexpected_char chr decoder))
         | None -> raise (Leave (err_unexpected_end_of_input decoder))
     in
 
-    match pkt, sideband, unpack, commands with
-    | `Malformed, _, _, _ -> raise (Leave (err_malformed_pkt_line decoder))
-    | `Flush, _, Some unpack, Some (_ :: _ as commands) -> p_return { unpack; commands; } decoder
-    | `Flush, _, _, _ -> raise (Leave (err_unexpected_flush_pkt_line decoder))
-    | `Empty, _, _, _ -> raise (Leave (err_unexpected_empty_pkt_line decoder))
-    | `Line _, (`Side_band | `Side_band_64k), unpack, commands ->
+    let go_command ~pkt kcons kfinal decoder =
+      match pkt with
+      | `Malformed -> raise (Leave (err_malformed_pkt_line decoder))
+      | `Flush -> kfinal decoder
+      | `Empty -> raise (Leave (err_unexpected_empty_pkt_line decoder))
+      | `Line _ ->
+        match p_peek_char decoder with
+        | Some ('o' | 'n') ->
+          let command = p_command_status decoder in
+          kcons command decoder
+        | Some chr -> raise (Leave (err_unexpected_char chr decoder))
+        | None -> raise (Leave (err_unexpected_end_of_input decoder))
+    in
+
+    match pkt, sideband, unpack with
+    | `Malformed, _, _ -> raise (Leave (err_malformed_pkt_line decoder))
+    | `Flush, _, _ -> raise (Leave (err_unexpected_flush_pkt_line decoder))
+    | `Empty, _, _ -> raise (Leave (err_unexpected_empty_pkt_line decoder))
+    | `Line _, (`Side_band | `Side_band_64k), unpack ->
       (match p_peek_char decoder with
        | Some '\001' ->
          p_junk_char decoder;
-         let k { unpack; commands; } decoder =
-           p_pkt_line (p_http_report_status ~unpack:(Some unpack) ~commands:(Some commands) ~sideband) decoder in
-         p_pkt_line (go k unpack commands) decoder
+         (match unpack with
+          | None ->
+            let k unpack decoder =
+              p_pkt_line ~strict:true
+                (p_http_report_status ~unpack ~commands:[] ~sideband ~references)
+                decoder in
+            p_pkt_line (go_unpack k) decoder
+          | Some unpack ->
+            let kcons command decoder =
+              p_pkt_line ~strict:true
+                (p_http_report_status ~unpack ~sideband ~commands:(command :: commands) ~references)
+                decoder in
+            let kfinal decoder = p_return { unpack; commands; } decoder in
+            p_pkt_line (go_command kcons kfinal) decoder)
        | Some '\002' ->
          ignore @@ p_while0 (fun _ -> true) decoder;
-         p_pkt_line (p_http_report_status ~unpack ~commands ~sideband) decoder
+         p_pkt_line (p_http_report_status ?unpack ~commands ~sideband ~references) decoder
        | Some '\003' ->
          ignore @@ p_while0 (fun _ -> true) decoder;
-         p_pkt_line (p_http_report_status ~unpack ~commands ~sideband) decoder
+         p_pkt_line (p_http_report_status ?unpack ~commands ~sideband ~references) decoder
        | Some chr ->
          raise (Leave (err_unexpected_char chr decoder))
        | None ->
          raise (Leave (err_unexpected_end_of_input decoder)))
-    | `Line _ as pkt, _, unpack, commands ->
-      let k { unpack; commands; } decoder =
-        p_pkt_line (p_http_report_status ~unpack:(Some unpack) ~commands:(Some commands) ~sideband) decoder in
-      go ~pkt k unpack commands decoder
+    | `Line _ as pkt, _, None ->
+      let k unpack decoder =
+        p_pkt_line ~strict:true (p_http_report_status ~unpack ~sideband ~commands:[] ~references) decoder in
+      go_unpack ~pkt k decoder
+    | `Line _ as pkt, _, Some unpack ->
+      let kcons command decoder =
+        p_pkt_line ~strict:true (p_http_report_status ~unpack ~sideband ~commands:(command :: commands) ~references) decoder in
+      let kfinal decoder = p_return { unpack; commands; } decoder in
+      go_command ~pkt kcons kfinal decoder
 
-  let p_http_report_status sideband decoder =
-    p_pkt_line (p_http_report_status ~unpack:None ~commands:None ~sideband) decoder
+  let p_http_report_status references sideband decoder =
+    p_pkt_line ~strict:true (p_http_report_status ~references ?unpack:None ~commands:[] ~sideband) decoder
 
   let rec p_report_status ~pkt ~unpack ~commands ~sideband decoder =
     let go unpack commands sideband decoder =
@@ -1073,7 +1099,7 @@ struct
     | NegociationResult  : negociation_result transaction
     | PACK               : side_band -> flow transaction
     | ReportStatus       : side_band -> report_status transaction
-    | HttpReportStatus   : side_band -> report_status transaction
+    | HttpReportStatus   : string list * side_band -> report_status transaction
   and ack_mode =
     [ `Ack | `Multi_ack | `Multi_ack_detailed ]
   and flow =
@@ -1091,7 +1117,7 @@ struct
     | NegociationResult              -> p_safe p_negociation_result decoder
     | PACK sideband                  -> p_safe (p_pack ~mode:sideband) decoder
     | ReportStatus sideband          -> p_safe (p_report_status sideband) decoder
-    | HttpReportStatus sideband      -> p_safe (p_http_report_status sideband) decoder
+    | HttpReportStatus (refs, sideband) -> p_safe (p_http_report_status refs sideband) decoder
 
   let decoder () =
     { buffer = Cstruct.create 65535

--- a/src/git/smart.ml
+++ b/src/git/smart.ml
@@ -1502,9 +1502,7 @@ struct
     flush_pack k encoder
 
   let w_http_update_request i k encoder =
-    (w_update_request i
-     @@ w_flush k)
-      encoder
+    w_update_request i k encoder
 
   type action =
     [ `GitProtoRequest   of git_proto_request

--- a/src/git/smart.mli
+++ b/src/git/smart.mli
@@ -226,7 +226,7 @@ sig
     | NegociationResult      : negociation_result transaction
     | PACK                   : side_band -> flow transaction
     | ReportStatus           : side_band -> report_status transaction
-    | HttpReportStatus       : side_band -> report_status transaction
+    | HttpReportStatus       : string list * side_band -> report_status transaction
 
   (** The ACK mode type to describe which mode is shared by the client
       and the server. *)


### PR DESCRIPTION
This code fixed 3 kinds of bugs:
- parsing of the Smart protocol on the HTTP overlay (this patch does not have conflict with the parsing on the TCP overlay)
- check if it's needed or not to update a the server's reference (`push_handler` algorithm) and avoid to send an empty PACK file
- better algorithm to calculate which objects we need to send to the server (an algorithm which color the DAG) and avoid to traverse entirely the repository - see [rev-list](https://github.com/dinosaure/rev-list)

We can start to test this implementation.