### PR TITLE
Abstract file-system

### DIFF
--- a/src/git/helper.ml
+++ b/src/git/helper.ml
@@ -559,17 +559,16 @@ module type ENCODER = sig
   val flush: int -> int -> state -> state
 end
 
-module type DECODER =
-sig
-  type state
+module type DECODER = sig
+  type decoder
   type error
   type t
-  val eval: state ->
-    [ `Await of state
+  val eval: decoder ->
+    [ `Await of decoder
     | `End of (Cstruct.t * t)
     | `Error of (Cstruct.t * error) ]
-  val refill: Cstruct.t -> state -> (state, error) result
-  val finish: state -> state
+  val refill: Cstruct.t -> decoder -> (decoder, error) result
+  val finish: decoder -> decoder
 end
 
 (* XXX(dinosaure): this function takes care about how many byte(s) we

--- a/src/git/helper.mli
+++ b/src/git/helper.mli
@@ -133,18 +133,17 @@ sig
   val flush: int -> int -> state -> state
 end
 
-module type DECODER =
-sig
-  type state
+module type DECODER = sig
+  type decoder
   type error
   type t
 
-  val eval: state ->
-    [ `Await of state
+  val eval: decoder ->
+    [ `Await of decoder
     | `End of (Cstruct.t * t)
     | `Error of (Cstruct.t * error) ]
-  val refill: Cstruct.t -> state -> (state, error) result
-  val finish: state -> state
+  val refill: Cstruct.t -> decoder -> (decoder, error) result
+  val finish: decoder -> decoder
 end
 
 module Decoder (D: DECODER) (FS: S.FS): sig
@@ -156,7 +155,7 @@ module Decoder (D: DECODER) (FS: S.FS): sig
 
   (** [of_file t f tmp state] decodes from the file [f] a value using [state]
      and [tmp] as intermediary buffer. *)
-  val of_file: FS.t -> Fpath.t -> Cstruct.t -> D.state -> (D.t, error) result Lwt.t
+  val of_file: FS.t -> Fpath.t -> Cstruct.t -> D.decoder -> (D.t, error) result Lwt.t
 end
 
 module Encoder (E: ENCODER) (FS: S.FS): sig

--- a/src/git/loose.ml
+++ b/src/git/loose.ml
@@ -199,11 +199,11 @@ module Make
           | Error _ -> acc)
         [] firsts
 
-  type ('result, 'state) decoder =
-    (module Helper.DECODER with type t = 'result
-                            and type state = 'state
-                            and type error = [ Error.Decoder.t
-                                             | `Inflate of Inflate.error ] )
+  type ('result, 'decoder) decoder =
+    (module Helper.DECODER
+            with type t = 'result
+             and type decoder = 'decoder
+             and type error = [ Error.Decoder.t | `Inflate of Inflate.error ] )
 
   let gen (type state) (type result) ~fs ~root (state:state) ~raw (decoder : (result, state) decoder) hash =
     let module D = (val decoder) in
@@ -221,15 +221,6 @@ module Make
 
   let read ~fs ~root ~window ~ztmp ~dtmp ~raw hash =
     let state = D.default (window, ztmp, dtmp) in
-    let module D = struct
-        type state = D.decoder
-        type error = D.error
-        type t = D.t
-
-        let eval = D.eval
-        let refill = D.refill
-        let finish = D.finish
-      end in
     gen ~fs ~root state ~raw (module D) hash
 
   module HeaderAndBody = struct
@@ -285,15 +276,6 @@ module Make
 
   let inflate ~fs ~root ~window ~ztmp ~dtmp ~raw hash =
     let state = I.default (window, ztmp, dtmp) in
-    let module I = struct
-        type state = I.decoder
-        type error = I.error
-        type t = I.t
-
-        let eval = I.eval
-        let refill = I.refill
-        let finish = I.finish
-      end in
     gen ~fs ~root state ~raw (module I) hash
 
   let inflate_wa ~fs ~root ~window ~ztmp ~dtmp ~raw ~result hash =
@@ -302,15 +284,6 @@ module Make
         let p = decoder ~result:(Some result)
       end) in
     let state = P.default (window, ztmp, dtmp) in
-    let module P = struct
-        type state = P.decoder
-        type error = P.error
-        type t = P.t
-
-        let eval = P.eval
-        let refill = P.refill
-        let finish = P.finish
-      end in
     gen ~fs ~root state ~raw (module P) hash
 
   module HeaderOnly = struct
@@ -330,15 +303,6 @@ module Make
 
   let size ~fs ~root ~window ~ztmp ~dtmp ~raw hash =
     let state = S.default (window, ztmp, dtmp) in
-    let module S = struct
-        type state = S.decoder
-        type error = S.error
-        type t = S.t
-
-        let eval = S.eval
-        let refill = S.refill
-        let finish = S.finish
-      end in
     gen ~fs ~root state ~raw (module S) hash >|= function
     | Ok (_, v) -> Ok v
     | Error _ as err -> err

