### PR TITLE
Weave in the file-system state in every filesystem calls

### DIFF
--- a/src/git-mirage/fs.mli
+++ b/src/git-mirage/fs.mli
@@ -1,12 +1,4 @@
-module type GAMMA = sig
-  val current : Fpath.t
-  val temp    : Fpath.t
+module Make (FS: Mirage_fs_lwt.S): sig
+  include Git.FS
+  val v: ?temp_dir:Fpath.t -> ?current_dir:Fpath.t -> FS.t -> t
 end
-
-module type S = sig
-  include Mirage_fs_lwt.S
-  val connect : unit -> t Lwt.t
-  (* XXX: the constructor should not be there *)
-end
-
-module Make (Gamma: GAMMA) (FS: S): Git.FS

--- a/src/git-mirage/git_mirage.ml
+++ b/src/git-mirage/git_mirage.ml
@@ -2,10 +2,13 @@ module Net = Net
 module SHA1 = Git.Hash.Make(Digestif.SHA1)
 module FS = Fs
 
-module Store (G: FS.GAMMA) (X: FS.S) = struct
-  module F = Fs.Make(G)(X)
+module Store (X: Mirage_fs_lwt.S) = struct
+  module F = Fs.Make(X)
   module S = Git.Store.FS(SHA1)(F)(Git.Inflate)(Git.Deflate)
   include S
+  let create ?temp_dir ?current_dir ?root ?dotgit ?compression ?buffer fs =
+    let fs = F.v ?temp_dir ?current_dir fs in
+    create ?root ?dotgit ?compression ?buffer fs
 end
 
 module Sync (C: Net.CONDUIT) = Git.Sync.Make(Net.Make(C))

--- a/src/git-mirage/git_mirage.mli
+++ b/src/git-mirage/git_mirage.mli
@@ -6,4 +6,14 @@ module Sync (C: Net.CONDUIT) (S: Git.S): Git.Sync.S
   with module Store = S
    and module Net = Net.Make(C)
 
-module Store (G: FS.GAMMA) (X: FS.S): Git.Store.S with module Hash = SHA1
+module Store (X: Mirage_fs_lwt.S): sig
+  include Git.Store.S with module Hash = SHA1
+  val create:
+    ?temp_dir:Fpath.t ->
+    ?current_dir:Fpath.t ->
+    ?root:Fpath.t ->
+    ?dotgit:Fpath.t ->
+    ?compression:int ->
+    ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
+    X.t -> (t, error) result Lwt.t
+end

--- a/src/git-unix/fs.mli
+++ b/src/git-unix/fs.mli
@@ -1,1 +1,3 @@
 include Git.FS
+
+val v: ?temp_dir:Fpath.t -> unit -> t

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -18,4 +18,9 @@ module SHA1 = Git.Hash.Make(Digestif.SHA1)
 module Sync = Git.Sync.Make(Net)
 module HTTP = Http.Make
 
-module FS = Git.Store.FS(SHA1)(Fs)(Git.Inflate)(Git.Deflate)
+module FS = struct
+  include Git.Store.FS(SHA1)(Fs)(Git.Inflate)(Git.Deflate)
+  let create ?temp_dir ?root ?dotgit ?compression ?buffer () =
+    let fs = Fs.v ?temp_dir () in
+    create ?root ?dotgit ?compression ?buffer fs
+end

--- a/src/git-unix/git_unix.mli
+++ b/src/git-unix/git_unix.mli
@@ -19,9 +19,16 @@
 module SHA1:  Git.HASH
 module Net = Net
 
-module FS : Git.Store.S
-  with module Hash = SHA1
-   and module FS = Fs
+module FS: sig
+  include Git.Store.S with module Hash = SHA1
+  val create:
+    ?temp_dir:Fpath.t ->
+    ?root:Fpath.t ->
+    ?dotgit:Fpath.t ->
+    ?compression:int ->
+    ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
+    unit -> (t, error) result Lwt.t
+end
 
 module Sync (S: Git.S): Git.Sync.S with module Store = S and module Net = Net
 module HTTP (S: Git.S): Git_http.Sync.S with module Store = S

