### PR TITLE
Fix test-and-set for packed references

### DIFF
--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
 
 build: ["jbuilder" "build" "-p" name "-j" jobs]
-build-test: ["jbuilder" "runtest" "test/git-mirage"]
+build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "jbuilder" {build}

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -24,7 +24,7 @@ depends: [
   "mtime"          {test & >= "1.0.0"}
   "mirage-fs-unix" {test & >= "1.3.0"}
   "nocrypto"       {test & >= "0.5.4"}
-  "io-page"        {test & >= "1.6.1"}
+  "io-page-unix"   {test & >= "2.0.0"}
 ]
 
 available: [ocaml-version >= "4.02.3"]

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -11,7 +11,7 @@ build: [
   ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-build-test: ["jbuilder" "runtest" "test/git-unix"]
+build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "jbuilder" {build}

--- a/git.opam
+++ b/git.opam
@@ -11,7 +11,7 @@ build: [
   ["jbuilder" "subst" "-n" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
-build-test: ["jbuilder" "build" "test/git"]
+build-test: ["jbuilder" "build" "-p" name]
 
 depends: [
   "jbuilder"   {build}

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -448,12 +448,24 @@ module IO_FS = struct
           )
       )
 
+  let trim s =
+    let len = Cstruct.len s in
+    if len >= 2
+    && Cstruct.get_char s (len - 1) = '\n'
+    && Cstruct.get_char s (len - 2) = '\r'
+    then
+      Cstruct.sub s 0 (len - 2)
+    else if len >= 1 && Cstruct.get_char s (len - 1) = '\n' then
+      Cstruct.sub s 0 (len - 1)
+    else
+      s
+
   let test_and_set_file ?temp_dir ~lock file ~test ~set =
     Lock.with_lock (Some lock) (fun () ->
         read_file file >>= fun v ->
         let equal = match test, v with
           | None  , None   -> true
-          | Some x, Some y -> Cstruct.equal x y
+          | Some x, Some y -> Cstruct.equal (trim x) (trim y)
           | _ -> false
         in
         if not equal then Lwt.return false

--- a/src/git/git.mli
+++ b/src/git/git.mli
@@ -1123,11 +1123,16 @@ module Store: sig
     (** Write a reference. *)
 
     val remove_reference: t -> Reference.t -> unit Lwt.t
-    (** Remove a refernce. *)
+    (** Remove a reference. Note: packed references cannot be removed
+       (and no error will be raised) so assume that [remove_reference
+       r] is unsafe as it could either delete [r], do nothing, or
+       revert [r] to a previous (packed) value. *)
 
     val test_and_set_reference: t -> Reference.t ->
       test:Hash.t option -> set:Hash.t option -> bool Lwt.t
-    (** Atomic updates (Test and set) for references. *)
+    (** Atomic updates (Test and set) for references. Note: when [set]
+       is [None], [test_and_set_reference] should be considered
+       unsafe. See {!remove_reference} for details. *)
 
     (** {1 Git index files} *)
 

--- a/src/git/packed_refs.ml
+++ b/src/git/packed_refs.ml
@@ -55,6 +55,14 @@ let references (t:t) =
   in
   aux Set.empty t
 
+let bindings (t:t) =
+  let rec aux acc = function
+    | [] -> acc
+    | (`Newline | `Comment _) :: t -> aux acc t
+    | `Entry (h, r) :: t -> aux (Reference.Map.add r h acc) t
+  in
+  aux Reference.Map.empty t
+
 module IO (D: Hash.DIGEST) = struct
 
   module Hash_IO = Hash.IO(D)

--- a/src/git/packed_refs.mli
+++ b/src/git/packed_refs.mli
@@ -24,5 +24,6 @@ include S.S with type t = entry list
 
 val find: t -> Reference.t -> Hash.t option
 val references: t -> Reference.t list
+val bindings: t -> Hash.t Reference.Map.t
 
 module IO (D: Hash.DIGEST): S.IO with type t = t

--- a/src/git/reference.ml
+++ b/src/git/reference.ml
@@ -31,6 +31,7 @@ let pretty x = String.Ascii.escape x
 let pp ppf x = Format.fprintf ppf "%s" (pretty x)
 
 module Map = Misc.Map(Misc.S)
+module Set = Misc.Set(Misc.S)
 
 let compare x y =
   match x, y with

--- a/src/git/reference.mli
+++ b/src/git/reference.mli
@@ -20,6 +20,7 @@ val to_raw: t -> string
 val of_raw: string -> t
 
 module Map: S.Map with type key = t
+module Set: S.Set with type elt = t
 
 val head: t
 

--- a/test/git-mirage/jbuild
+++ b/test/git-mirage/jbuild
@@ -2,7 +2,7 @@
 
 (executable
  ((name      test)
-  (libraries (test git-mirage mirage-fs-unix io-page.unix))))
+  (libraries (test git-mirage mirage-fs-unix io-page-unix))))
 
 (alias
  ((name runtest)

--- a/test/git-mirage/jbuild
+++ b/test/git-mirage/jbuild
@@ -7,4 +7,5 @@
 (alias
  ((name runtest)
   (deps (test.exe))
+  (package git-mirage)
   (action (run ${exe:test.exe} -q --color=always))))

--- a/test/git-unix/jbuild
+++ b/test/git-unix/jbuild
@@ -7,4 +7,5 @@
 (alias
  ((name runtest)
   (deps (test.exe))
+  (package git-unix)
   (action (chdir ${ROOT} (run ${exe:test.exe} -q --color=always)))))

--- a/test/git/jbuild
+++ b/test/git/jbuild
@@ -7,4 +7,5 @@
 (alias
  ((name runtest)
   (deps (test.exe))
+  (package git)
   (action (run ${exe:test.exe} -q --color=always))))


### PR DESCRIPTION
As ocaml-git 1.11 never unpack the packed references (instead it just writes
loose references when it wants to update them), test_and_set_reference needs
to be adapted.

Note: remove_reference and test_and_set ~set:None are completely buggy when
using packed references. This will be fixed by ocaml-git 2.0 but there is
no easy fix in ocaml-git 1.11... So simply add a note in API docs.