### PR TITLE
New pack engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _build/
 *~
 *.install
 .merlin
+_opam
+.envrc

--- a/src/git/index_pack.ml
+++ b/src/git/index_pack.ml
@@ -38,6 +38,7 @@ module type LAZY = sig
   val mem: t -> Hash.t -> bool
   val iter: t -> (Hash.t -> (Crc32.t * int64) -> unit) -> unit
   val fold: t -> (Hash.t -> (Crc32.t * int64) -> 'a -> 'a) -> 'a -> 'a
+  val cardinal: t -> int
 end
 
 module Lazy (H: S.HASH): LAZY with module Hash = H = struct
@@ -129,6 +130,8 @@ module Lazy (H: S.HASH): LAZY with module Hash = H = struct
        ; values_offset
        ; v64_offset
        ; cache = Cache.create ~random:true cache }
+
+  let cardinal { number_of_hashes; _ } = number_of_hashes
 
   exception Break
 

--- a/src/git/index_pack.mli
+++ b/src/git/index_pack.mli
@@ -68,6 +68,8 @@ module type LAZY = sig
 
   val fold: t -> (Hash.t -> (Crc32.t * int64) -> 'a -> 'a) -> 'a -> 'a
   (** Fold in the IDX file. *)
+
+  val cardinal: t -> int
 end
 
 module Lazy (H: S.HASH): LAZY with module Hash = H

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -253,7 +253,7 @@ module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE) = struct
         let contents _ = assert false
       end)
 
-    module Graph = GC.Graph
+    module Map = GC.Graph
 
     let make = GC.make_stream
 

--- a/src/git/minimal.ml
+++ b/src/git/minimal.ml
@@ -132,7 +132,7 @@ module type S = sig
     type stream = unit -> Cstruct.t option Lwt.t
     (** The stream contains the PACK flow. *)
 
-    module Graph: Map.S with type key = Hash.t
+    module Map: Map.S with type key = Hash.t
 
     val from: t -> stream -> (Hash.t * int, error) result Lwt.t
     (** [from git stream] populates the Git repository [git] from the
@@ -144,7 +144,7 @@ module type S = sig
       -> ?window:[ `Object of int | `Memory of int ]
       -> ?depth:int
       -> Value.t list
-      -> (stream * (Crc32.t * int64) Graph.t Lwt_mvar.t, error) result Lwt.t
+      -> (stream * (Crc32.t * int64) Map.t Lwt_mvar.t, error) result Lwt.t
     (** [make ?window ?depth values] makes a PACK stream from a list
         of {!Value.t}.
 

--- a/src/git/pack_engine.ml
+++ b/src/git/pack_engine.ml
@@ -794,10 +794,17 @@ module Make
       let arr = Array.make depth empty_cstruct in
       let rec fill idx off = function
         | PInfo.Load _ -> ()
-        | PInfo. Patch { hunks; src; _ } ->
+        | PInfo.Patch { hunks; src; _ } ->
           Array.unsafe_set arr idx (Cstruct.sub cs off hunks);
           fill (idx + 1) (off + hunks) src in
       fill 0 0 path; arr
+
+    let list_of_path path =
+      let rec go acc = function
+        | PInfo.Load _ -> List.rev acc
+        | PInfo.Patch { hunks; src; _ } ->
+          go (hunks :: acc) src in
+      go [] path
 
     module EIDX = struct
       module E = struct

--- a/src/git/pack_engine.ml
+++ b/src/git/pack_engine.ml
@@ -1319,14 +1319,13 @@ module Make
                       ; buff       = resolved.Resolved.buff }
   end
 
-  type pack =
+  type state =
     | Exists     of Exists.t
     | Loaded     of Loaded.t
     | Resolved   of Resolved.t
     | Total      of Total.t
 
-  type t =
-    { packs : (Hash.t, pack) Hashtbl.t }
+  type t = { packs : (Hash.t, state) Hashtbl.t }
 
   let pp_error ppf = function
     | `Pack_decoder err       -> RPDec.pp_error ppf err

--- a/src/git/pack_engine.ml
+++ b/src/git/pack_engine.ml
@@ -106,7 +106,7 @@ module type S = sig
     -> t
     -> Fpath.t
     -> [ `Normalized of PInfo.path ] PInfo.t
-    -> (unit, error) result Lwt.t
+    -> (Hash.t * int, error) result Lwt.t
 
   val read:
        root:Fpath.t
@@ -1417,8 +1417,8 @@ module Make
     >>?= Total.make ~root ~ztmp ~window ~read_inflated fs r
     >>= function
     | Ok total ->
-      Hashtbl.add t.packs total.Total.hash_pack (Total total);
-      Lwt.return_ok ()
+      Hashtbl.replace t.packs total.Total.hash_pack (Total total);
+      Lwt.return_ok (total.Total.hash_pack, Hashtbl.length total.Total.index)
     | Error _ as err -> Lwt.return err
 
   exception Found of (Hash.t * (Crc32.t * int64))

--- a/src/git/pack_engine.ml
+++ b/src/git/pack_engine.ml
@@ -509,8 +509,8 @@ module Make
                 RPDec.Object.first_crc_exn obj,
                 RPDec.Object.first_offset_exn obj,
                 RPDec.Object.length obj in
-              Hashtbl.add info.PInfo.index hash (crc, abs_off, length);
-              Hashtbl.add info.PInfo.delta abs_off (object_to_delta obj.RPDec.Object.from);
+              Hashtbl.replace info.PInfo.index hash (crc, abs_off, length);
+              Hashtbl.replace info.PInfo.delta abs_off (object_to_delta obj.RPDec.Object.from);
 
               let () = match obj.RPDec.Object.from with
                 | RPDec.Object.External _ -> t.thin <- true
@@ -672,7 +672,7 @@ module Make
               RPDec.Object.first_crc_exn obj,
               RPDec.Object.first_offset_exn obj in
             Hashtbl.add normalized.info.PInfo.index hash (crc, abs_off, needed);
-            Hashtbl.add normalized.info.PInfo.delta abs_off (Loaded.object_to_delta obj.RPDec.Object.from);
+            Hashtbl.replace normalized.info.PInfo.delta abs_off (Loaded.object_to_delta obj.RPDec.Object.from);
 
             let () = match obj.RPDec.Object.from with
               | RPDec.Object.External _ -> normalized.thin <- true
@@ -1110,8 +1110,8 @@ module Make
                          go ~src_length (fun src -> PInfo.Patch { hunks; target = length; src }) (max acc length) delta
                        | PEnc.Delta.Z -> k (PInfo.Load (Int64.to_int length)), acc in
                      go ~src_length (fun x -> x) 0 delta in
-                 Hashtbl.add index hash (crc, abs_off, needed);
-                 Hashtbl.add paths abs_off path) entries;
+                 Hashtbl.replace index hash (crc, abs_off, needed);
+                 Hashtbl.replace paths abs_off path) entries;
 
              let rec merge abs_off path acc = match path, acc with
                | PInfo.Load a, PInfo.Load b -> PInfo.Load (max a b)
@@ -1402,7 +1402,7 @@ module Make
   let v fs indexes =
     Lwt_list.map_p (Exists.make fs) indexes >|= fun exists ->
     let packs = Hashtbl.create 32 in
-    List.iter (function Ok ({ Exists.hash_pack; _ } as exists) -> Hashtbl.add packs hash_pack (Exists exists)
+    List.iter (function Ok ({ Exists.hash_pack; _ } as exists) -> Hashtbl.replace packs hash_pack (Exists exists)
                       | Error err ->
                         Log.err (fun l -> l "Retrieve an error when we load IDX file: %a." pp_error err))
       exists;

--- a/src/git/pack_engine.ml
+++ b/src/git/pack_engine.ml
@@ -16,10 +16,17 @@
  *)
 
 open Lwt.Infix
+
 let ( >>!= ) a f = Lwt_result.bind_lwt_err a f
 let ( >>?= ) = Lwt_result.bind
 let ( >>|= ) = Lwt_result.map
 let ( >!= ) a f = Lwt_result.map_err f a
+
+module Option =
+struct
+  let ( >>= ) v f = match v with Some v -> f v | None -> None
+  let ( >|= ) v f = match v with Some v -> Some (f v) | None -> None
+end
 
 let src = Logs.Src.create "git.pack" ~doc:"Git pack engine"
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -61,88 +68,65 @@ module type S = sig
      and module PDec := PDec
 
   type t
-  type loaded
+
+  type ('location, 'mmu) r =
+    { mmu              : 'mmu
+    ; with_cstruct     : 'mmu -> int -> (('location * Cstruct.t) -> unit Lwt.t) -> unit Lwt.t
+    ; with_cstruct_opt : 'mmu -> int option -> (('location * Cstruct.t) option -> unit Lwt.t) -> unit Lwt.t
+    ; free             : 'mmu -> 'location -> unit Lwt.t }
 
   type error =
     [ `Pack_decoder of RPDec.error
     | `Pack_encoder of PEnc.error
-    | `Pack_info    of PInfo.error
-    | `Idx_decoder  of IDec.error
-    | `Idx_encoder  of IEnc.error
+    | `Pack_info of PInfo.error
+    | `Idx_decoder of IDec.error
+    | `Idx_encoder of IEnc.error
     | FS.error Error.FS.t
     | `Invalid_hash of Hash.t
-    | `Integrity    of string
+    | `Integrity of string
+    | `Delta of PEnc.Delta.error
     | `Not_found ]
 
   val pp_error: error Fmt.t
 
   val v: FS.t -> Fpath.t list -> t Lwt.t
+  val lookup: t -> Hash.t -> (Hash.t * (Crc32.t * int64)) option
+  val list: t -> Hash.t list
+  val mem: t -> Hash.t -> bool
 
-  val add_total:
+  val add:
        root:Fpath.t
+    -> read_loose:(Hash.t -> (RPDec.kind * Cstruct.t) option Lwt.t)
+    -> ztmp:Cstruct.t
+    -> window:Inflate.window
+    -> FS.t
+    -> ('mmu, 'location) r
     -> t
     -> Fpath.t
-    -> PInfo.full PInfo.t
-    -> (Hash.t * int, error) result Lwt.t
-
-  val add_exists:
-       root:Fpath.t
-    -> t
-    -> Hash.t
+    -> [ `Normalized of PInfo.path ] PInfo.t
     -> (unit, error) result Lwt.t
-
-  val merge: t -> [> PInfo.partial | PInfo.full ] PInfo.t -> unit Lwt.t
-
-  val load_index:
-       FS.t -> Fpath.t
-    -> (Hash.t * IDec.t * FS.Mapper.fd, Fpath.t * error) result Lwt.t
-
-  val load_partial:
-       root:Fpath.t
-    -> t
-    -> Hash.t
-    -> IDec.t
-    -> FS.Mapper.fd
-    -> (loaded, error) result Lwt.t
-
-  val force_total:
-       t
-    -> loaded
-    -> ((RPDec.t * FS.Mapper.fd * PInfo.full PInfo.t), error) result Lwt.t
-
-  val lookup: t -> Hash.t -> (Hash.t * (Crc32.t * int64)) option Lwt.t
-
-  val mem: t -> Hash.t -> bool Lwt.t
-
-  val list: t -> Hash.t list Lwt.t
 
   val read:
        root:Fpath.t