--- a/src/git/helper.mli
+++ b/src/git/helper.mli
@@ -132,15 +132,15 @@ module Encoder (E: ENCODER) (FS: S.FS): sig
     [ `Encoder of E.error
     | FS.error Error.FS.t ]
 
-  (** [to_file f tmp state] encodes [state] in the file [f] using
+  (** [to_file t f tmp state] encodes [state] in the file [f] using
       [tmp] as an intermediary buffer.
 
       The result is [Error `Stack] if at least [limit] writes have
       returned 0.
 
       If [atomic] is set, the operation is guaranteed to be atomic. *)
-  val to_file: ?limit:int -> ?atomic:bool -> Fpath.t -> Cstruct.t -> E.state ->
-    (E.result, error) result Lwt.t
+  val to_file: ?limit:int -> ?atomic:bool -> FS.t -> Fpath.t -> Cstruct.t ->
+    E.state -> (E.result, error) result Lwt.t
 
 end
 
@@ -148,17 +148,17 @@ module FS (FS: S.FS): sig
 
   include (module type of struct include FS end)
 
-  val with_open_r: Fpath.t ->
+  val with_open_r: FS.t -> Fpath.t ->
     ([ `Read ] FS.File.fd ->
      ('a, [> `Open of Fpath.t * FS.error
           | `Move of Fpath.t * Fpath.t * FS.error ] as 'e) result Lwt.t) ->
     ('a, 'e) result Lwt.t
-  (** [with_open_r p f] opens the file [p] in read-only mode and calls
-      [f] on the resulting file-descriptor. When [f] completes, the
-      file-descriptor is closed. Failure to close that file-descriptor
-      is ignored. *)
+  (** [with_open_r t p f] opens the file [p] in the file-system
+      [t] with read-only mode and calls [f] on the resulting
+      file-descriptor. When [f] completes, the file-descriptor is
+      closed. Failure to close that file-descriptor is ignored. *)
 
-  val with_open_w: ?atomic:bool -> Fpath.t ->
+  val with_open_w: ?atomic:bool -> FS.t -> Fpath.t ->
     ([ `Write ] FS.File.fd ->
      ('a, [> `Open of Fpath.t * FS.error
           | `Move of Fpath.t * Fpath.t * FS.error ] as 'e) result Lwt.t) ->

--- a/src/git/index.ml
+++ b/src/git/index.ml
@@ -1093,9 +1093,9 @@ module Make (H: S.HASH) (FS: S.FS) = struct
     | `IndexDecoder err -> Fmt.pf ppf "(`IndexDecoder %a)" IndexDecoder.pp_error err
     | `FS err           -> Fmt.pf ppf "(`FS %a)" FS.pp_error err
 
-  let load ~root ~dtmp =
+  let load fs ~root ~dtmp =
     let open Lwt.Infix in
-    FS.with_open_r Fpath.(root / "index") @@ fun read ->
+    FS.with_open_r fs Fpath.(root / "index") @@ fun read ->
     let decoder = IndexDecoder.default in
     let rec loop decoder = match IndexDecoder.eval dtmp decoder with
       | `Error (_, err)             -> Lwt.return (Error (`IndexDecoder err))

--- a/src/git/mem.mli
+++ b/src/git/mem.mli
@@ -35,14 +35,8 @@
     back-end).
 *)
 