--- a/src/git/loose.ml
+++ b/src/git/loose.ml
@@ -211,13 +211,11 @@ module Make
     let first, rest = explode hash in
     let file        = Fpath.(root / "objects" / first / rest) in
     Log.debug (fun l -> l "Reading the loose object %a." Fpath.pp file);
-    Decoder.of_file fs file raw state >>= function
-    | Ok v -> Lwt.return (Ok v)
-    | Error (`Decoder (#Error.Decoder.t as err)) ->
-       Lwt.return Error.(v @@ Error.Decoder.with_path file err)
-    | Error (`Decoder (`Inflate _ as err)) ->
-       Lwt.return Error.(v @@ Inf.with_path file err)
-    | Error #fs_error as err -> Lwt.return err
+    Decoder.of_file fs file raw state >|= function
+    | Ok _ as v -> v
+    | Error (`Decoder (#Error.Decoder.t as err)) -> Error.(v @@ Error.Decoder.with_path file err)
+    | Error (`Decoder (`Inflate _ as err)) -> Error.(v @@ Inf.with_path file err)
+    | Error #fs_error as err -> err
 
   let read ~fs ~root ~window ~ztmp ~dtmp ~raw hash =
     let state = D.default (window, ztmp, dtmp) in

--- a/src/git/packed_refs.ml
+++ b/src/git/packed_refs.ml
@@ -155,20 +155,7 @@ module Make (H: S.HASH) (FS: S.FS) = struct
 
   open Lwt.Infix
 
-  module Decoder =
-    struct
-      module D =
-        struct
-          type state = D.decoder
-          type error = D.error
-          type t = D.t
-
-          let eval = D.eval
-          let refill = D.refill
-          let finish = D.finish
-        end
-      include Helper.Decoder(D)(FS)
-    end
+  module Decoder = Helper.Decoder(D)(FS)
 
   let read ~fs ~root ~dtmp ~raw =
     let state = D.default dtmp in

--- a/src/git/packed_refs.ml
+++ b/src/git/packed_refs.ml
@@ -155,25 +155,30 @@ module Make (H: S.HASH) (FS: S.FS) = struct
 
   open Lwt.Infix
 
+  module Decoder =
+    struct
+      module D =
+        struct
+          type state = D.decoder
+          type error = D.error
+          type t = D.t
+
+          let eval = D.eval
+          let refill = D.refill
+          let finish = D.finish
+        end
+      include Helper.Decoder(D)(FS)
+    end
+
   let read ~fs ~root ~dtmp ~raw =
-    let decoder = D.default dtmp in
-    let path = Fpath.(root / "packed-refs") in
-    FS.with_open_r fs path @@ fun read ->
-    let rec loop decoder = match D.eval decoder with
-      | `End (_, value)               -> Lwt.return (Ok value)
-      | `Error (_, (#Error.Decoder.t as err)) ->
-        Lwt.return Error.(v @@ Error.Decoder.with_path path err)
-      | `Await decoder ->
-        FS.File.read raw read >>= function
-        | Error err -> Lwt.return Error.(v @@ Error.FS.err_read path err)
-        | Ok 0      -> loop (D.finish decoder)
-        | Ok n      ->
-          match D.refill (Cstruct.sub raw 0 n) decoder with
-          | Ok decoder              -> loop decoder
-          | Error (#Error.Decoder.t as err) ->
-            Lwt.return Error.(v @@ Error.Decoder.with_path path err)
-    in
-    loop decoder
+    let state = D.default dtmp in
+    let file  = Fpath.(root / "packed-refs") in
+    Decoder.of_file fs file raw state >>= function
+    | Ok v -> Lwt.return (Ok v)
+    | Error (`Decoder (#Error.Decoder.t as err)) ->
+       Lwt.return Error.(v @@ Error.Decoder.with_path file err)
+    | Error #fs_error as err ->
+       Lwt.return err
 
   module Encoder = struct
     module E = struct

--- a/src/git/packed_refs.ml
+++ b/src/git/packed_refs.ml
@@ -160,12 +160,10 @@ module Make (H: S.HASH) (FS: S.FS) = struct
   let read ~fs ~root ~dtmp ~raw =
     let state = D.default dtmp in
     let file  = Fpath.(root / "packed-refs") in
-    Decoder.of_file fs file raw state >>= function
-    | Ok v -> Lwt.return (Ok v)
-    | Error (`Decoder (#Error.Decoder.t as err)) ->
-       Lwt.return Error.(v @@ Error.Decoder.with_path file err)
-    | Error #fs_error as err ->
-       Lwt.return err
+    Decoder.of_file fs file raw state >|= function
+    | Ok _ as v -> v
+    | Error (`Decoder err) -> Error.(v @@ Error.Decoder.with_path file err)
+    | Error #fs_error as err -> err
 
   module Encoder = struct
     module E = struct

--- a/src/git/reference.ml
+++ b/src/git/reference.ml
@@ -307,11 +307,10 @@ module IO (Hash: S.HASH) (FS: S.FS) = struct
   let read ~fs ~root reference ~dtmp ~raw : (_, error) result Lwt.t =
     let state = D.default dtmp in
     let file  = Fpath.(root // (to_path reference)) in
-    Decoder.of_file fs file raw state >>= function
-    | Ok v -> Lwt.return (Ok (normalize file, v))
-    | Error (`Decoder (#Error.Decoder.t as err)) ->
-       Lwt.return Error.(v @@ Error.Decoder.with_path file err)
-    | Error #fs_error as err -> Lwt.return err
+    Decoder.of_file fs file raw state >|= function
+    | Ok v -> (Ok (normalize file, v))
+    | Error (`Decoder err) -> Error.(v @@ Error.Decoder.with_path file err)
+    | Error #fs_error as err -> err
 
   let write ~fs ~root ?(capacity = 0x100) ~raw reference value =
     let state = E.default (capacity, value) in

--- a/src/git/reference.ml
+++ b/src/git/reference.ml
@@ -272,6 +272,19 @@ module IO (Hash: S.HASH) (FS: S.FS) = struct
     include Helper.Encoder(E)(FS)
   end
 
+  module Decoder = struct
+    module D = struct
+      type state = D.decoder
+      type error = D.error
+      type t = D.t
+
+      let eval = D.eval
+      let refill = D.refill
+      let finish = D.finish
+    end
+    include Helper.Decoder(D)(FS)
+  end
+
   type fs_error = FS.error Error.FS.t
   type error =
     [ Error.Decoder.t
@@ -303,34 +316,13 @@ module IO (Hash: S.HASH) (FS: S.FS) = struct
     | Error _ -> false
 
   let read ~fs ~root reference ~dtmp ~raw : (_, error) result Lwt.t =
-    let decoder = D.default dtmp in
-    let path = Fpath.(root // (to_path reference)) in
-    Log.debug (fun l -> l "Reading the reference: %a." Fpath.pp path);
-    FS.with_open_r fs path @@ fun read ->
-    let rec loop decoder = match D.eval decoder with
-      | `End (_, value) -> Lwt.return (Ok value)
-      | `Error (_, (#Error.Decoder.t as err)) ->
-        Lwt.return Error.(v @@ Decoder.with_path path err)
-      | `Await decoder ->
-        FS.File.read raw read >>= function
-        | Error err -> Lwt.return Error.(v @@ FS.err_read path err)
-        | Ok 0 -> loop (D.finish decoder)
-        (* XXX(dinosaure): in this case, we read a file, so when we
-           retrieve 0 bytes, that means we get end of the file. We
-           can finish the deserialization. *)
-        | Ok n -> match D.refill (Cstruct.sub raw 0 n) decoder with
-          | Ok decoder -> loop decoder
-          | Error (#Error.Decoder.t as err) ->
-            Lwt.return Error.(v @@ Decoder.with_path path err)
-    in
-    loop decoder >|= function
-    | Error _ as e     -> e
-    | Ok head_contents ->
-      let reference' = normalize path in
-      Log.debug (fun l ->
-          l "Normalize reference %a = %a." pp reference pp reference');
-      assert (equal reference reference');
-      Ok (normalize path, head_contents)
+    let state = D.default dtmp in
+    let file  = Fpath.(root // (to_path reference)) in
+    Decoder.of_file fs file raw state >>= function
+    | Ok v -> Lwt.return (Ok (normalize file, v))
+    | Error (`Decoder (#Error.Decoder.t as err)) ->
+       Lwt.return Error.(v @@ Error.Decoder.with_path file err)
+    | Error #fs_error as err -> Lwt.return err
 
   let write ~fs ~root ?(capacity = 0x100) ~raw reference value =
     let state = E.default (capacity, value) in

--- a/src/git/reference.ml
+++ b/src/git/reference.ml
@@ -272,18 +272,7 @@ module IO (Hash: S.HASH) (FS: S.FS) = struct
     include Helper.Encoder(E)(FS)
   end
 
-  module Decoder = struct
-    module D = struct
-      type state = D.decoder
-      type error = D.error
-      type t = D.t
-
-      let eval = D.eval
-      let refill = D.refill
-      let finish = D.finish
-    end
-    include Helper.Decoder(D)(FS)
-  end
+  module Decoder = Helper.Decoder(D)(FS)
 
   type fs_error = FS.error Error.FS.t
   type error =


### PR DESCRIPTION
This PR is a step to abstract step by step file-system and limit POSIX syscall on the git core library. Currently, the status is to use `to_file` and `of_file` which use a subset of POSIX syscall (and can be easily translated to another back-end like [wodan](https://github.com/g2p/wodan)) to load or store a Git object (loose or reference) from a file-system.

However, this abstraction is provided by the `Helper` module which stills on the Git core library.

Then, pack-engine stills to use POSIX syscall in only one place (`Pack_engine`) to do a first pass but an update of the pack-engine is out of the scope of this PR - and compatibility between `wodan` and the pack-engine stills an open question.