+    -> read_loose:(Hash.t -> (RPDec.kind * Cstruct.t) option Lwt.t)
+    -> to_result:(RPDec.Object.t -> ('value, error) result Lwt.t)
     -> ztmp:Cstruct.t
     -> window:Inflate.window
+    -> FS.t
+    -> ('mmu, 'location) r
     -> t
     -> Hash.t
-    -> (RPDec.Object.t, error) result Lwt.t
+    -> ('value, error) result Lwt.t
 
   val size:
        root:Fpath.t
+    -> read_loose:(Hash.t -> (RPDec.kind * Cstruct.t) option Lwt.t)
     -> ztmp:Cstruct.t
     -> window:Inflate.window
+    -> FS.t
     -> t
     -> Hash.t
     -> (int, error) result Lwt.t
-
-  val save_idx_file:
-       fs:FS.t -> root:Fpath.t
-    -> (Hash.t * (Crc32.t * int64)) IEnc.sequence
-    -> Hash.t
-    -> (unit, error) result Lwt.t
-
-  val save_pack_file:
-       fs:FS.t -> (string -> string)
-    -> (PEnc.Entry.t * PEnc.Delta.t) list
-    -> (Hash.t -> Cstruct.t option Lwt.t)
-    -> (Fpath.t * (Hash.t * (Crc32.t * int64)) IEnc.sequence * Hash.t, error) result Lwt.t
 end
 
 module Make
@@ -262,34 +246,7 @@ module Make
      predict how much memory you need when we look your pack
      files). So, we continue to control the memory consumption. *)
 
-  type loaded =
-    { decoder : RPDec.t
-    ; idx     : IDec.t
-    ; fdp     : FS.Mapper.fd
-    ; fdi     : FS.Mapper.fd
-    ; info    : PInfo.partial PInfo.t }
-
-  type pack =
-    | Exists of { idx : IDec.t
-                ; fdi : FS.Mapper.fd }
-    | Loaded of loaded
-    | Total of  { decoder : RPDec.t
-                ; fdp     : FS.Mapper.fd
-                ; info    : PInfo.full PInfo.t }
-
-  module Graph = Map.Make(Hash)
-
-  type buffers =
-    { objects : Cstruct.t * Cstruct.t * int
-    ; hunks   : Cstruct.t
-    ; depth   : int }
-
   type fs_error = FS.error Error.FS.t
-
-  type t =
-    { fs      : FS.t
-    ; packs   : pack Graph.t Lwt_mvar.t
-    ; buffers : buffers Lwt_mvar.t }
 
   type error =
     [ `Pack_decoder of RPDec.error
@@ -300,7 +257,1016 @@ module Make
     | fs_error
     | `Invalid_hash of Hash.t
     | `Integrity of string
+    | `Delta of PEnc.Delta.error
     | `Not_found ]
+
+  type ('location, 'mmu) r =
+    { mmu              : 'mmu
+    ; with_cstruct     : 'mmu -> int -> (('location * Cstruct.t) -> unit Lwt.t) -> unit Lwt.t
+    ; with_cstruct_opt : 'mmu -> int option -> (('location * Cstruct.t) option -> unit Lwt.t) -> unit Lwt.t
+    ; free             : 'mmu -> 'location -> unit Lwt.t }
+
+  let empty_cstruct = Cstruct.create 0
+
+  module Exists =
+  struct
+
+    (* XXX(dinosaure): Voici l'état [exists]. C'est le premier /entry-point/
+       pour un fichier PACK déjà existant. La seule opération, sans promotion,
+       disponible dans cet état est [lookup]. On y charge uniquement le fichier
+       IDX associé - et ainsi savoir tout les objets qui compose le fichier
+       PACK. Ainsi, si l'utilisateur demande un objet depuis ce fichier PACK, il
+       devrait y avoir une promotion vers l'état [loaded].
+
+       Il n'y a que très peu d'allocation dans cet état, juste un [mmap] total
+       du fichier IDX. *)
+
+    type t =
+      { index     : IDec.t
+      ; hash_pack : Hash.t
+      ; fd        : FS.Mapper.fd }
+
+    let lookup { index; _ } hash = IDec.find index hash
+    let mem { index; _ } hash = IDec.mem index hash
+    let fold f { index; _ } a = IDec.fold index f a
+
+    let make fs path =
+      let err_idx_decoder err = `Idx_decoder err in
+
+      let ( <.> ) f g = fun x -> f (g x) in
+      let ( >>?= ) = Lwt_result.bind in
+      let ( >>|= ) = Lwt_result.bind_result in
+      (* ('a, 'e) result Lwt.t -> ('e -> (unit, 'e) result Lwt.t) -> ('a, 'e) result Lwt.t *)
+      let ( >>!= ) v f = v >>= function Ok _ as v -> Lwt.return v | Error err -> f err in
+
+      FS.Mapper.openfile fs path                        >|= Rresult.R.reword_error (Error.FS.err_open path)
+      >>?= fun fd -> FS.Mapper.length fd                >|= Rresult.R.reword_error (Error.FS.err_length path)
+      >>?= fun ln -> FS.Mapper.map fd (Int64.to_int ln) >|= Rresult.R.reword_error (Error.FS.err_map path)
+      >>|= (Rresult.R.reword_error err_idx_decoder <.> IDec.make)
+      >>?= fun id ->
+       let hash_pack =
+         let basename = Fpath.basename (Fpath.rem_ext path) in
+         Scanf.sscanf basename "pack-%s" (fun x -> Hash.of_hex x) in
+       Lwt.return_ok { index = id; hash_pack; fd; }
+      >>!= fun er -> FS.Mapper.close fd                 >|= Rresult.R.reword_error (Error.FS.err_close path)
+      >>?= fun () -> Lwt.return_error er
+  end
+
+  module Loaded =
+  struct
+
+    (* XXX(dinosaure): Voici l'état [loaded], il ne peut dériver que de l'état
+       [exists]. Cet état est le pire sous le plan de l'allocation et de la
+       recherche des objets. On y est associé au fichier IDX et au fichier PACK.
+       L'opération [lookup] est disponible et est mémoizé avec une ~Hashtbl~
+       interne (disponible dans ~info.PInfo.index).
+
+       Seule l'opération [read] peut compléter cet ~Hashtbl~ - puisqu'on a
+       besoin de savoir la position absolue de l'objet, son /checksum/ et sa
+       taille qui ne sont disponible qu'en ayant lu entièrement l'objet (le
+       fichier IDX ne nous renseigne pas sur la taille par exemple).
+
+       Ensuite, l'opération [read] complète petit à petit les opérations. Il
+       peut y avoir une promotion vers l'état [Normalized] seulement quand
+       ~info.PInfo.paths~ contient tout les objets référencés par le fichier IDX
+       (à vrai dire, on peut même passé à l'état [resolved] puisque si
+       ~info.PInfo.paths~ est complet, ~info.PInfo.index~ l'est aussi). *)
+
+    type t =
+      { index : IDec.t
+      ; pack  : RPDec.t
+      ; info  : [ `Pass ] PInfo.t
+      ; fdi   : FS.Mapper.fd
+      ; fdp   : FS.Mapper.fd
+      ; mutable thin : bool }
+
+    let lookup { index; info; _ } hash =
+      match Hashtbl.find_opt info.PInfo.index hash with
+      | Some (crc, abs_off, _) -> Some (crc, abs_off)
+      | None -> IDec.find index hash
+
+    let mem { index; info; _ } hash =
+      Hashtbl.mem info.PInfo.index hash || IDec.mem index hash
+
+    let fold f { index; _ } a = IDec.fold index f a
+
+    (* XXX(dinosaure): avec l'extraction d'un objet, on connait son /path/ de
+       delta-ification. Il s'agit de le transformer en /apth/ selon les termes
+       de ~PInfo~ ensuite. *)
+    let rec object_to_delta ?(depth = 1) = function
+      | RPDec.Object.External { hash; length; } -> PInfo.Unresolved { hash; length; }
+      | RPDec.Object.Internal { offset; length; _ } -> PInfo.Internal { abs_off = offset; length; }
+      | RPDec.Object.Delta { descr; base; inserts; _ } -> PInfo.Delta { hunks_descr = descr; inserts; depth; from = object_to_delta ~depth:(depth + 1) base; }
+
+    (* XXX(dinosaure): depuis un /path/, on fait un tableau pouvant contenir
+       TOUT les /insert hunks/ pour reconstruire le dit objet. Cependant,
+       [delta] n'est pas forcément résolu ! Cela veut dire que le /path/ donné
+       est peut être incomplet et on va donc pouvoir stocker dans ce tableau
+       seulement quelques niveaux nécessaires à la delta-ification.
+
+       L'algorithme derrière l'extraction d'un objet peut s'en sortir même si le
+       /path/ n'est pas complet - il va juste se mettre à allouer des [string]
+       en lieu et place d'utiliser ce [Cstruct.t]. *)
+    let split_of_delta cs delta =
+      let depth =
+        let rec go acc = function
+          | PInfo.Unresolved _ | PInfo.Internal _ -> acc
+          | PInfo.Delta { from; _ } -> go (acc + 1) from in
+        go 1 delta in
+      let arr = Array.make depth empty_cstruct in
+      let rec fill idx off = function
+        | PInfo.Unresolved _ | PInfo.Internal _ -> ()
+        | PInfo.Delta { inserts; from; _ } ->
+          Array.unsafe_set arr idx (Cstruct.sub cs off inserts);
+          fill (idx + 1) (off + inserts) from in
+      fill 0 0 delta; arr
+
+    (* XXX(dinosaure): calculer la taille nécessaire pour stocker tout les
+       /insert hunks/ selon le /path/ [delta]. *)
+    let length_of_delta delta =
+      let rec go acc = function
+        | PInfo.Unresolved _ -> acc
+        | PInfo.Internal _ -> acc
+        | PInfo.Delta { inserts; from; _ } -> go (acc + inserts) from in
+      go 0 delta
+
+    let size { pack; _ } ~ztmp ~window hash =
+      RPDec.length pack hash ztmp window >|= Rresult.R.reword_error (fun err -> `Pack_decoder err)
+
+    (* XXX(dinosaure): voici la fonction [read] disponible à l'état [loaded].
+
+       ## Arguments
+
+       [root]: [.git]
+
+       [mmu]: unité de management de la mémoire - c'est l'acronyme le plus
+       significatif sur l'objectif de cette variable. C'est l'état
+       /mutable/global/ qu'on renseignera à chaque allocation.
+
+       [with_cstruct]: malloc
+
+       [with_optional_malloc]: optional malloc
+
+       [free]: free
+
+       [to_result]: Cette fonction doit avoir un seul objectif, prendre
+       l'/ownership/ sur le [Cstruct.t] donné. Cela veut dire que le [Cstruct.t]
+       donné est celui que nous a donné [with_cstruct]. Il s'agit de le libérer
+       (voir [free]) et cette fonction doit tout simplement reprendre
+       l'ownership. Cela peut être un simple [cstruct_copy] mais, dans ce
+       contexte, on peut donner le [Value.to_result] qui s'assure de bien
+       prendre l'/ownership/ (pour les objets Git et spécifiquement pour l'objet
+       Blob qui équivaut en tout point à un [cstruct_copy]) et de retourner la
+       représentation OCaml de l'objet Git. Cette fonction peut échouer.
+
+       [ztmp]: zlib buffer
+
+       [window]: zlib window
+
+       [loaded]: l'état [loaded]
+
+       [hash]: le hash de l'objet
+
+       ## Allocation
+
+       Comme on peut le constater, [to_result] semble être la fonction la plus
+       critique dans tout ces arguments et c'est le cas. L'idée de ces
+       abstraction et de laisser le client choisir la politique d'allocation.
+       Ces allocations sont nécessaires pour extraire l'objet et l'on peut
+       imaginer un cache LRU derrière pour quelques [Cstruct.t].
+
+       Ensuite, on s'assure de libérer ces [Cstruct.t] associés à une /location/
+       le plus rapidement possible avec [free]. Bien entendu, cela n'arrive
+       seulement qu'après l'application de [to_result]. Si [to_result] est juste
+       la fonction identité (ce qui peut être le cas), vous devriez avoir un
+       problème sur le contenu qui risque d'être changeant si les [Cstruct.t]
+       reçus par [with_cstruct] sont réutilisés.
+
+       [to_result] donc doit __allouer__ la même ou une nouvelle forme de la
+       valeur pour en garantir l'/ownership/.
+
+       Enfin, on assure pas que les allocations demandées sont suffisantes pour
+       extraire l'objet. C'est parce que les /paths/ ne sont pas résolus que ce
+       que l'on peut demander avec [with_optional_cstruct] soit partiel pour
+       l'extraction - cela peut alors entraîner l'allocation de [string]
+       incontrôlé.
+
+       ## Mémoization
+
+       Bien entendu, pour chaque lecture, on résoud le /path/ de l'objet
+       demandé. On mets 2 informations à jour, la première est la ~Hashtbl~
+       ~info.PInfo.paths~ et la deuxième est savoir si le fichier PACK est
+       /thin/ ou pas.
+
+       Pour la deuxième information, vu que le fichier PACK ne peut venir que de
+       l'état [exists], ce n'est normalement pas possible que le fichier PACK
+       soit /thin/ - mais on sait jamais. *)
+    let read
+        (type mmu) (type location) (type value)
+        ~root
+        ~(to_result:RPDec.Object.t -> (value, error) result Lwt.t)
+        ~ztmp ~window
+        (r:(mmu, location) r)
+        ({ pack; info; index; _ } as t) hash
+      : [ `Error of error | `Promote of value | `Return of value ] Lwt.t =
+      lookup t hash |> function
+      | None -> Lwt.return (`Error (`Pack_decoder (RPDec.Invalid_hash hash)))
+      | Some (_, abs_off) ->
+        RPDec.needed_from_offset t.pack abs_off ztmp window >>= function
+        | Error err -> Lwt.return (`Error (`Pack_decoder err))
+        | Ok length ->
+          let res = ref None in
+          let delta = Hashtbl.find_opt info.PInfo.delta abs_off in
+
+          (r.with_cstruct r.mmu (length * 2) @@ fun (loc_raw, raw) ->
+           let raw = Cstruct.sub raw 0 length, Cstruct.sub raw length length, length in
+
+           r.with_cstruct_opt r.mmu Option.(delta >|= length_of_delta) @@ fun hraw ->
+           let htmp = Option.(delta >>= fun delta -> hraw >|= fun (_, cs) -> split_of_delta cs delta) in
+
+           let deliver () = r.free r.mmu loc_raw >>= fun () -> match Option.(hraw >|= fst) with
+             | Some loc -> r.free r.mmu loc
+             | None -> Lwt.return_unit in
+
+           RPDec.get_from_hash ?htmp pack hash raw ztmp window
+           >>= fun x -> res := Some (deliver, x); Lwt.return_unit)
+
+          >>= (fun () -> match !res with
+              | None -> assert false
+              | Some (deliver, res) ->
+                Rresult.R.reword_error (fun err -> `Pack_decoder err) res
+                |> Lwt.return
+                >>?= fun obj -> to_result obj
+                >>?= fun res -> Lwt.return_ok (obj, res)
+                >>= fun res -> deliver () >|= fun () -> res)
+          >|= function
+            | Ok (obj, value) ->
+              let crc, abs_off, length =
+                RPDec.Object.first_crc_exn obj,
+                RPDec.Object.first_offset_exn obj,
+                RPDec.Object.length obj in
+              Hashtbl.add info.PInfo.index hash (crc, abs_off, length);
+              Hashtbl.add info.PInfo.delta abs_off (object_to_delta obj.RPDec.Object.from);
+
+              let () = match obj.RPDec.Object.from with
+                | RPDec.Object.External _ -> t.thin <- true
+                | RPDec.Object.Internal _ -> ()
+                | RPDec.Object.Delta { base; _ } ->
+                  let rec go = function
+                    | RPDec.Object.Delta { base; } -> go base
+                    | RPDec.Object.External _ -> t.thin <- true
+                    | RPDec.Object.Internal _ -> () in
+                  go base in
+
+              if Hashtbl.length info.PInfo.delta = IDec.cardinal index
+              then `Promote value
+              else `Return value
+            | Error err -> `Error err
+
+    let make_pack_decoder ~read_and_exclude ~idx fs path =
+      let ( >>!= ) v f = v >>= function Ok _ as v -> Lwt.return v | Error err -> f err in
+
+      FS.Mapper.openfile fs path
+      >|= Rresult.R.reword_error (Error.FS.err_open path)
+      >>?= fun fd ->
+      let fun_cache  = fun _ -> None in
+      let fun_idx    = idx in
+      let fun_revidx = fun _ -> None in
+      let fun_last   = read_and_exclude in
+
+      RPDec.make fd fun_cache fun_idx fun_revidx fun_last
+      >|= Rresult.R.reword_error (Error.FS.err_length path)
+      >>?= fun pack -> Lwt.return_ok (fd, pack)
+      >>!= fun er -> FS.Mapper.close fd >|= Rresult.R.reword_error (Error.FS.err_close path)
+      >>?= fun () -> Lwt.return_error er
+
+    (* XXX(dinosaure): voici la fonction de promotion de l'état [exists] à
+       l'état [loaded]. La fonction [read_and_exclude] est expliqué plus bas -
+       elle dépends de tout les états de chaque fichiers PACK.
+
+       Ici enfin, on utilise le fichier IDX - et pas la ~Hashtbl~ qui n'est pas
+       complète - en vrai, on pourrait utiliser la ~Hashtbl~. *)
+    let make ~root ~read_and_exclude fs exists =
+      let path = Fpath.(root / "objects" / "pack" / Fmt.strf "pack-%s.pack" (Hash.to_hex exists.Exists.hash_pack)) in
+      let index = exists.Exists.index in
+      let info = PInfo.v exists.Exists.hash_pack in
+
+      let ( >>!= ) v f = v >>= function Ok _ as v -> Lwt.return v | Error err -> f err in
+
+      make_pack_decoder ~read_and_exclude ~idx:(IDec.find exists.Exists.index) fs path
+      >>?= fun (fd, pack) ->  Lwt.return_ok { index; pack; info; fdi = exists.Exists.fd; fdp = fd; thin = false }
+      >>!= fun er -> FS.Mapper.close exists.Exists.fd >|= Rresult.R.reword_error Error.FS.err_sys_map
+      >>?= fun () -> Lwt.return_error er
+  end
+
+  module Normalized =
+  struct
+
+    (* XXX(dinosaure): Voici l'état [normalized] qui est l'/entry-point/ pour
+       les fichiers PACK venant du réseau (clone, pull, fetch). Cet état est
+       surtout un état pour le dissocié de [resolved] et enclenché la seconde
+       /pass/. La deuxième /pass/ va résoudre les paths des objets delta-ifiés
+       and demandant des allocations explicites à l'utilisateur.
+
+       Avec cette résolution, on va résoudre les paths pour ensuite les merger
+       entre eux et avoir l'approximation nécessaire à l'extraction de tout les
+       objets du dit fichier PACK. Cette résolution va nous permettre aussi de
+       savoir si un des objets nécessaire à la delta-ification est externe au
+       fichier PACK ou non (ce qui devrait être le cas). *)
+
+    type t =
+      { pack  : RPDec.t
+      ; path  : Fpath.t
+      ; info  : [ `Normalized of PInfo.path ] PInfo.t
+      ; fd    : FS.Mapper.fd
+      ; mutable thin : bool }
+
+    (* XXX(dinosaure): cette fonction permet de créer un tableau de [Cstruct.t]
+       à partir du /path/ - qui peut être partiel. *)
+    let split_of_delta cs delta =
+      let depth =
+        let rec go acc = function
+          | PInfo.Unresolved _ | PInfo.Internal _ -> acc
+          | PInfo.Delta { from; _ } -> go (acc + 1) from in
+        go 0 delta in
+      let arr = Array.make depth empty_cstruct in
+      let rec fill idx off = function
+        | PInfo.Unresolved _ | PInfo.Internal _ -> ()
+        | PInfo.Delta { inserts; from; _ } ->
+          Array.unsafe_set arr idx (Cstruct.sub cs off inserts);
+          fill (idx + 1) (off + inserts) from in
+      fill 0 0 delta; arr
+
+    let length_of_delta delta =
+      let rec go acc = function
+        | PInfo.Unresolved _ -> acc
+        | PInfo.Internal _ -> acc
+        | PInfo.Delta { inserts; from; _ } -> go (acc + inserts) from in
+      go 0 delta
+
+    let length_of_path path =
+      let rec go acc = function
+        | PInfo.Load _ -> acc
+        | PInfo.Patch { hunks; src; _ } -> go (acc + hunks) src in
+      go 0 path
+
+    let digest cs =
+      let ctx = Hash.Digest.init () in
+      Hash.Digest.feed ctx cs;
+      Hash.Digest.get ctx
+
+    let make_from_info ~read_and_exclude fs path_tmp info =
+      let idx hash = match Hashtbl.find_opt info.PInfo.index hash with
+        | Some (crc, abs_off, _) -> Some (crc, abs_off)
+        | None -> None in
+
+      Loaded.make_pack_decoder ~read_and_exclude ~idx fs path_tmp >>= function
+      | Ok (fd, pack) ->
+        Lwt.return_ok { pack; path = path_tmp; info; fd; thin = false }
+      | Error _ as err -> Lwt.return err
+
+    exception Fail of RPDec.error
+
+    (* XXX(dinosaure): la seconde /pass/ permet de résoudre les objets
+       delta-ifiés et ainsi, par la même occasion, savoir si le fichier PACK est
+       /thin/ ou pas. Avec cette résolution, on peut passer de l'état
+       [normalized] à l'état [resolved].
+
+       On pourrait déplacer ce code dans le module [Resolved] (TODO).
+
+       Puisque les résolutions sont faites séquentiellement, au niveau de
+       l'allocation, un seul buffer qui peut grandir est nécessaire - il n'y
+       aura pas de /data-race condition/ dans ce contexte de résolution.info
+
+       NOTE: on pourrait faire une résolution en concurrence mais cela
+       compliquerait la gestion des allocations au niveau utilisateur (pour
+       justement éviter la /data-race condition/) bien que cette gestion soit
+       possible puisque on demande à l'utilisation une fonction [free]
+       permettant de notifier l'utilisateur que la ressource demandé associé à
+       une [location] (qui peut sémantiquement être une /mutex/) est libéré. *)
+    let second_pass
+      (type mmu) (type location)
+      ~ztmp
+      ~window
+      (r:(mmu, location) r)
+      normalized =
+      let resolve (abs_off, delta) =
+        RPDec.needed_from_offset normalized.pack abs_off ztmp window >>= function
+        | Error err -> Lwt.fail (Fail err)
+        | Ok needed ->
+          r.with_cstruct r.mmu (needed * 2) @@ fun (loc_raw, raw) ->
+          let raw = Cstruct.sub raw 0 needed, Cstruct.sub raw needed needed, needed in
+
+          r.with_cstruct_opt r.mmu (Some (length_of_delta delta)) @@ fun hraw ->
+          let htmp = Option.(hraw >|= fun (_, cs) -> split_of_delta cs delta) in
+
+          RPDec.get_from_offset ?htmp normalized.pack abs_off raw ztmp window >>= function
+          | Error err -> Lwt.fail (Fail err)
+          | Ok obj ->
+            let hash = digest obj.RPDec.Object.raw in
+            let crc, abs_off =
+              RPDec.Object.first_crc_exn obj,
+              RPDec.Object.first_offset_exn obj in
+            Hashtbl.add normalized.info.PInfo.index hash (crc, abs_off, needed);
+            Hashtbl.add normalized.info.PInfo.delta abs_off (Loaded.object_to_delta obj.RPDec.Object.from);
+
+            let () = match obj.RPDec.Object.from with
+              | RPDec.Object.External _ -> normalized.thin <- true
+              | RPDec.Object.Internal _ -> ()
+              | RPDec.Object.Delta { base; _ } ->
+                let rec go = function
+                  | RPDec.Object.Delta { base; _ } -> go base
+                  | RPDec.Object.External _ -> normalized.thin <- true
+                  | RPDec.Object.Internal _ -> () in
+                go base in
+
+            r.free r.mmu loc_raw
+            >>= fun () -> match hraw with
+            | Some (loc, _) -> r.free r.mmu loc
+            | None -> Lwt.return_unit in
+
+      Lwt.catch
+        (fun () ->
+           Lwt_list.iter_s
+             resolve
+             (Hashtbl.fold (fun k v a -> (k, v) :: a) normalized.info.PInfo.delta []
+              |> List.sort (fun (ka, _) (kb, _) -> Int64.compare ka kb))
+           >>= fun () -> Lwt.return_ok ())
+        (function Fail err -> Lwt.return_error (`Pack_decoder err)
+                | exn -> Lwt.fail exn)
+  end
+
+  let with_buffer buff f =
+    let c = ref None in
+    buff (fun buf ->
+        f buf >|= fun x ->
+        c := Some x
+      ) >|= fun () ->
+    match !c with
+    | Some x -> x
+    | None   -> assert false
+
+  module Resolved =
+  struct
+
+    (* XXX(dinosaure): voici l'état [resolved], on y est presque. Dans cette
+       état, on a résolu tout les objets delta-ifiés et, sauf pour les objets
+       extérieurs au fichier PACK, on est sur un modèle où l'allocation est
+       déterminé - c'est à dire que on vous ne demandera jamais plus que ce
+       qu'on vous a déjà demandé. En effet, à ce stade, puisque tout les objets
+       sont résolus, on est capable de savoir le plus gros objet du fichier PACK
+       et on est capable de savoir strictement les buffers nécessaires pour
+       sauvegarder pendant la récursion les /insert hunks/ (et, en cela,
+       appliquer successivement les patchs).
+
+       On pourrait même aller jusqu'à faire une fonction /tail-rec/ puisqu'on a
+       déterminé les sources nécessaires à la delta-fication. *)
+
+    type t =
+      { pack       : RPDec.t
+      ; index      : (Hash.t, Crc32.t * int64 * int) Hashtbl.t
+      ; delta      : (int64, PInfo.delta) Hashtbl.t
+      ; hash_pack  : Hash.t
+      ; path_delta : PInfo.path
+      ; fd         : FS.Mapper.fd
+      ; buff       : (buffer -> unit Lwt.t) -> unit Lwt.t
+      ; thin       : bool }
+    and buffer =
+      { hunks : Cstruct.t array
+      ; buffer : Cstruct.t * Cstruct.t * int
+      ; depth : int
+      ; deliver : unit -> unit Lwt.t }
+
+    let stream_of_path _ = assert false
+
+    let mem { index; _ } hash = Hashtbl.mem index hash
+
+    let fold f { index; _ } a = Hashtbl.fold (fun hash (crc, abs_off, _) a -> f hash (crc, abs_off) a) index a
+
+    let depth_of_path path =
+      let rec go acc = function
+        | PInfo.Load _ -> acc
+        | PInfo.Patch { src; _ } -> go (acc + 1) src in
+      go 1 path
+
+    let split_of_path cs path =
+      let depth = depth_of_path path in
+      let arr = Array.make depth empty_cstruct in
+      let rec fill idx off = function
+        | PInfo.Load _ -> ()
+        | PInfo. Patch { hunks; src; _ } ->
+          Array.unsafe_set arr idx (Cstruct.sub cs off hunks);
+          fill (idx + 1) (off + hunks) src in
+      fill 0 0 path; arr
+
+    module EIDX = struct
+      module E = struct
+        type state  = IEnc.t
+        type result = unit
+        type error  = IEnc.error
+        type end' = [ `End of state ]
+        type rest = [ `Flush of state | `Error of state * error ]
+        let flush = IEnc.flush
+        let used = IEnc.used_out
+        let eval raw state = match IEnc.eval raw state with
+          | #end' as v   -> let `End state = v in Lwt.return (`End (state, ()))
+          | #rest as res -> Lwt.return res
+      end
+      include Helper.Encoder(E)(FS)
+    end
+
+    (* XXX(dinosaure): à ce stade, on peut sauvegarder le fichier IDX si le
+       fichier PACK est pas /thin/. C'est une fonction abstraite pour, depuis
+       une sequence (version itérable d'une structure), sauvegarde un fichier
+       IDX selon le hash du fichier PACK - un fichier IDX est forcément associé
+       à un fichier PACK. *)
+    let store_idx_file ~root fs sequence hash_pack =
+      let file = Fmt.strf "pack-%s.idx" (Hash.to_hex hash_pack) in
+      let encoder_idx = IEnc.default sequence hash_pack in
+      let raw = Cstruct.create 0x8000 in (* XXX(dinosaure): as argument? *)
+      let path = Fpath.(root / "objects" / "pack" / file) in
+      EIDX.to_file fs path raw encoder_idx >|= function
+      | Ok ()                  -> Ok ()
+      | Error (`Encoder err)   -> Error (`Idx_encoder err)
+      | Error #fs_error as err -> err
+
+    let make_buffer
+        (type mmu) (type location) (type a)
+        (r:(mmu, location) r)
+        length_hunks length_buffer path_delta : (buffer -> unit Lwt.t) -> unit Lwt.t =
+      let ret = ref None in
+
+      let make () =
+        r.with_cstruct r.mmu length_hunks @@ fun (loc_hunks, hunks) ->
+        r.with_cstruct r.mmu (length_buffer * 2) @@ fun (loc_objrw, objrw) ->
+
+        let hunks = split_of_path hunks path_delta in
+        let depth = depth_of_path path_delta in
+        let buffer = Cstruct.sub objrw 0 length_buffer, Cstruct.sub objrw length_buffer length_buffer, length_buffer in
+        let deliver () = r.free r.mmu loc_hunks >>= fun () -> r.free r.mmu loc_objrw in
+
+        ret := Some { hunks; buffer; deliver; depth; };
+        Lwt.return_unit in
+
+      (* XXX(dinosaure): bypass value restriction. *)
+      let make () = make () >>= fun () -> match !ret with
+        | Some ret -> Lwt.return ret
+        | None -> assert false in
+
+      let pool = Lwt_pool.create 4 make in
+      Lwt_pool.use pool
+
+    (* XXX(dinosaure): Cette fonction permet de passer de l'état [normalized] à
+       l'état [resolved]. On applique ainsi la /second_pass/. Ensuite, si le
+       fichier PACK est /thin/, on retourne un état qui continue d'utiliser le
+       fichier PACK qui devrait se retrouver dans le dossier ~tmp~. Sinon, on
+       sauvegarde le fichier IDX dans le dépôt git et cette fonction va
+       __déplacer__ le fichier PACK temporaire dans le dépôt git - on
+       s'appliquera bien à fermer le /file-descriptor/ du fichier PACK
+       temporaire.
+
+       Il s'agira ensuite de passer à l'état [total]. Ce dernier s'appliquera à
+       faire la troisième phase ou non. Il faut donc bien saisir que l'état
+       [resolved] n'est qu'un état de passage comme l'état [noramlized] - à la
+       différence de l'état [loaded] qui peut être utilisé à défaut de devoir
+       allouer de la mémoire.
+
+       La politique d'allocation est bien entendu déterminé mais concurrente !
+       *)
+    let make_from_normalized
+        (type mmu) (type location)
+        ~root
+        ~read_and_exclude
+        ~ztmp
+        ~window
+        fs
+        (r:(mmu, location) r)
+        normalized =
+      Normalized.second_pass ~ztmp ~window r normalized >>= function
+      | Error _ as err -> Lwt.return err
+      | Ok () ->
+        let info = PInfo.resolve ~length:(Hashtbl.length normalized.info.PInfo.delta) normalized.info in
+        let path = Fpath.(root / "objects" / "pack" / Fmt.strf "pack-%s.idx" (Hash.to_hex info.PInfo.hash_pack)) in
+        let `Resolved path_delta = info.PInfo.state in
+
+        if normalized.Normalized.thin
+        then Loaded.make_pack_decoder ~read_and_exclude ~idx:Option.(fun hash -> Hashtbl.find_opt info.PInfo.index hash >|= fun (crc, abs_off, _) -> (crc, abs_off)) fs path
+          >>?= fun (fd, pack) ->
+
+          let length_hunks = Normalized.length_of_path path_delta in
+          let length_objrw = Hashtbl.fold (fun k (_, _, v) -> max v) info.PInfo.index 0 in
+          let buff = make_buffer r length_hunks length_objrw path_delta in
+
+          Lwt.return_ok { pack
+                        ; index = info.PInfo.index
+                        ; delta = info.PInfo.delta
+                        ; hash_pack = info.PInfo.hash_pack
+                        ; path_delta
+                        ; fd
+                        ; buff
+                        ; thin = normalized.Normalized.thin }
+        else
+          let sequence f = Hashtbl.iter (fun k (crc, abs_off, _) -> f (k, (crc, abs_off))) info.PInfo.index in
+
+          store_idx_file ~root fs sequence info.PInfo.hash_pack
+          >>?= fun () -> FS.File.move fs normalized.Normalized.path path >|= Rresult.R.reword_error (Error.FS.err_move normalized.Normalized.path path)
+          >>?= fun () -> FS.Mapper.close normalized.Normalized.fd >|= Rresult.R.reword_error (Error.FS.err_close normalized.Normalized.path)
+          >>?= fun () -> Loaded.make_pack_decoder ~read_and_exclude ~idx:Option.(fun hash -> Hashtbl.find_opt info.PInfo.index hash >|= fun (crc, abs_off, _) -> (crc, abs_off)) fs path
+          >>?= fun (fd, pack) ->
+
+          let length_hunks = Normalized.length_of_path path_delta in
+          let length_objrw = Hashtbl.fold (fun k (_, _, v) -> max v) info.PInfo.index 0 in
+          let buff = make_buffer r length_hunks length_objrw path_delta in
+
+          Lwt.return_ok { pack
+                        ; index = info.PInfo.index
+                        ; delta = info.PInfo.delta
+                        ; hash_pack = info.PInfo.hash_pack
+                        ; path_delta
+                        ; fd
+                        ; buff
+                        ; thin = normalized.Normalized.thin }
+
+    let make_from_loaded
+        (type mmu) (type location)
+        ~read_and_exclude
+        ~ztmp
+        ~window
+        fs
+        (r:(mmu, location) r)
+        loaded =
+      let info = PInfo.normalize ~length:(Hashtbl.length loaded.Loaded.info.PInfo.delta) loaded.Loaded.info in
+      let info = PInfo.resolve ~length:(Hashtbl.length loaded.Loaded.info.PInfo.delta) info in
+      let `Resolved path_delta = info.PInfo.state in
+
+      let length_hunks = Normalized.length_of_path path_delta in
+      let length_objrw = Hashtbl.fold (fun k (_, _, v) -> max v) info.PInfo.index 0 in
+      let buff = make_buffer r length_hunks length_objrw path_delta in
+
+      FS.Mapper.close loaded.Loaded.fdi >|= Rresult.R.reword_error Error.FS.err_sys_map >>?= fun () ->
+      Lwt.return_ok { pack = loaded.Loaded.pack
+                    ; index = info.PInfo.index
+                    ; delta = info.PInfo.delta
+                    ; hash_pack = info.PInfo.hash_pack
+                    ; path_delta
+                    ; fd = loaded.Loaded.fdp
+                    ; buff
+                    ; thin = loaded.Loaded.thin }
+
+    (* XXX(dinosaure): cette fonction permet de passer de l'etat [exists]
+       directement à l'état [resolved]. Cette fonction se base sur une
+       /assumption/ importante, un fichier PACK dans un dépôt git qui est
+       forcément à la base dans l'état [exists] est non-/thin/. Dans ce cas, la
+       résolution des objets delta-ifiés peut se faire uniquement à l'aide du
+       fichier IDX et du fichier PACK - en effet, les objets ayant une référence
+       OBJ_REF_DELTA ont une résolution possible à l'aide du fichier IDX et si
+       le fichier PACK est non-/thin/, ces références sont forcément dans le
+       fichier PACK.
+
+       Di côté de Git, c'est nécessairement le cas que les fichiers PACK dans le
+       dépôt sont non-/thin/ (et c'est pour cette raison qu'on s'applique à
+       faire la troisième phase d'ailleurs). Cependant, dans des situations non
+       communes à git, il peut arriver que les fichiers PACK soient /thin/. Il
+       faut donc utiliser cette fonction en état de cause.
+
+       TODO: on pourrait faire la vérification si le fichier PACK est /thin/ ou
+       pas en regardant si, après la première /pass/ on a bien tout les objets
+       dans nos ~Hashtbl~.
+
+       Comme pour [make], la politique d'allocation est déterminé mais elle est
+       concurrente ! *)
+    let force
+      (type mmu) (type location)
+      ~root
+      ~read_and_exclude
+      ~ztmp
+      ~window
+      fs
+      (r:(mmu, location) r)
+      exists =
+      let path = Fpath.(root / "objects" / "pack" / Fmt.strf "pack-%s.pack" (Hash.to_hex exists.Exists.hash_pack)) in
+      let stream = stream_of_path path in
+      let thin = ref false in
+      let idx hash = match IDec.find exists.Exists.index hash with
+        | Some _ as v -> v
+        | none -> thin := true; none in
+
+      PInfo.first_pass ~ztmp ~window ~idx stream >>= function
+      | Ok info ->
+        let info = PInfo.resolve ~length:(IDec.cardinal exists.Exists.index) info in
+        let `Resolved path_delta = info.PInfo.state in
+
+        let length_hunks = Normalized.length_of_path path_delta in
+        let length_objrw = Hashtbl.fold (fun k (_, _, v) -> max v) info.PInfo.index 0 in
+        let buff = make_buffer r length_hunks length_objrw path_delta in
+
+        let ( >>!= ) v f = v >>= function Ok _ as v -> Lwt.return v | Error err -> f err in
+
+        Loaded.make_pack_decoder ~read_and_exclude ~idx:Option.(fun hash -> Hashtbl.find_opt info.PInfo.index hash >>= fun (crc, abs_off, _) -> Some (crc, abs_off)) fs path
+        >>?= fun (fd, pack) -> FS.Mapper.close exists.Exists.fd >|= Rresult.R.reword_error Error.FS.err_sys_map
+        >>?= fun () -> Lwt.return_ok { pack
+                                     ; index = info.PInfo.index
+                                     ; delta = info.PInfo.delta
+                                     ; hash_pack = exists.Exists.hash_pack
+                                     ; path_delta
+                                     ; fd
+                                     ; buff
+                                     ; thin = !thin }
+        >>!= fun er -> FS.Mapper.close exists.Exists.fd >|= Rresult.R.reword_error Error.FS.err_sys_map
+        >>?= fun () -> Lwt.return_error er
+      | Error err -> Lwt.return (Error (`Pack_info err))
+
+    let lookup { index; _ } hash = match Hashtbl.find_opt index hash with
+      | Some (crc, abs_off, _) -> Some (crc, abs_off)
+      | None -> None
+
+    let size { pack; _ } ~ztmp ~window hash =
+      RPDec.length pack hash ztmp window >|= Rresult.R.reword_error (fun err -> `Pack_decoder err)
+
+    let read (type value) ~ztmp ~window ~(to_result:RPDec.Object.t -> (value, error) result Lwt.t) ({ pack; thin; _ } as t) hash
+      : [ `Error of error | `Promote of value | `Return of value ] Lwt.t =
+      with_buffer t.buff @@ fun { hunks; buffer; deliver; _ } ->
+      RPDec.get_from_hash ~htmp:hunks pack hash buffer ztmp window >|= Rresult.R.reword_error (fun err -> `Pack_decoder err)
+      >>?= to_result >>= fun res -> deliver () >|= fun () -> match res with
+      | Ok value ->
+        if not thin then `Promote value else `Return value
+      | Error err -> ` Error err
+  end
+
+  module Total =
+  struct
+    type t =
+      { index      : (Hash.t, Crc32.t * int64 * int) Hashtbl.t
+      ; path_delta : PInfo.path
+      ; hash_pack  : Hash.t
+      ; pack       : RPDec.t
+      ; buff       : (Resolved.buffer -> unit Lwt.t) -> unit Lwt.t
+      ; fd         : FS.Mapper.fd }
+
+    let lookup { index; _ } hash = Hashtbl.find_opt index hash
+    let mem { index; _ } hash = Hashtbl.mem index hash
+    let fold f { index; _ } a = Hashtbl.fold (fun hash (crc, abs_off, _) a -> f hash (crc, abs_off) a) index a
+
+    let size { pack; _ } ~ztmp ~window hash =
+      RPDec.length pack hash ztmp window >|= Rresult.R.reword_error (fun err -> `Pack_decoder err)
+
+    let read (type value) ~ztmp ~window ~(to_result:RPDec.Object.t -> (value, error) result Lwt.t) ({ pack; _ } as t) hash
+      : [ `Error of error | `Return of value ] Lwt.t =
+      with_buffer t.buff @@ fun { hunks; buffer; deliver; _ } ->
+      RPDec.get_from_hash ~htmp:hunks pack hash buffer ztmp window >|= Rresult.R.reword_error (fun err -> `Pack_decoder err)
+      >>?= to_result >>= fun res -> deliver () >|= fun () -> match res with
+      | Ok value -> `Return value
+      | Error err -> ` Error err
+
+    exception Leave of Hash.t
+
+    module EPACK = struct
+      module E = struct
+        type state =
+          { get : Hash.t -> Cstruct.t option Lwt.t
+          ; pack: PEnc.t
+          ; src : Cstruct.t option }
+        type result =
+          { tree: (Crc32.t * int64) PEnc.Map.t
+          ; hash: Hash.t }
+        type error = PEnc.error
+
+        let option_get ~default = function Some a -> a | None -> default
+
+        let rec eval dst state =
+          match
+            PEnc.eval (option_get ~default:empty_cstruct state.src) dst state.pack
+          with
+          | `End (pack, hash) ->
+            Lwt.return (`End ({ state with pack; },
+                              { tree = (PEnc.idx pack)
+                              ; hash }))
+          | `Error (pack, err) -> Lwt.return (`Error ({ state with pack; }, err))
+          | `Flush pack        -> Lwt.return (`Flush { state with pack; })
+          | `Await pack ->
+            match state.src with
+            | Some _ ->
+              eval dst { state with pack = PEnc.finish pack ; src = None }
+            | None   ->
+              let hash = PEnc.expect pack in
+              state.get hash >>= function
+              | None -> Lwt.fail (Leave hash)
+              | Some raw ->
+                let state = {
+                  state with pack = PEnc.refill 0 (Cstruct.len raw) pack;
+                             src  = Some raw;
+                } in
+                eval dst state
+
+        let flush off len ({ pack; _ } as state) =
+          { state with pack = PEnc.flush off len pack }
+
+        let used { pack; _ } = PEnc.used_out pack
+      end
+      include Helper.Encoder(E)(FS)
+    end
+
+    let random_string len =
+      let gen () = match Random.int (26 + 26 + 10) with
+        | n when n < 26 -> int_of_char 'a' + n
+        | n when n < 26 + 26 -> int_of_char 'A' + n - 26
+        | n -> int_of_char '0' + n - 26 - 26
+      in
+      let gen () = char_of_int (gen ()) in
+      Bytes.create len |> fun raw ->
+      for i = 0 to len - 1 do Bytes.set raw i (gen ()) done;
+      Bytes.unsafe_to_string raw
+
+    let store_pack_file ~fs fmt entries get =
+      let ztmp = Cstruct.create 0x8000 in
+      let file = fmt (random_string 10) in
+      let state = PEnc.default ztmp entries in
+      FS.Dir.temp fs >>= fun temp ->
+      let path = Fpath.(temp / file) in
+      let rawo = Cstruct.create 0x8000 in
+      let state = { EPACK.E.get; src = None; pack = state } in
+      Lwt.catch
+        (fun () ->
+           (* XXX(dinosaure): why is not atomic? *)
+           EPACK.to_file fs ~atomic:false path rawo state >|= function
+           | Ok { EPACK.E.tree; hash; } ->
+             let index = Hashtbl.create (PEnc.Map.cardinal tree) in
+             let paths = Hashtbl.create (PEnc.Map.cardinal tree) in
+             List.iter (fun (entry, delta) ->
+                 let (crc, abs_off) = PEnc.Map.find (PEnc.Entry.id entry) tree in
+                 let path, needed = match delta.PEnc.Delta.delta with
+                   | PEnc.Delta.Z ->
+                     let length = Int64.to_int (PEnc.Entry.length entry) in
+                     PInfo.Load length, length
+                   | PEnc.Delta.S { src_length; _ } as delta ->
+                     let rec go ~src_length:length k acc = function
+                       | PEnc.Delta.S { length; src = { PEnc.Delta.delta }; hunks; src_length; _ } ->
+                         let hunks = List.fold_left (fun a -> function Rabin.Insert (_, l) -> a + l | _ -> a) 0 hunks in
+                         go ~src_length (fun src -> PInfo.Patch { hunks; target = length; src }) (max acc length) delta
+                       | PEnc.Delta.Z -> k (PInfo.Load (Int64.to_int length)), acc in
+                     go ~src_length (fun x -> x) 0 delta in
+                 Hashtbl.add index hash (crc, abs_off, needed);
+                 Hashtbl.add paths abs_off path) entries;
+
+             let rec merge abs_off path acc = match path, acc with
+               | PInfo.Load a, PInfo.Load b -> PInfo.Load (max a b)
+               | PInfo.Load x, PInfo.Patch { hunks; target; src; }
+               | PInfo.Patch { hunks; target; src; }, Load x -> PInfo.Patch { hunks; target = max x target; src; }
+               | PInfo.Patch { hunks = hunks_a
+                       ; target = target_a
+                       ; src = src_a },
+                 Patch { hunks = hunks_b
+                       ; target = target_b
+                       ; src = src_b } ->
+                 Patch { hunks = max hunks_a hunks_b; target = max target_a target_b; src = merge abs_off src_a src_b } in
+             let path = Hashtbl.fold merge paths (Load 0) in
+
+             Ok (Fpath.(temp / file)
+                , (index, path)
+                , hash)
+           | Error #fs_error as err -> err
+           | Error (`Encoder e) -> Error (`Pack_encoder e))
+        (function
+          | Leave hash -> Lwt.return (Error (`Invalid_hash hash))
+          | exn        -> Lwt.fail exn (* XXX(dinosaure): should never happen. *))
+
+    let filter_map f lst =
+      List.fold_left (fun a v -> match f v with
+          | Some v -> v :: a
+          | None -> a) [] lst
+      |> List.rev
+
+    let third_pass ~root ~ztmp ~window ~read_inflated fs resolved =
+      let deltas = filter_map (function PInfo.Delta { hunks_descr; _ } -> Some hunks_descr | _ -> None)
+          (Hashtbl.fold (fun _ v a -> v :: a) resolved.Resolved.delta []) in
+      let revidx = Hashtbl.create (Hashtbl.length resolved.Resolved.index) in
+      Hashtbl.iter (fun hash (crc, abs_off, length)-> Hashtbl.add revidx abs_off hash) resolved.Resolved.index;
+
+      let k2k = function
+        | `Commit -> Pack.Kind.Commit
+        | `Tree   -> Pack.Kind.Tree
+        | `Blob   -> Pack.Kind.Blob
+        | `Tag    -> Pack.Kind.Tag in
+      let make acc (hash, (_, abs_off, _)) =
+        with_buffer resolved.Resolved.buff @@ fun { hunks; buffer; deliver; _ } ->
+
+        RPDec.get_from_offset ~htmp:hunks resolved.Resolved.pack abs_off buffer ztmp window
+        >>= fun obj -> deliver () >|= fun () -> match obj with
+        | Error _ -> acc
+        | Ok obj ->
+          let delta = match obj.RPDec.Object.from with
+            | RPDec.Object.External { hash; _ } -> Some (PEnc.Entry.From hash)
+            | RPDec.Object.Internal _ -> None
+            | RPDec.Object.Delta { offset; _ } ->
+              try let hash = Hashtbl.find revidx offset in
+                Some (PEnc.Entry.From hash)
+              with Not_found -> None (* XXX(dinosaure): should not appear. *) in
+          PEnc.Entry.make hash ?delta (k2k obj.RPDec.Object.kind) (Int64.of_int (Cstruct.len obj.RPDec.Object.raw)) :: acc in
+      let external_objects acc =
+        let res = List.fold_left
+            (fun acc hunks_descr ->
+               match hunks_descr.HDec.reference with
+               | HDec.Offset _ -> acc
+               | HDec.Hash hash ->
+                 if Hashtbl.mem resolved.Resolved.index hash
+                 then acc
+                 else
+                   try ignore @@ List.find (Hash.equal hash) acc; acc
+                   with Not_found -> hash :: acc)
+            [] deltas in
+        Lwt_list.fold_left_s
+          (fun acc hash -> read_inflated hash >|= function
+             | None -> acc
+             | Some (kind, raw) -> PEnc.Entry.make hash (k2k kind) (Int64.of_int (Cstruct.len raw)) :: acc)
+          acc res in
+      let read_inflated hash =
+        if Hashtbl.mem resolved.Resolved.index hash
+        then
+          with_buffer resolved.Resolved.buff @@ fun { hunks; buffer = (_, _, length); deliver; _ } ->
+          let buffer = Cstruct.create (length * 2) in
+          let buffer = Cstruct.sub buffer 0 length, Cstruct.sub buffer length length, length in
+
+          RPDec.get_from_hash ~htmp:hunks resolved.Resolved.pack hash buffer ztmp window
+          >>= fun obj -> deliver () >|= fun () -> match obj with
+          | Error _ -> None
+          | Ok obj -> (Some obj.RPDec.Object.raw)
+        else read_inflated hash >|= function
+          | Some (_, raw) -> Some raw
+          (* XXX(dinosaure): normalement, il devrait y avoir un [cstruct_copy]
+             ici puisque [read_inflated] est externe à cette fonction - on y
+             contrôle donc pas son allocation. Cependant, plus bas (dans [read])
+             cette fonction est le [read_and_exclude] qui alloue bien les
+             [Cstruct.t]. Donc dans ce cas, ce serait une allocation d'une
+             allocation - ce qui est pas le plus top.
+
+             Bref, attention si on change ce code. *)
+          | None -> None in
+
+      Hashtbl.fold (fun hash value acc -> (hash, value) :: acc) resolved.Resolved.index []
+      |> Lwt_list.fold_left_s make []
+      >>= external_objects
+      >>= fun entries -> PEnc.Delta.deltas ~memory:false entries read_inflated (fun _ -> false) 10 50
+      >>= function
+      | Error err -> Lwt.return_error (`Delta err)
+      | Ok entries ->
+        store_pack_file ~fs (Fmt.strf "pack-%s.pack") entries read_inflated
+        >>= function
+        | Error _ as err -> Lwt.return err
+        | Ok (path, (index, delta_path), hash_pack) ->
+          let sequence f = Hashtbl.iter (fun hash (crc, abs_off, _) -> f (hash, (crc, abs_off))) index in
+          Resolved.store_idx_file ~root fs sequence hash_pack >>= function
+          | Error _ as err -> Lwt.return err
+          | Ok () ->
+            let file = Fmt.strf "pack-%s.pack" (Hash.to_hex hash_pack) in
+            let dst  = Fpath.(root / "objects" / "pack" / file) in
+            FS.File.move fs path dst >|= Rresult.R.reword_error (Error.FS.err_move path dst)
+            >>?= fun () -> FS.Mapper.close resolved.Resolved.fd >|= Rresult.R.reword_error Error.FS.err_sys_map
+            (* XXX(dinosaure): le fichier PACK temporaire de l'état [resolved]
+               est fermé ici ! *)
+            >>?= fun () -> Lwt.return_ok (path, hash_pack, index, delta_path)
+
+    let make
+      (type mmu) (type location)
+      ~root
+      ~ztmp
+      ~window
+      ~read_inflated
+      fs
+      (r:(mmu, location) r)
+      resolved =
+      if resolved.Resolved.thin
+      then third_pass ~root ~ztmp ~window ~read_inflated fs resolved >>= function
+        | Error _ -> assert false
+        | Ok (path, hash_pack, index, path_delta) ->
+
+          let idx hash = let open Option in Hashtbl.find_opt index hash >|= fun (crc, abs_off, _) -> (crc, abs_off) in
+          Loaded.make_pack_decoder ~read_and_exclude:(fun _ -> Lwt.return_none) ~idx fs path
+          >>?= fun (fd, pack) ->
+
+            let length_hunks = Normalized.length_of_path path_delta in
+            let length_buffer = Hashtbl.fold (fun k (_, _, v) -> max v) index 0 in
+            let buff = Resolved.make_buffer r length_hunks length_buffer path_delta in
+
+            Lwt.return_ok { index; path_delta; hash_pack; pack; buff; fd; }
+      else
+        let extern _ = Lwt.return_none in
+
+        Lwt.return_ok { pack       = RPDec.update_extern extern resolved.Resolved.pack
+                      ; index      = resolved.Resolved.index
+                      ; hash_pack  = resolved.Resolved.hash_pack
+                      ; path_delta = resolved.Resolved.path_delta
+                      ; fd         = resolved.Resolved.fd
+                      ; buff       = resolved.Resolved.buff }
+  end
+
+  type pack =
+    | Exists     of Exists.t
+    | Loaded     of Loaded.t
+    | Resolved   of Resolved.t
+    | Total      of Total.t
+
+  type t =
+    { packs : (Hash.t, pack) Hashtbl.t }
 
   let pp_error ppf = function
     | `Pack_decoder err       -> RPDec.pp_error ppf err
@@ -310,320 +1276,22 @@ module Make
     | `Idx_encoder err        -> IEnc.pp_error ppf err
     | #fs_error as err        -> Error.FS.pp_error FS.pp_error ppf err
     | #Error.not_found as err -> Error.pp_not_found ppf err
+    | `Delta err              -> PEnc.Delta.pp_error ppf err
     | `Invalid_hash hash ->
       Fmt.pf ppf "Unable to load %a, it does not exists in the store"
         Hash.pp hash
     | `Integrity err ->
       Fmt.string ppf err
 
-  (* XXX(dinosaure): to make a _unloaded_ pack object. *)
-  let load_index fs path =
-    let close fd sys_err =
-      FS.Mapper.close fd >>= function
-      | Ok ()          -> Lwt.return sys_err
-      | Error sys_err' ->
-        Log.err (fun l ->
-            l "Error while closing the index fd: %a: %a."
-              Fpath.pp path FS.Mapper.pp_error sys_err');
-        Lwt.return sys_err
-    in
-    let open Lwt_result in
-    (* FIXME: this code is horrible *)
-    ((FS.Mapper.openfile fs path
-      >!= Error.FS.err_open path
-      >>= fun fd -> FS.Mapper.length fd
-      >>!= close fd
-           >!= Error.FS.err_length path
-      >|= fun length -> (fd, length))
-     >>= fun (fd, length) -> (
-       FS.Mapper.map fd (Int64.to_int length)
-       >>!= close fd
-       >!= Error.FS.err_map path
-       >|= fun map -> (fd, map)
-     ) >>= fun (fd, map) -> (
-       Lwt.return (IDec.make map)
-       >>!= close fd
-       >>!= (fun sys_err -> Lwt.return (`Idx_decoder sys_err))
-     ) >>= fun decoder_idx -> (
-       let hash_idx =
-         let basename = Fpath.basename (Fpath.rem_ext path) in
-         Scanf.sscanf basename "pack-%s" (fun x -> Hash.of_hex x)
-         (* XXX(dinosaure): check if [sscanf] raises an exception. *)
-       in
-       Log.debug (fun l -> l "IDX file %a is loaded." Hash.pp hash_idx);
-       Lwt.return (Ok (hash_idx, decoder_idx, fd)))
-    ) >>!= (fun err -> Lwt.return (path, err))
-
-  let v fs lst =
-    Lwt_list.map_p (load_index fs) lst >>= fun lst ->
-    Lwt_list.fold_left_s (fun acc -> function
-        | Ok (hash, idx, fdi) ->
-          Lwt.return (Graph.add hash (Exists { idx; fdi; }) acc)
-        | Error (path, err) ->
-          Log.err (fun l ->
-              l "Error while computing the IDX file %a: %a."
-                Fpath.pp path pp_error err);
-          Lwt.return acc
-      ) Graph.empty lst
-    >|= fun graph ->
-    let packs = Lwt_mvar.create graph in
-    let buffers =
-      let empty = Cstruct.create 0 in
-      Lwt_mvar.create { objects = empty, empty, 0
-                      ; hunks = empty
-                      ; depth = 1 }
-    in
-    { fs; packs; buffers; }
-
-  (* XXX(dinosaure): this function update the internal buffers of [t]
-     from a /fresh/ information of a pack file. It's thread-safe. *)
-  let merge t info =
-    Lwt_mvar.take t.buffers >>= fun buffers ->
-    let (raw0, raw1, len) = buffers.objects in
-    let (raw0', raw1', len') =
-      if len < info.PInfo.max_length_object
-      then
-        let plus0, plus1 =
-          Cstruct.create (info.PInfo.max_length_object - len),
-          Cstruct.create (info.PInfo.max_length_object - len) in
-        (Cstruct.concat [ raw0; plus0 ],
-         Cstruct.concat [ raw1; plus1 ],
-         info.PInfo.max_length_object)
-      else
-        (raw0, raw1, len)
-    in
-    let hunks_length = Cstruct.len buffers.hunks / buffers.depth in
-    let depth = info.PInfo.max_depth + 1 in
-    let hunks', depth' =
-      match buffers.depth < depth,
-            hunks_length < info.PInfo.max_length_insert_hunks
-      with
-      | false, true ->
-        Log.debug (fun l -> l ~header:"merge" "The hunks buffer needs to grow from %d to %d."
-                      hunks_length info.PInfo.max_length_insert_hunks);
-        let plus = Cstruct.create (buffers.depth * (info.PInfo.max_length_insert_hunks - hunks_length)) in
-        Cstruct.concat [ buffers.hunks; plus ], buffers.depth
-      | true, false ->
-        Log.debug (fun l -> l ~header:"merge" "The depth needs to be updated from %d to %d."
-                      buffers.depth depth);
-        let plus = Cstruct.create ((depth - buffers.depth) * hunks_length) in
-        Cstruct.concat [ buffers.hunks; plus ], depth
-      | true, true ->
-        Log.debug (fun l -> l ~header:"merge" "The depth and the hunks buffer need to be updated, \
-                                               %d to %d for the depth and %d to %d for the hunks buffer."
-                      buffers.depth depth
-                      hunks_length info.PInfo.max_length_insert_hunks);
-        let plus =
-          Cstruct.create
-            ((buffers.depth * (info.PInfo.max_length_insert_hunks - hunks_length))
-             + ((depth - buffers.depth) * info.PInfo.max_length_insert_hunks))
-        in
-        Cstruct.concat [ buffers.hunks; plus ], depth
-      | false, false ->
-        buffers.hunks, buffers.depth
-    in
-
-    Lwt_mvar.put t.buffers { objects = (raw0', raw1', len')
-                           ; hunks = hunks'
-                           ; depth = depth' }
-
-  module EIDX = struct
-    module E = struct
-      type state  = IEnc.t
-      type result = unit
-      type error  = IEnc.error
-      type end' = [ `End of state ]
-      type rest = [ `Flush of state | `Error of state * error ]
-      let flush = IEnc.flush
-      let used = IEnc.used_out
-      let eval raw state = match IEnc.eval raw state with
-        | #end' as v   -> let `End state = v in Lwt.return (`End (state, ()))
-        | #rest as res -> Lwt.return res
-    end
-    include Helper.Encoder(E)(FS)
-  end
-
-  let save_idx_file ~fs ~root sequence hash_pack =
-    let file = Fmt.strf "pack-%s.idx" (Hash.to_hex hash_pack) in
-    let encoder_idx = IEnc.default sequence hash_pack in
-    let raw = Cstruct.create 0x8000 in
-    let path = Fpath.(root / "objects" / "pack" / file) in
-    EIDX.to_file fs path raw encoder_idx >|= function
-    | Ok ()                  -> Ok ()
-    | Error (`Encoder err)   -> Error (`Idx_encoder err)
-    | Error #fs_error as err -> err
-
-  exception Leave of Hash.t
-
-  let random_string len =
-    let gen () = match Random.int (26 + 26 + 10) with
-      | n when n < 26 -> int_of_char 'a' + n
-      | n when n < 26 + 26 -> int_of_char 'A' + n - 26
-      | n -> int_of_char '0' + n - 26 - 26
-    in
-    let gen () = char_of_int (gen ()) in
-    Bytes.create len |> fun raw ->
-    for i = 0 to len - 1 do Bytes.set raw i (gen ()) done;
-    Bytes.unsafe_to_string raw
-
-  module EPACK = struct
-    module E = struct
-
-      type state = {
-        get : Graph.key -> Cstruct.t option Lwt.t;
-        pack: PEnc.t;
-        src : Cstruct.t option;
-      }
-
-      type result = {
-        tree: (Crc32.t * int64) PEnc.Map.t;
-        hash: Hash.t
-      }
-
-      type error = PEnc.error
-      let empty = Cstruct.create 0
-      let option_get ~default = function Some a -> a | None -> default
-
-      let rec eval dst state =
-        match
-          PEnc.eval (option_get ~default:empty state.src) dst state.pack
-        with
-        | `End (pack, hash) ->
-          Lwt.return (`End ({ state with pack; },
-                            { tree = (PEnc.idx pack)
-                            ; hash }))
-        | `Error (pack, err) -> Lwt.return (`Error ({ state with pack; }, err))
-        | `Flush pack        -> Lwt.return (`Flush { state with pack; })
-        | `Await pack ->
-          match state.src with
-          | Some _ ->
-            eval dst { state with pack = PEnc.finish pack ; src = None }
-          | None   ->
-            let hash = PEnc.expect pack in
-            state.get hash >>= function
-            | None -> Lwt.fail (Leave hash)
-            | Some raw ->
-              let state = {
-                state with pack = PEnc.refill 0 (Cstruct.len raw) pack;
-                           src  = Some raw;
-              } in
-              eval dst state
-
-      let flush off len ({ pack; _ } as state) =
-        { state with pack = PEnc.flush off len pack }
-
-      let used { pack; _ } = PEnc.used_out pack
-
-    end
-    include Helper.Encoder(E)(FS)
-  end
-
-  let save_pack_file ~fs fmt entries get =
-    let ztmp = Cstruct.create 0x8000 in
-    let filename_pack = fmt (random_string 10) in
-    let state = PEnc.default ztmp entries in
-    FS.Dir.temp fs >>= fun temp ->
-    let path = Fpath.(temp / filename_pack) in
-    let raw = Cstruct.create 0x8000 in
-    let state = { EPACK.E.get; src = None; pack = state } in
-    Lwt.catch (fun () ->
-        EPACK.to_file fs ~atomic:false path raw state >|= function
-        | Ok { EPACK.E.tree; hash; } ->
-          Ok (Fpath.(temp / filename_pack)
-             , (fun f -> PEnc.Map.iter (fun k v -> f (k, v)) tree)
-             , hash)
-        | Error #fs_error as err -> err
-        | Error (`Encoder e) -> Error (`Pack_encoder e)
-      ) (function
-        | Leave hash -> Lwt.return (Error (`Invalid_hash hash))
-        | exn        -> Lwt.fail exn (* XXX(dinosaure): should never happen. *)
-      )
-
-  let add_exists ~root t hash =
-    let filename_idx = Fmt.strf "pack-%s.idx" (Hash.to_hex hash) in
-    let path_idx = Fpath.(root / "objects" / "pack" / filename_idx) in
-    load_index t.fs path_idx >>= function
-    | Error (_, err)          -> Lwt.return (Error err)
-    | Ok (hash_idx, idx, fdi) ->
-      let pack = Exists { idx; fdi; } in
-      Lwt_mvar.take t.packs
-      >>= fun packs -> Lwt_mvar.put t.packs (Graph.add hash_idx pack packs)
-      >|= fun () -> Ok ()
-
-  let add_total ~root t path info =
-    let `Full { PInfo.Full.hash = hash_pack; PInfo.Full.thin; } =
-      info.PInfo.state
-    in
-    if thin then invalid_arg "Impossible to store a thin pack.";
-    let filename_pack = Fmt.strf "pack-%s.pack" (Hash.to_hex hash_pack) in
-    let filename_idx = Fmt.strf "pack-%s.idx" (Hash.to_hex hash_pack) in
-    FS.File.move t.fs path Fpath.(root / "objects" / "pack" / filename_pack)
-    >>= function
-    | Error err ->
-      Lwt.return Error.(v @@ FS.err_move path Fpath.(root / "objects" / "pack" / filename_pack) err)
-    | Ok ()     ->
-      let path_idx = Fpath.(root / "objects" / "pack" / filename_idx) in
-      let sequence = (fun f -> PInfo.Map.iter (fun k v -> f (k, v)) info.PInfo.tree) in
-      let encoder_idx = IEnc.default sequence hash_pack in
-      (* XXX(dinosaure): we save an IDX file for a future computation
-         of git/ocaml-git of this PACK file even if we don't use it -
-         we use the complete radix tree. *)
-      let raw = Cstruct.create 0x8000 in
-      EIDX.to_file t.fs path_idx raw encoder_idx >>= function
-      | Error #fs_error as err -> Lwt.return err
-      | Error (`Encoder e) -> Lwt.return (Error (`Idx_encoder e))
-      | Ok ()              ->
-        let path_pack = Fpath.(root / "objects" / "pack" / filename_pack) in
-        (FS.Mapper.openfile t.fs path_pack
-         >>!= fun sys_err -> Lwt.return (Error.FS.err_open path_pack sys_err))
-        >>?= fun fdp ->
-        let fun_cache _ = None in
-        let fun_idx hash =
-          try Some (PInfo.Map.find hash info.PInfo.tree)
-          with Not_found -> None in
-        let fun_revidx hash =
-          try let (_, ret) = PInfo.Graph.find hash info.PInfo.graph in ret
-          with Not_found -> None
-        in
-        let fun_last _ = Lwt.return None in
-        (* XXX(dinosaure): the pack file is not thin. So it does
-           not request any external ressource. *)
-        (RPDec.make fdp
-           fun_cache
-           fun_idx
-           fun_revidx
-           fun_last
-         >>!= fun err -> Lwt.return (Error.FS.err_open path_pack err))
-        >>?= fun decoder ->
-        let pack = Total { decoder; fdp; info; } in
-        Lwt_mvar.take t.packs
-        >>= fun packs -> Lwt_mvar.put t.packs (Graph.add hash_pack pack packs)
-        >>= fun () -> merge t info
-        >|= fun () ->
-        let count = PInfo.Graph.cardinal info.PInfo.graph in
-        Ok (hash_pack, count)
-
-  (* XXX(dinosaure): this function could not be exposed. It used in
-     a specific context, when a pack decoder requests an external
-     object. This case appear only when the pack file is a
-     /thin/-pack. So, we need to allocate some buffers to avoid a
-     memory-explosion (if the object is delta-ified) and return a
-     /fresh/ raw of the requested object. *)
-  let strong_weight_read decoder info hash request =
-    let (raw0, raw1, len) =
-      Cstruct.create info.PInfo.max_length_object,
-      Cstruct.create info.PInfo.max_length_object,
-      info.PInfo.max_length_object
-    in
-    let htmp = Cstruct.create ((info.PInfo.max_depth + 1) * info.PInfo.max_length_insert_hunks) in
-    let htmp = Array.init (info.PInfo.max_depth + 1)
-        (fun i -> Cstruct.sub htmp (i * info.PInfo.max_length_insert_hunks)
-            info.PInfo.max_length_insert_hunks)
-    in
-
+  (* XXX(dinosaure): this function could not be exposed. It used in a specific
+     context, when a pack decoder requests an external object. This case appear
+     only when the pack file is a /thin/-pack. So, we need to allocate some
+     buffers to avoid a memory-explosion (if the object is delta-ified) and
+     return a /fresh/ raw of the requested object. *)
+  let strong_weight_read decoder hash request =
     let ztmp = Cstruct.create 0x8000 in
     let window = Inflate.window () in
-    (RPDec.get_from_hash ~htmp decoder request (raw0, raw1, len) ztmp window >>= function
+    (RPDec.get_with_result_allocation_from_hash decoder request ztmp window >>= function
       | Ok obj -> Lwt.return (Some (obj.RPDec.Object.kind, obj.RPDec.Object.raw))
       | Error err ->
         Log.err (fun l -> l ~header:"read_and_exclude" "Error when we try to get the object %a from the pack %a: %a."
@@ -631,366 +1299,236 @@ module Make
                     RPDec.pp_error err);
         Lwt.return None)
 
-  (* XXX(dinosaure): [read_and_exclude] is called when a pack decoder
-     wants to reconstruct an internal object and the source is
-     external - by this way, we can consider the pack file as a /thin/
-     pack.
+  (* XXX(dinosaure): [read_and_exclude] is called when a pack decoder wants to
+     reconstruct an internal object and the source is external - by this way, we
+     can consider the pack file as a /thin/ pack.
 
-     So this is the biggest function which could allocate a lot.
-     Obviously, in a real world, this function could not happen (Git
-     takes care about pack file and stores only /non-thin/ pack
-     files).
+     So this is the biggest function which could allocate a lot. Obviously, in a
+     real world, this function could not happen (Git takes care about pack file
+     and stores only /non-thin/ pack files).
 
-     However, from a [ `Partial ] information, we can not ensure than
-     the pack file is not a /thin/-pack. So this function exists for
-     the pack decoder when we want to retrieve an external object.
+     However, from a [resolved]/[normalized]/[loaded]/[exists] information, we
+     can not ensure than the pack file is not a /thin/-pack. So this function
+     exists for the pack decoder when we want to retrieve an external object.
 
-     Then, we exclude the pack itself to avoid a infinite recursion
-     when the length of the redirection is 1. If it's upper, firstly,
-     what?  then, you could have a infinite loop. About this bug, we
-     could change the API of the pack decoder and allow to inform a
-     /close/ list to the function. *)
-  let rec read_and_exclude ~root t exclude request =
-    Lwt_mvar.take t.packs >>= fun packs ->
-    Lwt_mvar.put t.packs packs >>= fun () ->
-    Lwt_list.fold_left_s (function
-        | Some _ as x -> fun _ -> Lwt.return x
-        | None ->
-          fun (hash, pack) -> match pack with
-            | Exists { idx; fdi; } when IDec.mem idx request ->
-              (load_partial ~root t hash idx fdi >>= function
-                | Ok loaded -> strong_weight_read loaded.decoder loaded.info request hash
-                | Error _ -> Lwt.return None)
-            | Loaded { idx; decoder; info; _ } when IDec.mem idx request ->
-              strong_weight_read decoder info request hash
-            | Total { decoder; info; _ } when PInfo.Map.mem request info.PInfo.tree ->
-              strong_weight_read decoder info request hash
-            | _ -> Lwt.return None)
-      None
-      (Graph.fold (fun key value acc ->
-           if Hash.equal key exclude
-           then acc
-           else (key, value) :: acc)
-          packs [])
+     Then, we exclude the pack itself to avoid a infinite recursion when the
+     length of the redirection is 1. If it's upper, firstly, what? then, you
+     could have a infinite loop. About this bug, we could change the API of the
+     pack decoder and allow to inform a /close/ list to the function.
+
+     NOTE: [exclude] is added for each call (we put the current hash of the PACK
+     file), it's like a close list of already visited PACK files. This is to
+     avoid an infinite recursion. It's common to have 2 times (or more) the same
+     objet on multiple PACK file.
+
+     So, a /thin/ PACK file A can expect an external object O which appear on a
+     PACK file B which need an object M which could be appear inner A (and need
+     O to be reconstructed). In other words, O needs itself to be reconstructed.
+     This situation appear only if we did not exclude PACK file which we already
+     try to get the O object.
+
+     As I said, the object O can be appear 2 times (or more) in multiple PACK
+     file. That means, object O can appear in an other PACK file. The goal is to
+     get O from a different PACK file than A (may be a PACK file C) and this the
+     purpose of [exclude]. My brain is fuck up. *)
+
+  exception Catch of (RPDec.kind * Cstruct.t)
+
+  let rec read_and_exclude ~root ~read_loose fs t exclude request =
+    Lwt.catch
+      (fun () -> Lwt_list.fold_left_s (fun acc (hash, pack) -> match acc with
+           | Some _ -> assert false
+           | None -> match pack with
+             | Exists exists ->
+               if Exists.mem exists request
+               then
+                 Loaded.make ~root ~read_and_exclude:(read_and_exclude ~root ~read_loose fs t [ hash ]) fs exists >>= function
+                 | Error err ->
+                   Log.err (fun l -> l "Retrieve an error when we promote PACK %a to loaded state: %a."
+                               Hash.pp exists.Exists.hash_pack pp_error err);
+                   Lwt.return_none
+                 | Ok loaded ->
+                   Hashtbl.replace t.packs hash (Loaded loaded);
+                   let exclude = hash :: exclude in
+                   let read_and_exclude = read_and_exclude ~root ~read_loose fs t exclude in
+                   strong_weight_read (RPDec.update_extern read_and_exclude loaded.Loaded.pack) hash request >>= function
+                   | Some value -> Lwt.fail (Catch value)
+                   | None -> Lwt.return_none
+               else Lwt.return_none
+             | Loaded loaded ->
+               if Loaded.mem loaded request
+               then
+                 let exclude = hash :: exclude in
+                 let read_and_exclude = read_and_exclude ~root ~read_loose fs t exclude in
+                 strong_weight_read (RPDec.update_extern read_and_exclude loaded.Loaded.pack) hash request >>= function
+                 | Some value -> Lwt.fail (Catch value)
+                 | None -> Lwt.return_none
+               else Lwt.return_none
+             | Resolved resolved ->
+               if Resolved.mem resolved request
+               then
+                 let exclude = hash :: exclude in
+                 let read_and_exclude = read_and_exclude ~root ~read_loose fs t exclude in
+                 strong_weight_read (RPDec.update_extern read_and_exclude resolved.Resolved.pack) hash request >>= function
+                 | Some value -> Lwt.fail (Catch value)
+                 | None -> Lwt.return_none
+               else Lwt.return_none
+             | Total total ->
+               if Total.mem total request
+               then
+                 let exclude = hash :: exclude in
+                 let read_and_exclude = read_and_exclude ~root ~read_loose fs t exclude in
+                 strong_weight_read (RPDec.update_extern read_and_exclude total.Total.pack) hash request >>= function
+                 | Some value -> Lwt.fail (Catch value)
+                 | None -> Lwt.return_none
+               else Lwt.return_none)
+           None
+           (Hashtbl.fold (fun hash pack acc ->
+                if List.exists (Hash.equal hash) exclude
+                then acc
+                else (hash, pack) :: acc) t.packs []))
+      (function
+        | Catch (kind, raw) -> Lwt.return_some (kind, raw)
+        | exn -> Lwt.fail exn)
     >>= function