-module Make
-    (H: S.HASH)
-    (I: S.INFLATE)
-    (D: S.DEFLATE)
-  : Minimal.S
-    with module Hash = H
-     and module Inflate = I
-     and module Deflate = D
+module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE): sig
+
 (** The {i functor} needs 4 modules:
 
     {ul
@@ -61,7 +55,33 @@ module Make
     understand the Deflate module. For example, use [zlib] to inflate
     and [brotli] to deflate does not work. *)
 
-module Store (H : Digestif_sig.S):
-  Minimal.S with module Hash    = Hash.Make(H)
-             and module Inflate = Inflate
-             and module Deflate = Deflate
+  include Minimal.S with module Hash = H
+                     and module Inflate = I
+                     and module Deflate = D
+
+  val create:
+    ?root:Fpath.t ->
+    ?dotgit:Fpath.t ->
+    ?compression:int ->
+    ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
+    unit -> (t, error) result Lwt.t
+  (** [create ?root ?dotgit ?compression ()] creates a new store
+      represented by the path [root] (default is ["."]), where the Git
+      objects are located in [dotgit] (default is [root / ".git"] and
+      when Git objects are compressed by the [level] (default is
+      [4]). *)
+
+end
+
+module Store (H : Digestif_sig.S): sig
+  include Minimal.S with module Hash    = Hash.Make(H)
+                     and module Inflate = Inflate
+                     and module Deflate = Deflate
+
+  val create:
+    ?root:Fpath.t ->
+    ?dotgit:Fpath.t ->
+    ?compression:int ->
+    ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
+    unit -> (t, error) result Lwt.t
+end

--- a/src/git/minimal.ml
+++ b/src/git/minimal.ml
@@ -38,16 +38,6 @@ module type S = sig
     ?window:Inflate.window ->
     unit -> buffer
 
-  val create: ?root:Fpath.t ->
-    ?dotgit:Fpath.t ->
-    ?compression:int ->
-    ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
-    unit -> (t, error) result Lwt.t
-  (** [create ?root ?dotgit ?compression ()] creates a new store
-      represented by the path [root] (default is ["."]), where the Git
-      objects are located in [dotgit] (default is [root / ".git"] and when
-      Git objects are compressed by the [level] (default is [4]). *)
-
   val dotgit: t -> Fpath.t
   (** [dotgit state] returns the current [".git"] path used - eg. the
       default [?dotgit] value of {!create} if the client does not

--- a/src/git/reference.mli
+++ b/src/git/reference.mli
@@ -191,33 +191,32 @@ module type IO = sig
   val pp_error: error Fmt.t
   (** Pretty-printer of {!error}. *)
 
-  val mem: root:Fpath.t -> t -> bool Lwt.t
-  (** [mem ~root reference] returns [true] iff we found the
-      [reference] find in the git repository [root]. Otherwise, we returns
-      [false]. *)
+  val mem: fs:FS.t -> root:Fpath.t -> t -> bool Lwt.t
+  (** [mem ~fs ~root reference] is [true] iff [reference] can be found
+      in the git repository [root]. Otherwise, it is [false]. *)
 
-  val read: root:Fpath.t -> t -> dtmp:Cstruct.t -> raw:Cstruct.t ->
+  val read: fs:FS.t -> root:Fpath.t -> t -> dtmp:Cstruct.t -> raw:Cstruct.t ->
     ((t * head_contents), error) result Lwt.t
-  (** [read ~root reference dtmp raw] returns the value contains in
-      the reference [reference] (available in the git repository
+  (** [read ~fs ~root reference dtmp raw] is the value of the
+      reference [reference] (available in the git repository
       [root]). [dtmp] and [raw] are buffers used by the decoder
       (respectively for the decoder as an internal buffer and the
       input buffer).
 
       This function can returns an {!error}. *)
 
-  val write: root:Fpath.t -> ?capacity:int -> raw:Cstruct.t ->
+  val write: fs:FS.t -> root:Fpath.t -> ?capacity:int -> raw:Cstruct.t ->
     t -> head_contents -> (unit, error) result Lwt.t
-  (** [write ~root ~raw reference value] writes the value [value] in
-      the mutable representation of the [reference] in the git
+  (** [write ~fs ~root ~raw reference value] writes the value [value]
+      in the mutable representation of the [reference] in the git
       repository [root]. [raw] is a buffer used by the decoder to keep
       the input.
 
       This function can returns an {!error}. *)
 
-  val remove: root:Fpath.t -> t -> (unit, error) result Lwt.t
-  (** [remove ~root reference] removes the reference from the
-      git repository [root].
+  val remove: fs:FS.t -> root:Fpath.t -> t -> (unit, error) result Lwt.t
+  (** [remove ~root reference] removes the reference from the git
+      repository [root].
 
       This function can returns an {!error}. *)
 end

--- a/test/common/test_sync.ml
+++ b/test/common/test_sync.ml
@@ -19,7 +19,7 @@ open Lwt.Infix
 
 module type SYNC = sig
   (* common ground between Sync and Http.Sync *)
-  module Store: Git.S
+  module Store: Test_store.S
   type error
   val pp_error: error Fmt.t
   val clone: Store.t -> reference:Store.Reference.t -> Uri.t ->
@@ -74,7 +74,7 @@ module Make (Sync: SYNC) = struct
   let test_clone name uris =
     let test uri reference =
       let uri = Uri.of_string uri in
-      Store.create ~root () >>= T.init_err >>= fun t ->
+      Store.create root >>= T.check_err >>= fun t ->
       Sync.clone t ~reference uri >>= fun _ ->
       Store.list t >>=
       Lwt_list.iter_s (fun hash -> Store.read_exn t hash >|= fun _ -> ())

--- a/test/git-unix/test.ml
+++ b/test/git-unix/test.ml
@@ -17,9 +17,9 @@
 
 open Test_common
 
-module TCP (Store: Git.S) = Test_sync.Make(struct
-    module M = Git_unix.Sync(Store)
-    module Store = M.Store
+module TCP (S: Test_store.S) = Test_sync.Make(struct
+    module M = Git_unix.Sync(S)
+    module Store = S
     type error = M.error
     let pp_error = M.pp_error
     let clone t ~reference uri = M.clone t ~reference:(reference, reference) uri
@@ -37,9 +37,9 @@ module TCP (Store: Git.S) = Test_sync.Make(struct
 (* XXX(dinosaure): the divergence between the TCP API and the HTTP API
    will be update for an homogenization. *)
 
-module HTTP (Store: Git.S) = Test_sync.Make(struct
+module HTTP (Store: Test_store.S) = Test_sync.Make(struct
     module M = Git_unix.HTTP(Store)
-    module Store = M.Store
+    module Store = Store
     type error = M.error
     let pp_error = M.pp_error
     let clone t ~reference uri = M.clone t ~reference:(reference, reference) uri
@@ -57,9 +57,9 @@ module HTTP (Store: Git.S) = Test_sync.Make(struct
         uri
   end)
 
-module HTTPS (Store: Git.S) = Test_sync.Make(struct
+module HTTPS (Store: Test_store.S) = Test_sync.Make(struct
     module M = Git_unix.HTTP(Store)
-    module Store = M.Store
+    module Store = Store
     type error = M.error
     let pp_error = M.pp_error
     let clone t ~reference uri = M.clone t ~reference:(reference, reference) uri
@@ -77,8 +77,15 @@ module HTTPS (Store: Git.S) = Test_sync.Make(struct
         uri
   end)
 
-module MemStore = Git.Mem.Store(Digestif.SHA1)
-module FsStore = Git_unix.FS
+module MemStore = struct
+  include Git.Mem.Store(Digestif.SHA1)
+  let create root = create ~root ()
+end
+
+module FsStore = struct
+  include Git_unix.FS
+  let create root = create ~root ()
+end
 
 module TCP1  = TCP(MemStore)
 module TCP2  = TCP(FsStore)

--- a/test/git/test.ml
+++ b/test/git/test.ml
@@ -16,7 +16,10 @@
 
 open Test_common
 
-module Store = Git.Mem.Store(Digestif.SHA1)
+module Store = struct
+  include Git.Mem.Store(Digestif.SHA1)
+  let create root = create ~root ()
+end
 
 let () =
   verbose ();


### PR DESCRIPTION
This allows to remove the 'GAMMA' functor parameter and to cleanup the
`create/connect` functions. Now the main store signatures do not define a
creator anymore, only the implementation do and they can take different
parameters (e.g. the typical MirageOS style).