-    | Some _ as v -> Lwt.return v
-    | None ->
-      (* XXX(dinosaure): ok, the last chance to retrieve the
-         requested object. We lookup in the loose object. *)
-      assert false
+    | None -> read_loose request
+    | Some x -> Lwt.return_some x
 
-  (* XXX(dinosaure): this function loads _partially_ a pack file.
-     That means we calculate some useful informations from a _not
-     loaded_ pack representation (which has only the index decoder)
-     and make a new /fresh/ pack decoder.
+  let v fs indexes =
+    Lwt_list.map_p (Exists.make fs) indexes >|= fun exists ->
+    let packs = Hashtbl.create 32 in
+    List.iter (function Ok ({ Exists.hash_pack; _ } as exists) -> Hashtbl.add packs hash_pack (Exists exists)
+                      | Error err ->
+                        Log.err (fun l -> l "Retrieve an error when we load IDX file: %a." pp_error err))
+      exists;
+    { packs }
 
-     It consists to read one time entirely the pack file, calculate
-     some informations and store it to use it after - like how much
-     we need to decode a git object from this specific pack file.
+  let add ~root ~read_loose ~ztmp ~window fs r t path_tmp info =
+    let read_and_exclude = read_and_exclude ~root ~read_loose fs t [ info.PInfo.hash_pack ] in
+    let read_inflated = read_and_exclude in
 
-     This computation can not know how much we need if any
-     delta-ified objects of this specific pack file need an external
-     git object - at this point, we can consider this pack file as a
-     /thin/-pack.
-
-     If we catch any error for any computation, we delete this pack
-     file as an available pack file - we lost it forever! *)
-  and load_partial ~root t hash decoder_idx fdi =
-    let filename_pack = Fmt.strf "pack-%s.pack" (Hash.to_hex hash) in
-    let path = Fpath.(root / "objects" / "pack" / filename_pack) in
-    let ztmp = Cstruct.create 0x8000 in
-    let window = Inflate.window () in
-    let close_all fdi fdp sys_err =
-      (* XXX(dinosaure): delete from the git repository. *)
-      Lwt_mvar.take t.packs >>= fun packs ->
-      Lwt_mvar.put t.packs (Graph.remove hash packs) >>= fun () ->
-      (FS.Mapper.close fdi
-       >>!= fun sys_err' ->
-       Log.err (fun l -> l ~header:"log" "Impossible to close the index fd: %a"
-                   FS.Mapper.pp_error sys_err');
-       Lwt.return ())
-      >>= fun _ ->
-      (FS.Mapper.close fdp
-       >>!= fun sys_err' ->
-       Log.err (fun l -> l ~header:"log" "Impossible to close the pack fd: %a"
-                   FS.Mapper.pp_error sys_err');
-       Lwt.return ())
-      >>= fun _ -> Lwt.return sys_err
-    in
-    (FS.Mapper.openfile t.fs path
-     >>!= (fun sys_err ->
-         (* XXX(dinosaure): delete from the git repository. *)
-         Lwt_mvar.take t.packs >>= fun packs ->
-         Lwt_mvar.put t.packs (Graph.remove hash packs) >>= fun () ->
-         FS.Mapper.close fdi >|= function
-         | Ok () -> sys_err
-         | Error sys_err' ->
-           Log.err (fun l ->
-               l "Got an error while trying to close the index file-descriptor, ignoring: %a."
-                 FS.Mapper.pp_error sys_err');
-           sys_err)
-          >!= Error.FS.err_open path)
-    >>?= fun fdp ->
-    (let fun_cache  = fun _ -> None in
-     let fun_idx    = fun hash -> IDec.find decoder_idx hash in
-     let fun_revidx = fun _ -> None in
-     let fun_last   = fun hash' -> read_and_exclude ~root t hash hash' in
-
-     RPDec.make fdp fun_cache fun_idx fun_revidx fun_last
-     >!= Error.FS.err_length path (* XXX(dinosaure): we know [RPDec.make] try to compute length of the PACK file. *)
-     >>!= close_all fdi fdp)
-    >>?= fun decoder_pack ->
-    (FS.File.open_r t.fs path
-     >!= Error.FS.err_open path
-     >>!= close_all fdi fdp)
-    >>?= fun fd ->
-    (let raw = Cstruct.create 0x8000 in
-     let stream () =
-       FS.File.read raw fd >|= function
-       | Ok 0          -> None
-       | Ok len        -> Some (Cstruct.sub raw 0 len)
-       | Error sys_err ->
-         Log.err (fun l ->
-             l "Retrieve an error when we read the PACK file %s: %a."
-               filename_pack FS.pp_error sys_err);
-         None
-     in
-     let info = PInfo.v hash in
-     PInfo.from_stream ~ztmp ~window info stream
-     >>!= (fun err -> Lwt.return (`Pack_info err))
-     >>!= close_all fdi fdp
-     >>!= (fun sys_err ->
-         FS.File.close fd >|= function
-         | Ok ()          -> sys_err
-         | Error sys_err' ->
-           Log.err (fun l ->
-               l "Impossible to close the fd of the PACK file (to analyze it): \
-                  %a." FS.pp_error sys_err');
-           sys_err))
-    >>?= fun info ->
-    let pack =
-      { decoder = decoder_pack
-      ; fdp
-      ; fdi
-      ; info
-      ; idx = decoder_idx }
-    in
-
-    Lwt.return (Ok pack)
-
-  let force_total t loaded =
-    let `Partial { PInfo.Partial.hash = hash_pack; delta } =
-      loaded.info.PInfo.state
-    in
-    let hash_of_object obj =
-      let ctx = Hash.Digest.init () in
-      let hdr = Fmt.strf "%s %Ld\000%!"
-          (match obj.RPDec.Object.kind with
-           | `Commit -> "commit"
-           | `Tree -> "tree"
-           | `Tag -> "tag"
-           | `Blob -> "blob")
-          obj.RPDec.Object.length
-      in
-      Hash.Digest.feed ctx (Cstruct.of_string hdr);
-      Hash.Digest.feed ctx obj.RPDec.Object.raw;
-      Hash.Digest.get ctx
-    in
-    let crc32 obj = match obj.RPDec.Object.from with
-      | RPDec.Object.Offset { crc; _ } -> crc
-      | RPDec.Object.External _ -> raise (Invalid_argument "Try to get the CRC-32 from an external ressource")
-      | RPDec.Object.Direct { crc; _ } -> crc
-    in
-    let ztmp = Cstruct.create 0x8000 in
-    let window = Inflate.window () in
-    Lwt_mvar.take t.buffers >>= fun buffers ->
-    Lwt_list.map_s
-      (fun (offset, hunks_descr) ->
-         let length = Cstruct.len buffers.hunks / buffers.depth in
-         RPDec.get_from_offset ~htmp:
-           (Array.init buffers.depth
-              (fun i -> Cstruct.sub buffers.hunks (i * length) length))
-           loaded.decoder offset buffers.objects ztmp window >>= function
-         | Ok obj ->
-           let hash = hash_of_object obj in
-           let crc32 = crc32 obj in
-           Lwt.return (Ok (hunks_descr, hash, (crc32, offset)))
-         | Error err ->
-           Log.err (fun l ->
-               l "Retrieve an error when we try to reconstruct \
-                  the object at the offset %Lx from the PACK file %a: %a."
-                 offset Hash.pp hash_pack RPDec.pp_error err);
-           Lwt.return (Error ()))
-      delta
-    >>= fun lst -> Lwt_mvar.put t.buffers buffers >>= fun () -> Lwt.return lst
-    >>= Lwt_list.fold_left_s (fun ((tree, graph) as acc) -> function
-        | Ok (hunks_descr, hash, ((_, offset) as value)) ->
-          let tree = PInfo.Map.add hash value tree in
-          let graph =
-            let open PInfo in
-            let depth_source, _ = match hunks_descr.HDec.reference with
-              | HDec.Offset rel_off ->
-                (try Graph.find Int64.(sub offset rel_off) graph
-                 with Not_found -> 0, None)
-              | HDec.Hash hash_source ->
-                try let _, abs_off = Map.find hash_source tree in
-                    Graph.find abs_off graph
-                with Not_found -> 0, None
-            in
-            Graph.add offset (depth_source + 1, Some hash) graph
-          in
-          Lwt.return (tree, graph)
-        | Error _ -> Lwt.return acc
-      ) (loaded.info.PInfo.tree, loaded.info.PInfo.graph)
-    >>= fun (tree', graph') ->
-    let is_total =
-      PInfo.Graph.for_all
-        (fun _ -> function (_, Some _) -> true | (_, None) -> false) graph'
-    in
-    if is_total then
-      (* XXX(samoht): for_all_p is uselesse here *)
-      Lwt_list.for_all_p (fun (_, hunks_descr) ->
-          let open PInfo in
-          match hunks_descr.HDec.reference with
-          | HDec.Offset _  -> Lwt.return true
-          | HDec.Hash hash -> Lwt.return (Map.mem hash tree'))
-        delta
-      >|= fun is_not_thin ->
-      Ok (loaded.decoder,
-          loaded.fdp,
-          { loaded.info with PInfo.tree = tree'
-                           ; graph = graph'
-                           ; state = `Full { PInfo.Full.hash = hash_pack
-                                           ; thin = not is_not_thin } })
-    else
-      Fmt.kstrf (fun x -> Lwt.return (Error (`Integrity x)))
-        "Impossible to get all informations from the pack file: %a."
-        Hash.pp hash_pack
+    Normalized.make_from_info ~read_and_exclude fs path_tmp info
+    >>?= Resolved.make_from_normalized ~root ~read_and_exclude ~ztmp ~window fs r
+    >>?= Total.make ~root ~ztmp ~window ~read_inflated fs r
+    >>= function
+    | Ok total ->
+      Hashtbl.add t.packs total.Total.hash_pack (Total total);
+      Lwt.return_ok ()
+    | Error _ as err -> Lwt.return err
 
   exception Found of (Hash.t * (Crc32.t * int64))
 
   let lookup t hash =
-    Lwt_mvar.take t.packs >>= fun packs ->
-    Lwt_mvar.put t.packs packs >|= fun () ->
-    try Graph.iter (fun hash_pack -> function
-        | Loaded { idx; _ }
-        | Exists { idx; _ } ->
-          (match IDec.find idx hash with
-           | Some (crc32, offset) -> raise (Found (hash_pack, (crc32, offset)))
-           | None -> ())
-        | Total { info; _ } ->
-          (try let crc32, offset = PInfo.Map.find hash info.PInfo.tree in
-               raise (Found (hash_pack, (crc32, offset)))
-           with Not_found -> ()))
-        packs;
-      None
-    with Found (hash_pack, offset) ->
-      Some (hash_pack, offset)
+    let jump0 hash = function
+      | Some (crc, abs_off) -> raise (Found (hash, (crc, abs_off)))
+      | None -> () in
+    let jump1 hash = function
+      | Some (crc, abs_off, _) -> raise (Found (hash, (crc, abs_off)))
+      | None -> () in
+    try
+      Hashtbl.iter
+        (fun hash_pack -> function
+           | Exists exists -> Exists.lookup exists hash |> jump0 hash_pack
+           | Loaded loaded -> Loaded.lookup loaded hash |> jump0 hash_pack
+           | Resolved resolved -> Resolved.lookup resolved hash |> jump0 hash_pack
+           | Total total -> Total.lookup total hash |> jump1 hash_pack)
+        t.packs; None
+    with Found v -> Some v
 
   let mem t hash =
-    lookup t hash >|= function
+      Hashtbl.fold (fun hash_pack -> function
+          | Exists exists -> (||) (Exists.mem exists hash)
+          | Loaded loaded -> (||) (Loaded.mem loaded hash)
+          | Resolved resolved -> (||) (Resolved.mem resolved hash)
+          | Total total -> (||) (Total.mem total hash))
+        t.packs false
+
+  let mem t hash =
+    lookup t hash |> function
     | Some _ -> true
     | None   -> false
 
-  let list t =
-    Lwt_mvar.take t.packs >>= fun packs ->
-    Lwt_mvar.put t.packs packs >|= fun () ->
-    Graph.fold (fun _ -> function
-        | Loaded { idx; _ } ->
-          IDec.fold idx (fun hash _ acc -> hash :: acc)
-        | Exists { idx; _ } ->
-          IDec.fold idx (fun hash _ acc -> hash :: acc)
-        | Total { info; _ } ->
-          fun acc ->
-            PInfo.Map.fold (fun hash _ acc ->
-                hash :: acc
-              ) info.PInfo.tree acc
-      ) packs []
+  let read ~root ~read_loose ~to_result ~ztmp ~window fs r t hash =
+    let read_and_exclude hash_pack = read_and_exclude ~root ~read_loose fs t [ hash_pack ] in
+    let read_inflated hash_pack = read_and_exclude hash_pack in
 
-  let read ~root ~ztmp ~window t hash =
-    lookup t hash >>= function
-    | None -> Lwt.return Error.(v err_not_found)
-    | Some (pack_hash, _) ->
-      Lwt_mvar.take t.packs >>= fun packs ->
-      Lwt_mvar.put t.packs packs >>= fun () ->
-      match Graph.find pack_hash packs with
-      | Exists { idx; fdi; }  ->
-        (load_partial ~root t pack_hash idx fdi >>= function
-          | Ok loaded ->
-            merge t loaded.info >>= fun () ->
-            Lwt_mvar.take t.packs >>= fun packs ->
-            Lwt_mvar.put t.packs (Graph.add pack_hash (Loaded loaded) packs) >>= fun () ->
-            Lwt_mvar.take t.buffers >>= fun buffers ->
-            let length = Cstruct.len buffers.hunks / buffers.depth in
-            RPDec.get_from_hash
-              ~htmp:(Array.init buffers.depth (fun i -> Cstruct.sub buffers.hunks (i * length) length))
-              loaded.decoder hash buffers.objects ztmp window
-            >>!= (fun err -> Lwt.return (`Pack_decoder err)) >>= fun ret ->
-            Lwt_mvar.put t.buffers buffers >|= fun () ->
-            ret
-          | Error _ as err -> Lwt.return err)
+    (* XXX(dinosaure): [read_inflated] pourrait être optimiser. Son contexte
+       d'utilisation concerne la troisième /pass/ où un commentaire signale
+       l'utilisation explicite de [read_and_exclude] en lieu et place d'une
+       fonction plus optimisé (à propos de l'allocation). *)
+
+    let promote_loaded fs r (hash_pack, loaded) obj =
+      Resolved.make_from_loaded ~read_and_exclude:(read_and_exclude hash_pack) ~ztmp ~window fs r loaded >>= function
+      | Ok resolved ->
+        Hashtbl.replace t.packs hash_pack (Resolved resolved);
+        Lwt.return_ok obj
+      | Error _ as err -> Lwt.return err in
+
+    let return_loaded fs r loaded = function
+      | `Return ret -> Lwt.return_ok ret
+      | `Error err -> Lwt.return_error err
+      | `Promote obj -> promote_loaded fs r loaded obj in
+
+    let promote_resolved fs r (hash_pack, resolved) obj =
+      Total.make ~root ~ztmp ~window ~read_inflated:(read_inflated hash_pack) fs r resolved >>= function
+      | Ok total ->
+        Hashtbl.replace t.packs hash_pack (Total total);
+        Lwt.return_ok obj
+      | Error _ as err -> Lwt.return err in
+
+    let return_resolved fs r resolved = function
+      | `Return ret -> Lwt.return_ok ret
+      | `Error err -> Lwt.return_error err
+      | `Promote obj -> promote_resolved fs r resolved obj in
+
+    lookup t hash |> function
+    | None -> Lwt.return_error `Not_found
+    | Some (hash_pack, _) ->
+      match Hashtbl.find t.packs hash_pack with
       | Loaded loaded ->
-        Lwt_mvar.take t.buffers >>= fun buffers ->
-        let length = Cstruct.len buffers.hunks / buffers.depth in
-        RPDec.get_from_hash
-          ~htmp:(Array.init buffers.depth (fun i ->
-              Cstruct.sub buffers.hunks (i * length) length))
-          loaded.decoder hash buffers.objects ztmp window
-        >>!= (fun err -> Lwt.return (`Pack_decoder err))
-        >>= fun ret -> Lwt_mvar.put t.buffers buffers
-        >|= fun () -> ret
-      | Total { decoder; _ } ->
-        Lwt_mvar.take t.buffers >>= fun buffers ->
-        let length = Cstruct.len buffers.hunks / buffers.depth in
-        RPDec.get_from_hash
-          ~htmp:(Array.init buffers.depth (fun i ->
-              Cstruct.sub buffers.hunks (i * length) length))
-          decoder hash buffers.objects ztmp window
-        >>!= (fun err -> Lwt.return (`Pack_decoder err)) >>= fun ret ->
-        Lwt_mvar.put t.buffers buffers >|= fun () ->
-        ret
-      | exception Not_found ->
-        (* XXX(dinosaure): could appear in only one case: if the
-           version of the [t.packs] in [lookup_p] has the pack but
-           something (like an error) appeared with this pack and
-           deleted it in the current version of [t.packs] took by this
-           function.
-
-           So, if this case appears, that means the pack file expected
-           is malformed (and inner objects are losted with it). *)
-        Lwt.return (Error `Not_found)
-
-  let size ~root ~ztmp ~window t hash =
-    lookup t hash >>= function
-    | None -> Lwt.return (Error `Not_found)
-    | Some (pack_hash, _) ->
-      Lwt_mvar.take t.packs >>= fun packs ->
-      Lwt_mvar.put t.packs packs >>= fun () ->
-      match Graph.find pack_hash packs with
-      | Exists { idx; fdi; }  ->
-        (load_partial ~root t pack_hash idx fdi >>= function
+        Loaded.read ~root r ~to_result ~ztmp ~window loaded hash
+        >>= return_loaded fs r (hash_pack, loaded)
+      | Exists exists ->
+        (Loaded.make ~root ~read_and_exclude:(read_and_exclude exists.Exists.hash_pack) fs exists >>= function
+          | Error _ as err -> Lwt.return err
           | Ok loaded ->
-            merge t loaded.info >>= fun () ->
-            Lwt_mvar.take t.packs >>= fun packs ->
-            Lwt_mvar.put t.packs (Graph.add pack_hash (Loaded loaded) packs) >>= fun () ->
-            Lwt_mvar.take t.buffers >>= fun buffers ->
-            RPDec.length loaded.decoder hash ztmp window
-            >>!= (fun err -> Lwt.return (`Pack_decoder err)) >>= fun ret ->
-            Lwt_mvar.put t.buffers buffers >>= fun () ->
-            Lwt.return ret
-          | Error _ as err -> Lwt.return err)
-      | Loaded loaded ->
-        Lwt_mvar.take t.buffers >>= fun buffers ->
-        RPDec.length loaded.decoder hash ztmp window
-        >>!= (fun err -> Lwt.return (`Pack_decoder err)) >>= fun ret ->
-        Lwt_mvar.put t.buffers buffers >>= fun () ->
-        Lwt.return ret
-      | Total { decoder; _ } ->
-        Lwt_mvar.take t.buffers >>= fun buffers ->
-        RPDec.length decoder hash ztmp window
-        >>!= (fun err -> Lwt.return (`Pack_decoder err)) >>= fun ret ->
-        Lwt_mvar.put t.buffers buffers >>= fun () ->
-        Lwt.return ret
-      | exception Not_found ->
-        Lwt.return (Error `Not_found)
+            Hashtbl.replace t.packs hash_pack (Loaded loaded);
+            Loaded.read ~root r ~to_result ~ztmp ~window loaded hash
+            >>= return_loaded fs r (hash_pack, loaded))
+      | Resolved resolved ->
+        Resolved.read ~ztmp ~window ~to_result resolved hash >>= return_resolved fs r (hash_pack, resolved)
+      | Total total ->
+        Total.read ~ztmp ~window ~to_result total hash >>= function
+        | `Error err -> Lwt.return_error err
+        | `Return obj -> Lwt.return_ok obj
+
+  let size ~root ~read_loose ~ztmp ~window fs t hash =
+    let read_and_exclude hash_pack = read_and_exclude ~root ~read_loose fs t [ hash_pack ] in
+
+    lookup t hash |> function
+    | None -> Lwt.return_error `Not_found
+    | Some (hash_pack, _) ->
+      match Hashtbl.find t.packs hash_pack with
+      | Exists exists ->
+        (Loaded.make ~root ~read_and_exclude:(read_and_exclude exists.Exists.hash_pack) fs exists >>= function
+          | Error _ as err -> Lwt.return err
+          | Ok loaded ->
+            Hashtbl.replace t.packs hash_pack (Loaded loaded);
+            Loaded.size loaded ~ztmp ~window hash)
+      | Loaded loaded -> Loaded.size loaded ~ztmp ~window hash
+      | Resolved resolved -> Resolved.size resolved ~ztmp ~window hash
+      | Total total -> Total.size total ~ztmp ~window hash
+
+  let fold f t a =
+    Hashtbl.fold (fun hash_pack pack acc -> match pack with
+        | Exists exists -> Exists.fold f exists acc
+        | Loaded loaded -> Loaded.fold f loaded acc
+        | Resolved resolved -> Resolved.fold f resolved acc
+        | Total total -> Total.fold f total acc)
+      t.packs a
+
+  let list t = fold (fun hash _ acc ->
+      if List.exists (Hash.equal hash) acc
+      then acc else hash :: acc)
+      t []
 end

--- a/src/git/pack_info.ml
+++ b/src/git/pack_info.ml
@@ -38,6 +38,8 @@ sig
     | Internal of { abs_off: int64; length: int; }
     | Delta of { hunks_descr: HDec.hunks; inserts: int; depth: int; from: delta; }
 
+  val pp_delta: delta Fmt.t
+
   type path = Load of int | Patch of { hunks: int; target: int; src: path; }
 
   type 'a t =
@@ -102,6 +104,23 @@ module Make
     | Unresolved of { hash: Hash.t; length: int; }
     | Internal   of { abs_off: int64; length: int; }
     | Delta      of { hunks_descr: HDec.hunks; inserts: int; depth: int; from: delta; }
+
+  let rec pp_delta ppf = function
+    | Unresolved { hash; length; } ->
+      Fmt.pf ppf "(Unresolved@ { @[<hov>hash = %a;@ \
+                  length = %d;@] })"
+        Hash.pp hash length
+    | Internal { abs_off; length; } ->
+      Fmt.pf ppf "(Internal { @[<hov>abs_off = %Ld;@ \
+                  length = %d;@] })"
+        abs_off length
+    | Delta { hunks_descr; inserts; depth; from; } ->
+      Fmt.pf ppf "(Delta { @[<hov>hunks_descr = %a;@ \
+                  inserts = %d;@ \
+                  depth = %d;@ \
+                  delta = %a;@] })"
+        HDec.pp_hunks hunks_descr
+        inserts depth pp_delta from
 
   type 'a t =
     { index : (Hash.t, Crc32.t * int64 * int) Hashtbl.t

--- a/src/git/pack_info.ml
+++ b/src/git/pack_info.ml
@@ -145,20 +145,18 @@ module Make
       Load x ->
       Patch { hunks = inserts; target = max x target_length; src = Load source_length }
     | Delta { hunks_descr = { HDec.reference = HDec.Offset rel_off
-                            ; source_length
                             ; target_length
                             ; _ }
-            ; inserts; _ },
+            ; inserts; from; _ },
       Patch { hunks; target; src; } ->
       let abs_off = Int64.sub abs_off rel_off in
-      let src = merge abs_off (Internal { abs_off; length = source_length; }) src in
+      let src = merge abs_off from src in
       Patch { hunks = max hunks inserts; target = max target target_length; src; }
-    | Delta { hunks_descr = { HDec.reference = HDec.Hash hash
-                            ; source_length
+    | Delta { hunks_descr = { HDec.reference = HDec.Hash _
                             ; target_length; _ }
-            ; inserts; _ },
+            ; inserts; from; _ },
       Patch { hunks; target; src; } ->
-      let src = merge 0L (Unresolved { hash; length = source_length; }) src in
+      let src = merge 0L from src in
       (* XXX(dinosaure): because source is unresolved, we cannot know [abs_off]
          but it does not matter for merging. *)
       Patch { hunks = max hunks inserts; target = max target target_length; src; }

--- a/src/git/pack_info.ml
+++ b/src/git/pack_info.ml
@@ -96,8 +96,6 @@ module Make
     | `PDec err ->
       Fmt.pf ppf "Got an error while decoding PACK stream: %a" PDec.pp_error err
 
-  let option_default a v = match a with Some v -> v | None -> v
-
   type path = Load of int | Patch of { hunks: int; target: int; src: path; }
 
   type delta =

--- a/src/git/pack_info.ml
+++ b/src/git/pack_info.ml
@@ -19,8 +19,6 @@ module type S =
 sig
   module Hash: S.HASH
   module Inflate: S.INFLATE
-  module Graph: Map.S with type key = int64
-  module Map: Map.S with type key = Hash.t
 
   module HDec: Unpack.H with module Hash := Hash
   module PDec: Unpack.P
@@ -35,51 +33,30 @@ sig
 
   val pp_error: error Fmt.t
 
-  module Partial:
-  sig
-    type t =
-      { hash  : Hash.t
-      ; delta : (int64 * HDec.hunks) list }
-  end
+  type delta =
+    | Unresolved of { hash: Hash.t; length: int; }
+    | Internal of { abs_off: int64; length: int; }
+    | Delta of { hunks_descr: HDec.hunks; inserts: int; depth: int; from: delta; }
 
-  module Full:
-  sig
-    type t =
-      { hash : Hash.t
-      ; thin : bool }
-  end
-
-  type partial = [ `Partial of Partial.t ]
-  and empty    = [ `Empty of Hash.t ]
-  and full     = [ `Full of Full.t ]
-
-  type state =
-    [ empty
-    | partial
-    | full ]
+  type path = Load of int | Patch of { hunks: int; target: int; src: path; }
 
   type 'a t =
-    { max_length_object       : int
-    ; max_length_insert_hunks : int
-    ; max_depth               : int
-    ; tree                    : (Crc32.t * Int64.t) Map.t
-    ; graph                   : (int * Hash.t option) Graph.t
-    ; state                   : 'a }
-  constraint 'a = [< state ]
+    { index : (Hash.t, Crc32.t * int64 * int) Hashtbl.t
+    ; delta : (int64, delta) Hashtbl.t
+    ; hash_pack : Hash.t
+    ; state : 'a }
+  constraint 'a = [< `Pass | `Normalized of path | `Resolved of path ]
 
-  val v:
-       ?max_length_object:int
-    -> ?max_length_insert_hunks:int
-    -> ?tree:(Crc32.t * int64) Map.t
-    -> ?graph:(int * Hash.t option) Graph.t
-    -> Hash.t -> [> empty ] t
+  val v: Hash.t -> [ `Pass ] t
+  val normalize: length:int -> [ `Pass ] t -> [ `Normalized of path ] t
+  val resolve: length:int -> [ `Normalized of path ] t -> [ `Resolved of path ] t
 
-  val from_stream:
+  val first_pass:
        ztmp:Cstruct.t
     -> window:Inflate.window
-    -> [> empty ] t
+    -> ?idx:(Hash.t -> (Crc32.t * int64) option)
     -> (unit -> Cstruct.t option Lwt.t)
-    -> (partial t, error) result Lwt.t
+    -> ([ `Normalized of path ] t, error) result Lwt.t
 end
 
 module Make
@@ -94,19 +71,13 @@ module Make
        and module HDec := HDec
        and module PDec := PDec
 = struct
-  module Log =
-  struct
-    let src = Logs.Src.create "git.pack-info" ~doc:"logs git's pack-info event"
-    include (val Logs.src_log src : Logs.LOG)
-  end
+  let src = Logs.Src.create "git.pack-info" ~doc:"logs git's pack-info event"
+  module Log = (val Logs.src_log src : Logs.LOG)
 
   module Hash = Hash
   module Inflate = Inflate
   module HDec = HDec
   module PDec = PDec
-
-  module Graph = Map.Make(Int64)
-  module Map = Map.Make(Hash)
 
   type error =
     [ `Unexpected_end_of_input
@@ -123,51 +94,65 @@ module Make
     | `PDec err ->
       Fmt.pf ppf "Got an error while decoding PACK stream: %a" PDec.pp_error err
 
-  module Partial =
-  struct
-    type t =
-      { hash : Hash.t
-      ; delta : (int64 * HDec.hunks) list }
-  end
-
-  module Full =
-  struct
-    type t =
-      { hash : Hash.t
-      ; thin : bool }
-  end
-
-  type partial = [ `Partial of Partial.t ]
-  and empty    = [ `Empty of Hash.t ]
-  and full     = [ `Full of Full.t ]
-
-  type state =
-    [ empty
-    | partial
-    | full ]
-
-  type 'a t =
-    { max_length_object       : int
-    ; max_length_insert_hunks : int
-    ; max_depth               : int
-    ; tree                    : (Crc32.t * Int64.t) Map.t
-    ; graph                   : (int * Hash.t option) Graph.t
-    ; state                   : 'a }
-    constraint 'a = [< state ]
-
   let option_default a v = match a with Some v -> v | None -> v
 
-  let v ?max_length_object ?max_length_insert_hunks ?tree ?graph hash =
-    { max_length_object = option_default max_length_object 0
-    ; max_length_insert_hunks = option_default max_length_insert_hunks 0
-    ; max_depth = 1
-    ; tree = option_default tree Map.empty
-    ; graph = option_default graph Graph.empty
-    ; state = `Empty hash }
+  type path = Load of int | Patch of { hunks: int; target: int; src: path; }
 
-  let from_stream ~ztmp ~window info stream =
+  type delta =
+    | Unresolved of { hash: Hash.t; length: int; }
+    | Internal   of { abs_off: int64; length: int; }
+    | Delta      of { hunks_descr: HDec.hunks; inserts: int; depth: int; from: delta; }
+
+  type 'a t =
+    { index : (Hash.t, Crc32.t * int64 * int) Hashtbl.t
+    ; delta : (int64, delta) Hashtbl.t
+    ; hash_pack : Hash.t
+    ; state : 'a }
+    constraint 'a = [< `Pass | `Normalized of path | `Resolved of path ]
+
+  let v hash_pack =
+    { index = Hashtbl.create 128
+    ; delta = Hashtbl.create 128
+    ; hash_pack
+    ; state = `Pass }
+
+  let rec merge abs_off path acc = match path, acc with
+    | Unresolved { length; _ }, Load x
+    | Internal { length; _ },   Load x -> Load (max length x)
+    | Unresolved { length; _ }, Patch { hunks; target; src; }
+    | Internal { length; _ },   Patch { hunks; target; src; } -> Patch { hunks; target = max target length; src; }
+    | Delta { hunks_descr = { HDec.source_length
+                            ; target_length
+                            ;  _ }
+            ; inserts; _ },
+      Load x ->
+      Patch { hunks = inserts; target = max x target_length; src = Load source_length }
+    | Delta { hunks_descr = { HDec.reference = HDec.Offset rel_off
+                            ; source_length
+                            ; target_length
+                            ; _ }
+            ; inserts; _ },
+      Patch { hunks; target; src; } ->
+      let abs_off = Int64.sub abs_off rel_off in
+      let src = merge abs_off (Internal { abs_off; length = source_length; }) src in
+      Patch { hunks = max hunks inserts; target = max target target_length; src; }
+    | Delta { hunks_descr = { HDec.reference = HDec.Hash hash
+                            ; source_length
+                            ; target_length; _ }
+            ; inserts; _ },
+      Patch { hunks; target; src; } ->
+      let src = merge 0L (Unresolved { hash; length = source_length; }) src in
+      (* XXX(dinosaure): because source is unresolved, we cannot know [abs_off]
+         but it does not matter for merging. *)
+      Patch { hunks = max hunks inserts; target = max target target_length; src; }
+
+  let normalize paths = Hashtbl.fold merge paths (Load 0)
+
+  let first_pass ~ztmp ~window ?(idx = (fun _hash -> None)) stream =
     let state = PDec.default ztmp window in
     let empty = Cstruct.create 0 in
+    let index = Hashtbl.create 128 in (* hash: crc32, absolute offset *)
+    let delta = Hashtbl.create 128 in
 
     let ctx_with_header chunk state =
       let ctx = Hash.Digest.init () in
@@ -178,26 +163,23 @@ module Make
            | PDec.Tree -> "tree"
            | PDec.Blob -> "blob"
            | _ -> assert false)
-          (PDec.length state)
-      in
+          (PDec.length state) in
 
       Hash.Digest.feed ctx (Cstruct.of_string hdr);
       Hash.Digest.feed ctx chunk;
-      ctx
-    in
+      ctx in
 
     let open Lwt.Infix in
 
-    let rec go ?(src = empty) ?ctx ?insert_hunks partial info state = match PDec.eval src state with
+    let rec go ?(src = empty) ?ctx ?insert_hunks state = match PDec.eval src state with
       | `Hunk (state, HDec.Insert raw) ->
         let insert_hunks = match insert_hunks with
           | Some count -> count + Cstruct.len raw
-          | None -> Cstruct.len raw
-        in
+          | None -> Cstruct.len raw in
 
-        go ~src ~insert_hunks partial info (PDec.continue state)
+        go ~src ~insert_hunks (PDec.continue state)
       | `Hunk (state, _) ->
-        go ~src ?ctx ?insert_hunks partial info (PDec.continue state)
+        go ~src ?ctx ?insert_hunks (PDec.continue state)
       | `Error (_, err) ->
         Lwt.return (Error (`PDec err))
       | `Flush state ->
@@ -205,85 +187,44 @@ module Make
 
         let ctx = match ctx with
           | Some ctx -> Hash.Digest.feed ctx (Cstruct.sub chunk 0 len); ctx
-          | None -> ctx_with_header (Cstruct.sub chunk 0 len) state
-        in
+          | None -> ctx_with_header (Cstruct.sub chunk 0 len) state in
 
-        go ~src ~ctx partial info (PDec.flush 0 (Cstruct.len chunk) state)
+        go ~src ~ctx (PDec.flush 0 (Cstruct.len chunk) state)
       | `Object state ->
-        let hash = match PDec.kind state, ctx with
-          | (PDec.Commit
-            | PDec.Tree
-            | PDec.Tag
-            | PDec.Blob), Some ctx -> Some (Hash.Digest.get ctx)
-          | (PDec.Commit
-            | PDec.Tree
-            | PDec.Tag
-            | PDec.Blob), None ->
-            let ctx = ctx_with_header empty state in
-            Some (Hash.Digest.get ctx)
-          | _ -> None
-        in
+        let () = match PDec.kind state with
+          | PDec.Hunk ({ HDec.reference = HDec.Offset rel_off; _ } as hunks_descr) ->
+            let abs_off = Int64.(sub (PDec.offset state) rel_off) in
+            let inserts = match insert_hunks with Some x -> x | None -> 0 in
 
-        let tree = match hash with
-          | Some hash ->
-            Map.add hash (PDec.crc state, PDec.offset state) info.tree
-          | None -> info.tree
-        in
+            let from =
+              try Hashtbl.find delta abs_off
+              with Not_found -> invalid_arg "invalid pack stream" in
+            (* XXX(dinosaure): if we can not find source from absolute offset,
+               that means pack stream is invalid - offset points to previous (already saved) entry in any case. *)
+            let depth_source = match from with Delta { depth; _ } -> depth | _ -> 0 in
+            Hashtbl.add delta (PDec.offset state) (Delta { hunks_descr; inserts; depth = depth_source + 1; from; })
+          | PDec.Hunk ({ HDec.reference = HDec.Hash hash; source_length; _ } as hunks_descr) ->
+            let inserts = match insert_hunks with Some x -> x | None -> 0 in
 
-        let max_length_insert_hunks = match PDec.kind state, insert_hunks with
-          | PDec.Hunk _, Some insert_hunks ->
-            max info.max_length_insert_hunks insert_hunks
-          | PDec.Hunk _, None ->
-            max info.max_length_insert_hunks 0
-          | _ -> info.max_length_insert_hunks
-        in
+            let from =
+              try let _, abs_off = match idx hash with
+                  | Some x -> x
+                  | None -> Hashtbl.find index hash |> fun (crc, abs_off, _) -> (crc, abs_off) in
+                Hashtbl.find delta abs_off
+              with Not_found -> Unresolved { hash; length = source_length; } in
+            let depth_source = match from with Delta { depth; _ } -> depth | _ -> 0 in
+            Hashtbl.add delta (PDec.offset state) (Delta { hunks_descr; inserts; depth = depth_source + 1; from; })
+          | _ -> match ctx with
+            | Some ctx ->
+              Hashtbl.add index (Hash.Digest.get ctx) (PDec.crc state, PDec.offset state, PDec.length state);
+              Hashtbl.add delta (PDec.offset state) (Internal { abs_off = PDec.offset state; length = PDec.length state; })
+            | None ->
+              let ctx = ctx_with_header empty state in
+              Hashtbl.add index (Hash.Digest.get ctx) (PDec.crc state, PDec.offset state, PDec.length state);
+              Hashtbl.add delta (PDec.offset state) (Internal { abs_off = PDec.offset state; length = PDec.length state; }) in
 
-        let max_length_object = match PDec.kind state with
-          | (PDec.Commit
-            | PDec.Tree
-            | PDec.Tag
-            | PDec.Blob) ->
-            max info.max_length_object (PDec.length state)
-          | PDec.Hunk hunks_descr ->
-            let max' = max
-                hunks_descr.HDec.source_length
-                hunks_descr.HDec.target_length in
-            max info.max_length_object max'
-        in
-
-        let graph = match PDec.kind state with
-          | PDec.Hunk ({ HDec.reference = HDec.Offset rel_off; _ }) ->
-            let depth_source, _ =
-              try Graph.find Int64.(sub (PDec.offset state) rel_off) info.graph
-              with Not_found -> 0, None
-            in
-
-            Graph.add (PDec.offset state) (depth_source + 1, hash) info.graph
-          | PDec.Hunk ({ HDec.reference = HDec.Hash hash; _ }) ->
-            let depth_source, _ =
-              try let _, abs_off = Map.find hash info.tree in
-                  Graph.find abs_off info.graph
-              with Not_found -> 0, None
-            in
-
-            Graph.add (PDec.offset state) (depth_source + 1, Some hash) info.graph
-          | _ ->
-            Graph.add (PDec.offset state) (0, hash) info.graph
-        in
-
-        let partial = match PDec.kind state with
-          | PDec.Hunk hunks_descr ->
-            (PDec.offset state, hunks_descr) :: partial
-          | _ -> partial
-        in
-
-        go ~src partial
-          { info with max_length_insert_hunks
-                    ; max_length_object
-                    ; tree
-                    ; graph }
-          (PDec.next_object state)
-      | `End (_, hash) ->
+        go ~src (PDec.next_object state)
+      | `End (_, hash_pack) ->
         (stream () >>= function
           | Some raw ->
             Log.err (fun l -> l ~header:"from_stream" "Expected end of pack stream but retrieve: %a."
@@ -293,13 +234,7 @@ module Make
           | None ->
             Log.debug (fun l -> l ~header:"from_stream" "End of the PACK stream.");
 
-            Lwt.return
-              (Ok { info with state = `Partial { Partial.hash; delta = List.rev partial; }
-                            (* XXX(dinosaure): [List.rev] is very
-                               important to keep the topological
-                               order for any next computation of
-                               this pack file. *)
-                            ; max_depth = Graph.fold (fun _ (depth, _) acc -> max depth acc) info.graph 1 }))
+            Lwt.return (Ok { index; delta; hash_pack; state = `Normalized (normalize delta) }))
       | `Await state ->
         Log.debug (fun l -> l ~header:"from_stream" "Waiting more input.");
 
@@ -307,11 +242,21 @@ module Make
         | Some src ->
           Log.debug (fun l -> l ~header:"from_stream" "Receive a chunk of the PACK stream (length: %d)."
                         (Cstruct.len src));
-          go ~src ?ctx ?insert_hunks partial info (PDec.refill 0 (Cstruct.len src) state)
+          go ~src ?ctx ?insert_hunks (PDec.refill 0 (Cstruct.len src) state)
         | None ->
           Log.err (fun l -> l ~header:"from_stream" "Receive end of the PACK stream.");
           Lwt.return (Error `Unexpected_end_of_input)
     in
 
-    go [] info state
+    go state
+
+  let resolve ~length t =
+    if Hashtbl.length t.index = length
+    then { t with state = `Resolved (normalize t.delta) }
+    else invalid_arg "promote: invalid argument"
+
+  let normalize ~length t =
+    if Hashtbl.length t.delta = length
+    then { t with state = `Normalized (normalize t.delta) }
+    else invalid_arg "promote: invalid argument"
 end

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -551,12 +551,12 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
           Lwt_mutex.lock mutex >>= fun () ->
           exec (Lock mutex, fit length)
         | Pack hash_pack ->
-          match Hashtbl.find_opt heap hash_pack with
-          | Some (pool, length') ->
+          match Hashtbl.find heap hash_pack with
+          | (pool, length') ->
             assert (length = length');
 
             Lwt_pool.use pool (fun buffer -> exec (No_lock, buffer))
-          | None ->
+          | exception Not_found ->
             let pool = Lwt_pool.create n (fun () -> Lwt.return (Cstruct.create length)) in
             Hashtbl.add heap hash_pack (pool, length);
             Lwt_pool.use pool (fun buffer -> exec (No_lock, buffer)) in

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -278,7 +278,6 @@ end
 
 module Option = struct
   let get ~default = function Some x -> x | None -> default
-  let map f a = match a with Some a -> Some (f a) | None -> None
 end
 
 module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -420,8 +420,7 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
   let pp_error ppf = function
     | #LooseImpl.error as err -> Fmt.pf ppf "%a" LooseImpl.pp_error err
     | #PackImpl.error as err -> Fmt.pf ppf "%a" PackImpl.pp_error err
-    | `Delta err -> Fmt.pf ppf "(`Delta %a)" PEnc.Delta.pp_error err
-    | _ -> assert false
+    | `Invalid_reference reference -> Fmt.pf ppf "Invalid reference: %a" Reference.pp reference
 
   let lift_error err = (err :> error)
 

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -79,11 +79,20 @@ module type PACK = sig
   type state
   type error
 
+  type ('mmu, 'location) r =
+    { mmu              : 'mmu
+    ; with_cstruct     : 'mmu -> pack -> int -> (('location * Cstruct.t) -> unit Lwt.t) -> unit Lwt.t
+    ; with_cstruct_opt : 'mmu -> int option -> (('location * Cstruct.t) option -> unit Lwt.t) -> unit Lwt.t
+    ; free             : 'mmu -> 'location -> unit Lwt.t }
+  and pack = Pack of Hash.t | Unrecorded
+
   module Hash: S.HASH
   module FS: S.FS
   module Inflate: S.INFLATE
   module Deflate: S.DEFLATE
-  module HDec: Unpack.H with module Hash = Hash
+
+  module HDec: Unpack.H
+    with module Hash = Hash
   module PDec: Unpack.P
     with module Hash = Hash
      and module Inflate = Inflate
@@ -109,19 +118,18 @@ module type PACK = sig
   val lookup: state -> Hash.t -> (Hash.t * (Crc32.t * int64)) option Lwt.t
   val mem: state -> Hash.t -> bool Lwt.t
   val list: state -> Hash.t list Lwt.t
-  val read: state -> Hash.t -> (t, error) result Lwt.t
+  val read: state -> Hash.t -> (value, error) result Lwt.t
   val size: state -> Hash.t -> (int, error) result Lwt.t
 
   type stream = unit -> Cstruct.t option Lwt.t
-
-  module Graph : Map.S with type key = Hash.t
+  module Map: Map.S with type key = Hash.t
 
   val from: state -> stream -> (Hash.t * int, error) result Lwt.t
   val make: state
     -> ?window:[ `Object of int | `Memory of int ]
     -> ?depth:int
     -> value list
-    -> (stream * (Crc32.t * int64) Graph.t Lwt_mvar.t, error) result Lwt.t
+    -> (stream * (Crc32.t * int64) Map.t Lwt_mvar.t, error) result Lwt.t
 end
 
 module type S = sig
@@ -385,10 +393,15 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
     ; indexes   : CacheIndex.t
     ; revindexes: CacheRevIndex.t }
 
+  type lock =
+    | No_lock
+    | Lock of Lwt_mutex.t
+
   type t =
     { fs          : FS.t
     ; dotgit      : Fpath.t
     ; root        : Fpath.t
+    ; allocation  : ((Hash.t, Cstruct.t Lwt_pool.t * int) Hashtbl.t, lock) PackImpl.r
     ; compression : int
     ; cache       : cache
     ; buffer      : (buffer -> unit Lwt.t) -> unit Lwt.t
@@ -501,10 +514,10 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
 
     module HDec = HDec
     module PDec = PDec
-    module PInfo = PackImpl.PInfo
     module IEnc = PackImpl.IEnc
     module IDec = PackImpl.IDec
     module PEnc = PackImpl.PEnc
+    module PInfo = PackImpl.PInfo
     module RPDec = RPDec
 
     type state = t
@@ -513,14 +526,90 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
     type value = Value.t
     type nonrec error = error
 
+    type ('mmu, 'location) r = ('mmu, 'location) PackImpl.r =
+      { mmu              : 'mmu
+      ; with_cstruct     : 'mmu -> pack -> int -> (('location * Cstruct.t) -> unit Lwt.t) -> unit Lwt.t
+      ; with_cstruct_opt : 'mmu -> int option -> (('location * Cstruct.t) option -> unit Lwt.t) -> unit Lwt.t
+      ; free             : 'mmu -> 'location -> unit Lwt.t }
+    and pack = PackImpl.pack = Pack of Hash.t | Unrecorded
+
+    let default n =
+      let heap = Hashtbl.create 32 in
+      let mutex = Lwt_mutex.create () in
+      let buffer = ref (Cstruct.create 0x8000) in
+
+      let round len nlen =
+        let ilen = ref len in
+        while nlen > !ilen do ilen := 2 * !ilen done; !ilen in
+
+      let fit length =
+        if length > Cstruct.len !buffer
+        then let diff = round (Cstruct.len !buffer) length - (Cstruct.len !buffer) in begin buffer := Cstruct.concat [ !buffer; Cstruct.create diff ]; Cstruct.sub !buffer 0 length end
+        else Cstruct.sub !buffer 0 length in
+
+      let with_cstruct heap pack length (exec:(lock * Cstruct.t) -> unit Lwt.t) = match pack with
+        | Unrecorded ->
+          Lwt_mutex.lock mutex >>= fun () ->
+          exec (Lock mutex, fit length)
+        | Pack hash_pack ->
+          match Hashtbl.find_opt heap hash_pack with
+          | Some (pool, length') ->
+            assert (length = length');
+
+            Lwt_pool.use pool (fun buffer -> exec (No_lock, buffer))
+          | None ->
+            let pool = Lwt_pool.create n (fun () -> Lwt.return (Cstruct.create length)) in
+            Hashtbl.add heap hash_pack (pool, length);
+            Lwt_pool.use pool (fun buffer -> exec (No_lock, buffer)) in
+
+      let with_cstruct_opt _ length_opt exec = match length_opt with
+        | Some length ->
+          if Lwt_mutex.is_locked mutex
+          then exec None
+          else Lwt_mutex.lock mutex >>= fun () -> exec (Some (Lock mutex, fit length))
+        | None -> exec None in
+
+      let free _ = function
+        | Lock mutex' ->
+          assert (mutex == mutex');
+          Lwt_mutex.unlock mutex;
+          Lwt.return_unit
+        | No_lock -> Lwt.return_unit in
+
+      { mmu = heap
+      ; with_cstruct
+      ; with_cstruct_opt
+      ; free }
+
+    let to_result { RPDec.Object.kind; raw; _ } =
+      let open Rresult in
+
+      (match kind with
+       | `Commit -> Value.(Commit.D.to_result raw >>| commit)
+       | `Blob -> Value.(Blob.D.to_result raw >>| blob)
+       | `Tree -> Value.(Tree.D.to_result raw >>| tree)
+       | `Tag -> Value.(Tag.D.to_result raw >>| tag))
+      |> Rresult.R.reword_error (fun err -> (err :> PackImpl.error))
+      |> Lwt.return
+
+    let read_loose t hash =
+      Loose.read_inflated t hash >|= function
+      | Ok v -> Some v
+      | Error err ->
+        Log.err (fun l -> l "Retrieve an error when a PACK file expect an external loose object %a: %a." Hash.pp hash pp_error err);
+        None
+
     let lookup t hash =
       PackImpl.lookup t.engine hash
+      |> Lwt.return
 
     let mem t hash =
       PackImpl.mem t.engine hash
+      |> Lwt.return
 
     let list t =
       PackImpl.list t.engine
+      |> Lwt.return
 
     let read t hash =
       mem t hash >>= function
@@ -528,7 +617,23 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
       | true ->
         with_buffer t @@ fun { ztmp; window; _ } ->
         Log.debug (fun l -> l "Git object %a found in a PACK file." Hash.pp hash);
-        PackImpl.read ~root:t.dotgit ~ztmp ~window t.engine hash
+        PackImpl.read ~root:t.dotgit ~read_loose:(read_loose t) ~to_result ~ztmp ~window t.fs t.allocation t.engine hash
+        >>!= lift_error
+
+    let to_result { RPDec.Object.kind; raw; _ } =
+      let cstruct_copy cs =
+        let ln = Cstruct.len cs in
+        let rs = Cstruct.create ln in
+        Cstruct.blit cs 0 rs 0 ln; rs in
+      Lwt.return_ok (kind, cstruct_copy raw)
+
+    let read_inflated t hash =
+      mem t hash >>= function
+      | false -> Lwt.return (Error `Not_found)
+      | true ->
+        with_buffer t @@ fun { ztmp; window; _ } ->
+        Log.debug (fun l -> l "Git object %a found in a PACK file." Hash.pp hash);
+        PackImpl.read ~root:t.dotgit ~read_loose:(read_loose t) ~to_result ~ztmp ~window t.fs t.allocation t.engine hash
         >>!= lift_error
 
     let size t hash =
@@ -536,7 +641,8 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
       | false -> Lwt.return (Error `Not_found)
       | true ->
         with_buffer t @@ fun { ztmp; window; _ } ->
-        PackImpl.size ~root:t.dotgit ~ztmp ~window t.engine hash >>!= lift_error
+        PackImpl.size ~root:t.dotgit ~read_loose:(read_loose t) ~ztmp ~window t.fs t.engine hash
+        >>!= lift_error
 
     type stream = unit -> Cstruct.t option Lwt.t
 
@@ -544,55 +650,60 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
       let gen () = match Random.int (26 + 26 + 10) with
         | n when n < 26 -> int_of_char 'a' + n
         | n when n < 26 + 26 -> int_of_char 'A' + n - 26
-        | n -> int_of_char '0' + n - 26 - 26
-      in
+        | n -> int_of_char '0' + n - 26 - 26 in
       let gen () = char_of_int (gen ()) in
 
       Bytes.create len |> fun raw ->
       for i = 0 to len - 1 do Bytes.set raw i (gen ()) done;
       Bytes.unsafe_to_string raw
 
-    let to_temp_file fs fmt stream =
+    exception Save of error
+
+    let to_temp_file ?(limit = 50) fs fmt stream =
       let filename_of_pack = fmt (random_string 10) in
-      FS.Dir.temp fs >>= fun temp_dir ->
-      let path = Fpath.(temp_dir / filename_of_pack) in
-      FS.with_open_w fs path @@ fun fd ->
-      Log.debug (fun l -> l "Saving the pack stream to %a" Fpath.pp path);
-      let rec go ?chunk ~call () =
+      FS.Dir.temp fs >>= fun dir ->
+      let path = Fpath.(dir / filename_of_pack) in
+      FS.File.open_w fs path >|= Rresult.R.reword_error (fun err -> Error.FS.err_open path err) >>?= fun fd ->
+      Log.debug (fun l -> l "Saving pack stream to %a." Fpath.pp path);
+
+      let chunk = ref None in
+      let call = ref 0 in
+
+      let stream () =
         Lwt_stream.peek stream >>= function
         | None ->
-          Log.debug (fun l ->l "Pack stream saved to %a" Fpath.pp path);
-          Lwt.return (Ok path)
+          (FS.File.close fd >>= function
+            | Error err -> Lwt.fail (Save Error.(FS.err_close path err))
+            | Ok () -> Lwt.return_none)
         | Some raw ->
-          Log.debug (fun l -> l "Chunk received (length=%d)" (Cstruct.len raw));
-          let off, len = match chunk with
+          let off, len = match !chunk with
             | Some (off, len) -> off, len
-            | None            -> 0, Cstruct.len raw
-          in
+            | None            -> 0, Cstruct.len raw in
           FS.File.write raw ~off ~len fd >>= function
-          | Error err -> Lwt.return Error.(v @@ FS.err_write path err)
-          | Ok 0 when len <> 0 ->
-            if call <> 50 (* XXX(dinosaure): as argument? *)
-            then go ?chunk ~call:(call + 1) ()
-            else Lwt.return Error.(v @@ FS.err_stack path)
-          | Ok n when n = len ->
-            Log.debug (fun l -> l "Consuming a chunk of the pack stream.");
-            Lwt_stream.junk stream >>= fun () ->
-            go ~call:0 ()
-          | Ok n -> go ~chunk:(off + n, len - n) ~call:0 ()
-      in
-      go ~call:0 ()
+          | Error err -> Lwt.fail (Save Error.(FS.err_write path err))
+          | Ok 0 when !call = limit ->
+            Lwt.fail (Save Error.(FS.err_stack path));
+          | Ok 0 ->
+            incr call;
+            Lwt.return_some (Cstruct.sub raw off 0)
+          | Ok n ->
+            if n = len
+            then Lwt_stream.junk stream >>= fun () -> Lwt.return_some (Cstruct.sub raw off n)
+            else begin
+              chunk := Some (off + n, len - n);
+              Lwt.return_some (Cstruct.sub raw off n)
+            end in
 
-    let extern git hash =
-      read git hash >>= function
-      | Ok o ->
-        Lwt.return (Some (o.RPDec.Object.kind, o.RPDec.Object.raw))
-      | Error _ -> Loose.lookup git hash >>= function
-        | None -> Lwt.return None
-        | Some _ ->
-          Loose.read_inflated git hash >|= function
-          | Error #Loose.error -> None
-          | Ok v               -> Some v
+      Lwt.return_ok (path, stream)
+
+    let extern t hash =
+      read_inflated t hash >>= function
+      | Ok v -> Lwt.return_some v
+      | Error _ -> Loose.mem t hash >>= function
+        | false -> Lwt.return_none
+        | true -> Loose.read_inflated t hash >>= function
+          | Error _ -> Lwt.return_none
+          | Ok v -> Lwt.return_some v
 
     module GC =
       Collector.Make(struct
@@ -610,311 +721,21 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
         let contents _ = assert false
       end)
 
-    module Graph = GC.Graph
+    module Map = GC.Graph
 
     let make = GC.make_stream
 
-    let cstruct_copy cs =
-      let ln = Cstruct.len cs in
-      let rs = Cstruct.create ln in
-      Cstruct.blit cs 0 rs 0 ln;
-      rs
-
-    let canonicalize git path_pack decoder_pack fdp ~htmp ~rtmp delta info =
-      let k2k = function
-        | `Commit -> Pack.Kind.Commit
-        | `Blob -> Pack.Kind.Blob
-        | `Tree -> Pack.Kind.Tree
-        | `Tag -> Pack.Kind.Tag
-      in
-      let make acc (hash, (_, offset)) =
-        with_buffer git (fun { ztmp; window; _ } ->
-            RPDec.get_from_offset
-              ~htmp:htmp decoder_pack offset rtmp ztmp window
-          ) >|= function
-        | Error err ->
-          Log.err (fun l ->
-              l ~header:"from" "Retrieve an error when we try to \
-                                resolve the object at the offset %Ld \
-                                in the temporary pack file %a: %a."
-                offset Fpath.pp path_pack RPDec.pp_error err);
-          acc
-        | Ok obj ->
-          let open RPDec.Object in
-          let delta = match obj.from with
-            | External hash        -> Some (PEnc.Entry.From hash)
-            | Direct _             -> None
-            | Offset { offset; _ } ->
-              try
-                let (_, hash) =
-                  PInfo.Graph.find offset info.PInfo.graph
-                in
-                Option.map (fun hash -> PEnc.Entry.From hash) hash
-              with Not_found ->
-                None
-          in
-
-          PEnc.Entry.make hash ?delta
-            (k2k obj.RPDec.Object.kind) obj.RPDec.Object.length
-          :: acc
-      in
-
-      let external_ressources acc =
-        let res = List.fold_left
-          (fun acc (_, hunks_descr) ->
-             let open PInfo in
-
-             match hunks_descr.HDec.reference with
-             | HDec.Hash hash when not (Map.mem hash info.tree) ->
-               (try List.find (Hash.equal hash) acc |> fun _ -> acc
-                with Not_found -> hash :: acc)
-             | _ -> acc)
-          [] delta
-        in
-        Lwt_list.fold_left_s
-          (fun acc hash -> extern git hash >|= function
-             | None -> acc
-             | Some (kind, raw) ->
-               let entry = PEnc.Entry.make hash (k2k kind) (Int64.of_int (Cstruct.len raw)) in
-               entry :: acc)
-          acc res
-      in
-
-      let get hash =
-        if PInfo.Map.mem hash info.PInfo.tree
-        then
-          with_buffer git @@ fun { ztmp; window; _ } ->
-          RPDec.get_with_result_allocation_from_hash
-            ~htmp:htmp
-            decoder_pack
-            hash
-            ztmp window >|= function
-          | Error _ -> None
-          | Ok obj -> (Some obj.RPDec.Object.raw)
-        else extern git hash >|= function
-          | Some (_, raw) -> Some (cstruct_copy raw)
-          | None          -> None
-      in
-
-      let tag _ = false in
-
-      PInfo.Map.bindings info.PInfo.tree
-      |> Lwt_list.fold_left_s make []
-      >>= external_ressources
-      >>= fun entries -> PEnc.Delta.deltas ~memory:false entries get tag 10 50
-      >>= function
-      | Error err -> Lwt.return (Error (`Delta err))
-      | Ok entries ->
-        PackImpl.save_pack_file ~fs:git.fs
-          (Fmt.strf "pack-%s.pack")
-          entries
-          (fun hash ->
-             if PInfo.Map.mem hash info.PInfo.tree
-             then
-               with_buffer git @@ fun { ztmp; window; _ } ->
-               RPDec.get_with_result_allocation_from_hash
-                 ~htmp:htmp
-                 decoder_pack
-                 hash
-                 ztmp window
-               >|= function
-               | Error _ -> None
-               | Ok obj -> (Some (obj.RPDec.Object.raw))
-             else extern git hash >|= function
-               | Some (_, raw) -> Some raw
-               | None -> None)
-        >>!= lift_error
-        >>= function
-        | Error _ as err -> Lwt.return err
-        | Ok (path, sequence, hash_pack) ->
-          (PackImpl.save_idx_file
-             ~fs:git.fs ~root:git.dotgit sequence hash_pack >>!= lift_error)
-          >>= function
-          | Error _ as err -> Lwt.return err
-          | Ok () ->
-            let filename_pack = Fmt.strf "pack-%s.pack" (Hash.to_hex hash_pack) in
-            let dst = Fpath.(git.dotgit / "objects" / "pack" / filename_pack) in
-            (FS.File.move git.fs path dst >|= function
-              | Error err -> Error.(v @@ FS.err_move path dst err)
-              | Ok ()     -> Ok (hash_pack, List.length entries))
-            >>= fun ret ->
-            FS.Mapper.close fdp >|= function
-            | Error sys_err ->
-              Log.err (fun l ->
-                  l "Impossible to close the pack file %a, ignoring: %a."
-                          Fpath.pp path_pack FS.Mapper.pp_error sys_err);
-              ret
-            | Ok () -> ret
-
-    let from git stream =
-      let stream0, stream1 =
-        let stream', push' = Lwt_stream.create () in
-
-        Lwt_stream.from
-          (fun () -> stream () >>= function
-             | Some raw ->
-               Log.debug (fun l ->
-                   l "Dispatch a chunk of the PACK stream (length: %d)."
-                     (Cstruct.len raw));
-               push' (Some (cstruct_copy raw));
-               Lwt.return (Some raw)
-             | None ->
-               Log.debug (fun l ->
-                   l "Dispatch end of the PACK stream.");
-               push' None;
-               Lwt.return None),
-        stream'
-      in
-
-      let info = PInfo.v (Hash.of_hex (String.make (Hash.Digest.length * 2) '0')) in
-
-      (with_buffer git @@ fun { ztmp; window; _ } ->
-       PInfo.from_stream ~ztmp ~window info (fun () -> Lwt_stream.get stream0)
-       >>!= (fun sys_err -> `Pack_info sys_err))
-      >>?= fun info ->
-      to_temp_file git.fs (Fmt.strf "pack-%s.pack") stream1 >>?= fun path ->
-
-      let module Graph = PInfo.Graph in
-
-      FS.Mapper.openfile git.fs path >>= function
-      | Error err ->
-        Lwt.return Error.(v @@ FS.err_open path err)
-      | Ok fdp ->
-        let `Partial { PInfo.Partial.hash = hash_pack;
-                       PInfo.Partial.delta; } = info.PInfo.state
-        in
-
-        let htmp =
-          let raw = Cstruct.create (info.PInfo.max_length_insert_hunks * (info.PInfo.max_depth + 1)) in
-          Array.init
-            (info.PInfo.max_depth + 1)
-            (fun i -> Cstruct.sub raw (i * info.PInfo.max_length_insert_hunks) info.PInfo.max_length_insert_hunks)
-        in
-
-        let rtmp =
-          Cstruct.create info.PInfo.max_length_object,
-          Cstruct.create info.PInfo.max_length_object,
-          info.PInfo.max_length_object
-        in
-
-        RPDec.make fdp
-          (fun _ -> None)
-          (fun hash ->
-            try Some (PInfo.Map.find hash info.PInfo.tree)
-            with Not_found -> None)
-          (* XXX(dinosaure): this function will be updated. *)
-          (fun _ -> None)
-          (fun hash -> extern git hash)
-        >>= function
-        | Error err ->
-          Lwt.return Error.(v @@ FS.err_length path err)
-        | Ok decoder ->
-          let hash_of_object obj =
-            let ctx = Hash.Digest.init () in
-            let hdr = Fmt.strf "%s %Ld\000"
-                (match obj.RPDec.Object.kind with
-                 | `Commit -> "commit"
-                 | `Blob   -> "blob"
-                 | `Tree   -> "tree"
-                 | `Tag    -> "tag")
-                obj.RPDec.Object.length
-            in
-
-            Hash.Digest.feed ctx (Cstruct.of_string hdr);
-            Hash.Digest.feed ctx obj.RPDec.Object.raw;
-            Hash.Digest.get ctx
-          in
-
-          let crc obj = match obj.RPDec.Object.from with
-            | RPDec.Object.Offset { crc; _ } -> crc
-            | RPDec.Object.External _ ->
-              raise (Invalid_argument "Try to get the CRC-32 checksum from an external ressource.")
-            | RPDec.Object.Direct { crc; _ } -> crc
-          in
-
-          Lwt_list.fold_left_s
-            (fun ((decoder, tree, graph) as acc) (offset, hunks_descr) ->
-               with_buffer git (fun { ztmp; window; _ } ->
-               RPDec.get_from_offset
-                 ~htmp:htmp
-                 decoder
-                 offset
-                 rtmp ztmp window) >>= function
-               | Ok obj ->
-                 let hash = hash_of_object obj in
-                 let crc = crc obj in
-                 let tree = PInfo.Map.add hash (crc, offset) tree in
-
-                 let graph =
-                   let open PInfo in
-
-                   let depth_source, _ = match hunks_descr.HDec.reference with
-                     | HDec.Offset rel_off ->
-                       (try Graph.find Int64.(sub offset rel_off) graph
-                        with Not_found -> 0, None)
-                     | HDec.Hash hash_source ->
-                       try let _, abs_off = Map.find hash_source tree in
-                           Graph.find abs_off graph
-                       with Not_found -> 0, None
-                   in
-
-                   Graph.add offset (depth_source + 1, Some hash) graph
-                 in
-
-                 Lwt.return
-                   (RPDec.update_idx (fun key ->
-                        try Some (PInfo.Map.find key tree)
-                        with Not_found -> None) decoder,
-                    tree, graph)
-               | Error err ->
-                 Log.err (fun l -> l ~header:"from" "Retrieve an error when we try to \
-                                                     resolve the object at the offset %Ld \
-                                                     in the temporary pack file %a: %a."
-                             offset Fpath.pp path RPDec.pp_error err);
-                 Lwt.return acc)
-            (decoder, info.PInfo.tree, info.PInfo.graph) delta
-          >>= fun (decoder, tree', graph') ->
-
-          let is_total =
-            PInfo.Graph.for_all
-              (fun _ -> function (_, Some _) -> true | (_, None) -> false)
-              graph'
-          in
-
-          if is_total
-          then
-            Lwt_list.for_all_p
-              (fun (_, hunks_descr) ->
-                 let open PInfo in
-
-                 match hunks_descr.HDec.reference with
-                 | HDec.Offset _ -> Lwt.return true
-                 | HDec.Hash hash ->
-                   Lwt.return (Map.mem hash tree'))
-              delta
-            >>= fun is_not_thin ->
-            if is_not_thin
-            then begin
-              let info =
-                { info with PInfo.tree = tree'
-                          ; PInfo.graph = graph'
-                          ; PInfo.state =
-                              `Full { PInfo.Full.thin = not is_not_thin
-                                    ; PInfo.Full.hash = hash_pack } }
-              in
-
-              (FS.Mapper.close fdp >>!= Error.FS.err_close path)
-              >>?= fun () ->
-              (PackImpl.add_total ~root:git.dotgit git.engine path info >>!= lift_error)
-            end else
-              canonicalize git path decoder fdp ~htmp ~rtmp delta info
-              >>?= fun (hash, count) ->
-              (PackImpl.add_exists ~root:git.dotgit git.engine hash >>!= lift_error)
-              >>?= fun () -> Lwt.return (Ok (hash, count))
-          else
-            Fmt.kstrf (fun x ->  Lwt.return (Error (`Integrity x)))
-              "Impossible to get all informations from the file: %a."
-              Hash.pp hash_pack
+    let from t stream =
+      Lwt.catch
+        (fun () ->
+           let stream = Lwt_stream.from stream in
+           to_temp_file t.fs (Fmt.strf "pack-%s.pack") stream >>?= fun (path_tmp, stream) ->
+           with_buffer t @@ fun { ztmp; window; _ } ->
+           PInfo.first_pass ~ztmp ~window stream >>!= (fun err -> `Pack_info err) >>?= fun info ->
+           PackImpl.add ~root:t.dotgit ~read_loose:(read_loose t) ~ztmp ~window t.fs t.allocation t.engine path_tmp info
+           >>!= lift_error)
+        (function Save err -> Lwt.return_error err
+                | exn -> Lwt.fail exn)
   end
 
   type kind =
@@ -926,28 +747,10 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
   let read state hash =
     Log.debug (fun l -> l "read %a" Hash.pp hash);
     Pack.read state hash >>= function
-    | Ok o ->
-      (match o.RPDec.Object.kind with
-       | `Commit ->
-         Value.Commit.D.to_result o.RPDec.Object.raw
-         |> Rresult.R.map (fun v -> Value.Commit v)
-         |> Rresult.R.reword_error (fun err -> (err :> error))
-       | `Tree ->
-         Value.Tree.D.to_result o.RPDec.Object.raw
-         |> Rresult.R.map (fun v -> Value.Tree v)
-         |> Rresult.R.reword_error (fun err -> (err :> error))
-       | `Tag ->
-         Value.Tag.D.to_result o.RPDec.Object.raw
-         |> Rresult.R.map (fun v -> Value.Tag v)
-         |> Rresult.R.reword_error (fun err -> (err :> error))
-       | `Blob ->
-         Value.Blob.D.to_result o.RPDec.Object.raw
-         |> Rresult.R.map (fun v -> Value.Blob v)
-         |> fun blob -> Rresult.R.(ok (get_ok blob)))
-      |> Lwt.return
-    | Error err -> Loose.lookup state hash >>= function
-      | None -> Lwt.return (Error err)
-      | Some _ -> Loose.read state hash >|= function
+    | Ok _ as v -> Lwt.return v
+    | Error err -> Loose.mem state hash >>= function
+      | false -> Lwt.return (Error err)
+      | true -> Loose.read state hash >|= function
         | Error e -> Error (e :> error)
         | Ok v    -> Ok v
 
@@ -1361,6 +1164,7 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
       ; dotgit
       ; root
       ; compression
+      ; allocation = Pack.default 4
       ; engine
       ; packed = Hashtbl.create 64
       ; cache = cache ()

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -189,7 +189,6 @@ module type S = sig
     | `Pack_info         of PInfo.error
     | `Idx_decoder       of IDec.error
     | `Idx_encoder       of IEnc.error
-    | `Integrity         of string
     | `Invalid_hash      of Hash.t
     | `Invalid_reference of Reference.t
     | Error.Decoder.t

--- a/src/git/store.mli
+++ b/src/git/store.mli
@@ -234,13 +234,6 @@ module type PACK = sig
   type value
   (** The type of the Git values. *)
 
-  type ('mmu, 'location) r =
-    { mmu              : 'mmu
-    ; with_cstruct     : 'mmu -> pack -> int -> (('location * Cstruct.t) -> unit Lwt.t) -> unit Lwt.t
-    ; with_cstruct_opt : 'mmu -> int option -> (('location * Cstruct.t) option -> unit Lwt.t) -> unit Lwt.t
-    ; free             : 'mmu -> 'location -> unit Lwt.t }
-  and pack = Pack of Hash.t | Unrecorded
-
   module Hash: S.HASH
   (** The [Hash] module used to make the implementation. *)
 

--- a/src/git/store.mli
+++ b/src/git/store.mli
@@ -66,11 +66,6 @@ module type LOOSE = sig
 
   type error
 
-  val lookup: state -> Hash.t -> Hash.t option Lwt.t
-  (** [lookup state hash] is the object associated with the hash
-      [hash]. The result is [None] if the Git object does not exist or
-      is not stored as a {i loose} object. *)
-
   val mem: state -> Hash.t -> bool Lwt.t
   (** [mem state hash] is true iff there is an object such that
       [digest(object) = hash]. This function is the same as [lookup

--- a/src/git/store.mli
+++ b/src/git/store.mli
@@ -449,7 +449,6 @@ module type S = sig
     | `Pack_info         of PInfo.error
     | `Idx_decoder       of IDec.error
     | `Idx_encoder       of IEnc.error
-    | `Integrity         of string
     | `Invalid_hash      of Hash.t
     | `Invalid_reference of Reference.t
     | Error.Decoder.t

--- a/src/git/sync.mli
+++ b/src/git/sync.mli
@@ -243,7 +243,7 @@ sig
     Store.t ->
     ofs_delta:bool ->
     (Store.Hash.t * string * bool) list -> command list ->
-    (Store.Pack.stream *(Crc32.t * int64) Store.Pack.Graph.t Lwt_mvar.t, Store.error) result Lwt.t
+    (Store.Pack.stream * (Crc32.t * int64) Store.Pack.Map.t Lwt_mvar.t, Store.error) result Lwt.t
 
   val want_handler:
     Store.t ->

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -2010,10 +2010,6 @@ struct
      requested (where it come from, the CRC-32 checksum, etc.) and
      just want the raw data. *)
 
-  let blit_from_cstruct src offs dst offd len = match dst with
-    | S s -> Cstruct.blit_to_string src offs s offd len
-    | C c -> Cstruct.blit src offs c offd len
-
   let get_from_offset ?(chunk = 0x8000) ?(limit = false) ?htmp t absolute_offset (raw0, raw1, _) ztmp zwin =
     let get_free_raw = function
       | true -> raw0

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -2101,7 +2101,7 @@ struct
 
                get_pack_object
                  ~chunk
-                 ?htmp:(match htmp with Some hnks -> Some hnks.(depth) | None -> None)
+                 ?htmp:(match htmp with Some hnks -> if depth < Array.length hnks then Some hnks.(depth) else None | None -> None)
                  t
                  hunks.Hunk.reference
                  hunks.Hunk.source_length

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1883,6 +1883,8 @@ struct
   (* XXX(dinosaure): this function returns the max length needed to undelta-ify
      a PACK object. *)
   let needed_from ?(chunk = 0x8000) ?(cache = (fun _ -> None)) t value ztmp zwin =
+    ignore @@ cache;
+
     let get absolute_offset =
       find_window t absolute_offset
       >>= function

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1318,6 +1318,8 @@ module type D = sig
 
     val pp: t Fmt.t
     val first_crc_exn: t -> Crc32.t
+    val first_offset_exn: t -> int64
+    val length: t -> int
   end
 
   val find_window: t -> int64 -> ((Window.t * int), Mapper.error) result Lwt.t
@@ -1537,6 +1539,17 @@ struct
       | Internal { crc; _ } -> crc
       | Delta { crc; _ } -> crc
       | External _ -> invalid_arg "Object.first_crc"
+
+    let first_offset_exn t =
+      match t.from with
+      | Internal { offset; _ } -> offset
+      | Delta { offset; _ } -> offset
+      | External _ -> invalid_arg "Object.first_offset"
+
+    let length t = match t.from with
+      | Internal { length; _ } -> length
+      | Delta { descr = { Hunk.target_length; _ }; _ } -> target_length
+      | External { length; _ } -> length
   end
 
   type pack_object =

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1240,7 +1240,7 @@ module Pack
       match eval0 src t with
       | Cont (({ state = Next _; _ }
               | { state = Unzip _; _ }
-              | { state = Hunks _; _ }) as t) ->
+              | { state = Hunks { h = { Hunk.state = Hunk.List _; _ }; _ }; _ }) as t) ->
         `Length t
       | Cont ({ state = StopHunks _; _ } as t) -> loop (continue t)
       | Cont t -> loop t

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1298,7 +1298,6 @@ module type D = sig
   type kind = [ `Commit | `Blob | `Tree | `Tag ]
 
   module Object: sig
-
     type from =
       | Delta of { descr    : Hunk.hunks
                  ; consumed : int
@@ -1500,6 +1499,7 @@ struct
       ; raw      : Cstruct.t
       ; from     : from }
 
+    (* XXX(dinosaure): attention, it's a folding function. *)
     let to_partial = function
       | { from = Delta { descr; consumed; crc; offset; _ }; _ } ->
         { _length   = descr.Hunk.target_length

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1314,7 +1314,6 @@ module type D = sig
     and t =
       { kind   : kind
       ; raw    : Cstruct.t
-      ; length : int64
       ; from   : from }
 
     val pp: t Fmt.t
@@ -1489,7 +1488,6 @@ struct
     and t =
       { kind     : kind
       ; raw      : Cstruct.t
-      ; length   : int64
       ; from     : from }
 
     let to_partial = function
@@ -1531,9 +1529,8 @@ struct
     let pp ppf t =
       Fmt.pf ppf "{ @[<hov>kind = %a;@ \
                   raw = #raw;@ \
-                  length = %Ld;@ \
                   from = %a;@] }"
-        pp_kind t.kind t.length (Fmt.hvbox pp_from) t.from
+        pp_kind t.kind (Fmt.hvbox pp_from) t.from
 
     let first_crc_exn t =
       match t.from with
@@ -2033,7 +2030,6 @@ struct
               (Pack.flush 0 (Cstruct.len o) state)
           else Lwt.return (Ok (Object.{ kind = to_kind (Pack.kind state)
                                       ; raw  = get_free_raw swap
-                                      ; length = Int64.of_int (Pack.length state)
                                       ; from   = Internal { length   = Pack.length state
                                                           ; consumed = 0
                                                           ; offset   = Pack.offset state
@@ -2098,7 +2094,6 @@ struct
                | Ok (Object (kind, partial, raw)) ->
                  Lwt.return (Ok Object.{ kind
                                        ; raw
-                                       ; length = Int64.of_int partial._length
                                        ; from   = Internal { length   = partial._length
                                                            ; consumed = partial._consumed
                                                            ; offset   = partial._offset
@@ -2106,7 +2101,6 @@ struct
                | Ok (External (hash, kind, raw)) ->
                  Lwt.return (Ok Object.{ kind
                                        ; raw
-                                       ; length = Int64.of_int (Cstruct.len raw)
                                        ; from   = Object.External { hash; length = hunks.Hunk.source_length } })
              in
 
@@ -2132,7 +2126,6 @@ struct
                           if (not limit) || ((Pack.length state) < 0x10000FFFE && limit)
                           then Cstruct.sub (get_free_raw swap) 0 (Pack.length state)
                           else (get_free_raw swap)
-                      ; length = Int64.of_int (Pack.length state)
                       ; from   = Internal { length   = Pack.length state
                                           ; consumed = Pack.consumed state
                                           ; offset   = Pack.offset state

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1517,7 +1517,7 @@ struct
         invalid_arg "Object.to_partial: this object is external of the current PACK file"
 
     let rec pp_from ppf = function
-      | Delta { descr; consumed; offset; crc; base; } ->
+      | Delta { descr; consumed; offset; crc; base; _ } ->
         Fmt.pf ppf "(Delta { @[<hov>descr = %a;@ \
                     consumed = %d;@ \
                     offset = %Lx;@ \

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1240,7 +1240,7 @@ module Pack
       match eval0 src t with
       | Cont (({ state = Next _; _ }
               | { state = Unzip _; _ }
-              | { state = Hunks { h = { Hunk.state = Hunk.List _; _ }; _ }; _ }) as t) ->
+              | { state = Hunks _; _ }) as t) ->
         `Length t
       | Cont ({ state = StopHunks _; _ } as t) -> loop (continue t)
       | Cont t -> loop t

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1623,7 +1623,7 @@ struct
 
   let apply partial_hunks hunks_header hunks base raw =
     if Cstruct.len raw < hunks_header.Hunk.target_length
-    then raise (Invalid_argument "Decoder.apply");
+    then invalid_arg (Fmt.strf "Decoder.apply, has %d, expect %d." (Cstruct.len raw) hunks_header.Hunk.target_length);
 
     let target_length = List.fold_left
         (fun acc -> function
@@ -1649,7 +1649,7 @@ struct
 
   let get_pack_object ?(chunk = 0x8000) ?(limit = false) ?htmp t reference source_length source_offset ztmp zwin rtmp =
     if Cstruct.len rtmp < source_length && not limit
-    then raise (Invalid_argument (Fmt.strf "Decoder.delta: expected length %d and have %d" source_length (Cstruct.len rtmp)));
+    then invalid_arg (Fmt.strf "Decoder.delta: expected length %d and have %d" source_length (Cstruct.len rtmp));
 
     let aux = function
       | Error exn -> Lwt.return (Error exn)

--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -1344,6 +1344,14 @@ module type D = sig
     -> Cstruct.t
     -> Inflate.window
     -> (int, error) result Lwt.t
+  val needed_from_offset:
+       ?chunk:int
+    -> ?cache:(Hash.t -> int option)
+    -> t
+    -> int64
+    -> Cstruct.t
+    -> Inflate.window
+    -> (int, error) result Lwt.t
   val needed_from_hash:
        ?chunk:int
     -> ?cache:(Hash.t -> int option)
@@ -1940,6 +1948,9 @@ struct
     in
 
     loop 0 value
+
+  let needed_from_offset ?(chunk = 0x8000) ?(cache = (fun _ -> None)) t offset ztmp zwin =
+    needed_from ~chunk ~cache t (`IndirectOff (offset, 0)) ztmp zwin
 
   let needed_from_hash ?(chunk = 0x8000) ?(cache = (fun _ -> None)) t hash ztmp zwin =
     needed_from ~chunk ~cache t (`IndirectHash (hash, 0)) ztmp zwin

--- a/src/git/unpack.mli
+++ b/src/git/unpack.mli
@@ -493,6 +493,9 @@ module type D = sig
         function can't raise an exception for any object created from
         this API. However, an object created by the hand could not
         respect the assertion. *)
+
+    val first_offset_exn: t -> int64
+    val length: t -> int
   end
 
   val find_window: t -> int64 -> (Window.t * int, Mapper.error) result Lwt.t

--- a/src/git/unpack.mli
+++ b/src/git/unpack.mli
@@ -468,50 +468,23 @@ module type D = sig
   (** The type of the kind of the git object. *)
 
   module Object: sig
-
     type from =
-      | Offset of { length   : int
-                  (** Real inflated length of the object. *)
-                  ; consumed : int
-                  (** How many byte(s) consumed to de-serialize the
-                      object. *)
-                  ; offset   : int64
-                  (** The absolute offset in the PACK file of the
-                      object. *)
-                  ; crc      : Crc32.t
-                  (** The CRC-32 checksum of the object. *)
-                  ; base : from
-                  (** The source object. *)
-                  ; }
-      (** When the source is external of the PACK file. *)
-      | External of Hash.t
-      (** When the object is not come from a source but directly
-          serialized (no delta-ification) in the PACK file. *)
-      | Direct of { consumed : int
-                  (** How many byte(s) consumed to de-serialize the
-                      current object. *)
-                  ; offset   : int64
-                  (** The absolute offset in the PACK file of the
-                      current object. *)
-                  ; crc      : Crc32.t
-                  (** The CRC-32 checksum of the source object. *)
-                  ; }
-      (** The type to describe where the object come from (directly
-          from the PACK file or from a delta-ification with an
-          [External _] object or a {i in-PACK} object. *)
+      | Delta of { descr    : Hunk.hunks
+                 ; consumed : int
+                 ; inserts  : int
+                 ; offset   : int64
+                 ; crc      : Crc32.t
+                 ; base     : from }
+      | External of { hash: Hash.t; length: int; }
+      | Internal of { length   : int
+                    ; consumed : int
+                    ; offset   : int64
+                    ; crc      : Crc32.t }
     and t =
       { kind   : kind
-      (** The kind of the object. *)
       ; raw    : Cstruct.t
-      (** The de-serialized raw of the object. *)
       ; length : int64
-      (** The real inflated/undelta-ified length of the object. *)
-      ; from   : from
-      (** If the object is come from a delta-ification or it stored directly in
-         the PACK file. *)
-      ; }
-    (** The type of the git object (after we processed all necessary
-        undelta-ification). *)
+      ; from   : from }
 
     val pp: t Fmt.t
     (** Pretty-printer for {!t}. *)

--- a/src/git/unpack.mli
+++ b/src/git/unpack.mli
@@ -483,7 +483,6 @@ module type D = sig
     and t =
       { kind   : kind
       ; raw    : Cstruct.t
-      ; length : int64
       ; from   : from }
 
     val pp: t Fmt.t

--- a/src/git/unpack.mli
+++ b/src/git/unpack.mli
@@ -568,6 +568,15 @@ module type D = sig
       [window] used by the internal decoder {!P.t} (see
       {!P.default}). *)
 
+  val needed_from_offset:
+       ?chunk:int
+    -> ?cache:(Hash.t -> int option)
+    -> t
+    -> int64
+    -> Cstruct.t
+    -> Inflate.window
+    -> (int, error) result Lwt.t
+
   val needed_from_hash:
        ?chunk:int
     -> ?cache:(Hash.t -> int option)

--- a/test/common/test_rev_list.ml
+++ b/test/common/test_rev_list.ml
@@ -49,7 +49,7 @@ module Make0 (Source: Test_data.SOURCE) (Store: S) = struct
     >>?= (fun (stream, idx) ->
       consume stream
       >>= fun () -> Lwt_mvar.take idx
-      >|= fun graph -> Store.Pack.Graph.fold (fun hash _ acc -> hash :: acc) graph []
+      >|= fun graph -> Store.Pack.Map.fold (fun hash _ acc -> hash :: acc) graph []
         |> fun v -> Ok v)
 
   let rev_list t cs =


### PR DESCRIPTION
So this PR is a start to fix #286 and:

* Have a pack-engine which can be used in a context server or as a client
* Let the user to handle allocation

Firstly, we change a little bit the unpack module to be more general than before. The biggest change is to use an ADT to use a string or noticed `Cstruct.t` by the user instead to allocate some `Cstruct.t` (of 127 bytes) when the user did not noticed a already allocated `Cstruct.t`.

This `Cstruct.t`/`string` is used to store insert hunks while we delta-ify an object - and keep them at each level of delta-ification to apply them then at the end of the recursion. In _sirodepac_, I already noticed than `string` is not the best buffer to store them (specially when we wants to extract all objects of a PACK file, the OCaml GC does not support the pressure) but the solution with `Cstruct.t` is not good too for allocate a so tiny buffer (127 bytes is the maximum). Both seem to be the solution ...

Then, from @samoht's advise and benchmark, `Pack_info` switch to use `Hashtbl` instead a `Map`. Then, a flash of genius under my shower gave me a solution to resolve delta-ification from a already existed PACK file - the solution is to use the IDX file to resolve `OBJ_REF_DELTA` and compute what is needed to reconstruct objects.

Indeed, when an object is delta-ify, the source can be noticed by `OBJ_OFS_DELTA`, in this case, we just follow offset but it could be delta-ify by an object referenced by `OBJ_REF_DELTA` which is the hash of the source. The problem is, if the source object is delta-ified too, we did not compute hash from it yet (a second pass is necessary). However, with the IDX file, we can retrieve this object and if we did not find the source, that means the PACK file is thin.

This is the big change about `Pack_info`.

Finally, we can talk about the `Pack_engine` and some changes:

- First, we decide to cut in some states the `Pack_engine`:
  * `exists`: when the PACK file already exists on the git repository
  * `loaded`: when we load the PACK file (we promote `exists` to `loaded` when the user wants to read an object from this PACK file - but `lookup`, `list` and `mem` operations don't do this promotion)
  * `normalized`: when the PACK file comes from a stream (when you `pull`/`fetch`/`clone`)
  * `resolved`: when we resolved all delta-ified objects in the PACK file
  * `total`: when we ensure than the PACK file is _thin_ or not

As you can see, we can have two entry point for a PACK file:
- if the PACK file already exists on the git repository
- if the PACK file comes from a stream

As `git`, if the PACK file comes from a stream, we will apply 3 passes. The first one can be done while we store it on a temporary directory. Then, the second pass will try to resolve all delta-ified objects from this PACK file (always stuck on the temporary directory). With the second pass, we can determine if the PACK file is _thin_ or not. In the second case, we just do an atomic move from temporary directory to git repository and generate the IDX file. In the first case, we generate a new PACK file to ensure than any PACK file in the git repository are non-_thin_ (like what `git` does).

Obviously, this computation is little bit slow, however, then, we add a new PACK file from a stream directly as a `total` PACK file. That means, we calculated needed `Cstruct.t` to extract any objects from this PACK file and control allocation at this stage.

Finally, for an already existed PACK file, we did not do this kind of computation - but we don't control allocation - and when we have enough to promote it to a new state (`resolved`), we do it. Finally, in common way, for the next call, the PACK file will be promoted as a `total` PACK file (because any PACK file in the git repository is _thin_).

So, in this way, we did not do a pass automatically (and scan all PACK file) on already existed PACK file. However, the client will be able to force this scan if he wants - but it's not the default behavior now and should be fix #286.

- Secondly, we let the user to control allocations

This is the biggest mandatory for me, it's to let the user to keep the control about the allocation. I created a new record:

```ocaml
type ('location, 'mmu) r =
   { mmu              : 'mmu
   ; with_cstruct     : 'mmu -> int -> (('location * Cstruct.t) -> unit Lwt.t) -> unit Lwt.t
   ; with_cstruct_opt : 'mmu -> int option -> (('location * Cstruct.t) option -> unit Lwt.t) -> unit Lwt.t
   ; free             : 'mmu -> 'location -> unit Lwt.t }
```

Which let the user to define a politic about allocation for `Cstruct.t` in some context. Obviously, we have an easy context where the user can just allocate one `Cstruct.t` which needs to grow specially when we apply the second pass. Then, the second context is, as @samoht asked, a concurrent context when we calculated what is needed to extract any objects from the PACK file (so `resolved` and `total` state). In this context, we will ask a fixed size and buffer will be use on a concurrent context (and it's the purpose of the `free` function which could be a Lwt waiter).

Then, I did some check (by hand) to ensure ownership on `Cstruct.t` but, as before, we delimited allocation of `Cstruct.t` in only one case: `read_and_exclude`.

- Third, we fixed `read_and_exclude`

Indeed, in a special context, a PACK file A can have an delta-ified object O which needs an object M outside from the PACK file A. The source object could be appear on a PACK file B but nothing in the documentation tell me than this object __can not__ be delta-ified by O. So we needs to avoid a circular dependency and because we can find multiple times the same object (like O) in multiple PACK files, we need to check to take object O from another PACK file than A.

This is the purpose of `read_and_exclude`. The code looks like a deep and non-optimized code which allocate a lot, and it's true but it's the worst comes to the worst - and from my knowledge, it should not appear ...

- Fourth, we replace `Map` by `Hashtbl` like `Pack_info`

This PR is not finished, we need to merge this store on `Store` and `Mem` now but the interface does not change a lot and should delete some duplicate codes (specially in `Store`). But I make this PR to follow development and get some advises before merging. So feel free to ask something if you want! 