### PR TITLE
Make Tree.entry a private type

### DIFF
--- a/src/git-unix/index.ml
+++ b/src/git-unix/index.ml
@@ -1979,18 +1979,14 @@ module Make (Hash: Git.HASH) (Store: Git.S with module Hash = Hash) (FS: Git.FS)
     let hash_of_entry entry = entry.Entry.hash
 
     let rec entries_to_tree ~bucket entries =
-      List.map
-        (fun (name, entry) ->
-          match entry with
+      List.map (fun (name, entry) -> match entry with
           | Blob entry ->
-             { Store.Value.Tree.perm = Entry.perm_of_kind entry.Entry.info.Entry.mode
-             ; name
-             ; node = hash_of_entry entry }
+            let perm = Entry.perm_of_kind entry.Entry.info.Entry.mode in
+            Store.Value.Tree.entry name perm (hash_of_entry entry)
           | Tree entries ->
-             { Store.Value.Tree.perm = `Dir
-             ; name
-             ; node = hash_of_tree ~bucket entries })
-        (StringMap.bindings entries)
+            Store.Value.Tree.entry name `Dir (hash_of_tree ~bucket entries)
+        ) (StringMap.bindings entries)
+
     and hash_of_tree ~bucket entries =
       let entries = entries_to_tree ~bucket entries in
       let tree = Store.Value.Tree.of_list entries in

--- a/src/git-unix/ogit-write-tree/main.ml
+++ b/src/git-unix/ogit-write-tree/main.ml
@@ -106,17 +106,13 @@ let perm_of_entry { Index.Entry.info = { mode; _ }; _ } =
 let hash_of_blob entry = entry.Index.Entry.hash
 
 let rec index_entries_to_tree_entries ~bucket entries =
-  List.map
-    (fun (name, entry) -> match entry with
-       | Index.Blob entry ->
-         { Store.Value.Tree.perm = perm_of_entry entry
-         ; name
-         ; node = hash_of_blob entry }
-       | Index.Tree entries ->
-         { Store.Value.Tree.perm = `Dir
-         ; name
-         ; node = hash_of_tree ~bucket entries })
-    (Index.StringMap.bindings entries)
+  List.map (fun (name, entry) -> match entry with
+      | Index.Blob entry ->
+        Store.Value.Tree.entry name (perm_of_entry entry) (hash_of_blob entry)
+      | Index.Tree entries ->
+        Store.Value.Tree.entry name `Dir (hash_of_tree ~bucket entries)
+    ) (Index.StringMap.bindings entries)
+
 and hash_of_tree ~bucket entries =
   let entries = index_entries_to_tree_entries ~bucket entries in
   let tree = Store.Value.Tree.of_list entries in

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -116,6 +116,7 @@ module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE) = struct
     Lwt.return (Ok t : (t, error) result)
 
   let reset t =
+    Log.info (fun l -> l "info");
     Hashtbl.clear t.values;
     Hashtbl.clear t.inflated;
     Hashtbl.clear t.refs;

--- a/src/git/tree.mli
+++ b/src/git/tree.mli
@@ -21,11 +21,7 @@ module type S = sig
 
   module Hash: S.HASH
 
-  type entry =
-    { perm : perm
-    ; name : string
-    ; node : Hash.t }
-  and perm =
+  type perm =
     [ `Normal (** A {!Blob.t}. *)
     | `Everybody
     | `Exec   (** An executable. *)
@@ -33,7 +29,20 @@ module type S = sig
     | `Dir    (** A sub-{!Tree.t}. *)
     | `Commit (** A sub-module ({!Commit.t}). *)
     ]
-  and t
+
+  type entry = private
+    { perm : perm
+    ; name : string
+    ; node : Hash.t }
+
+  val pp_entry: entry Fmt.t
+  (** Pretty-printer of {!entry}. *)
+
+  val entry: string -> perm -> Hash.t -> entry
+  (** [entry name perm node] is a new entry. Raise [Invalid_argument]
+      if [name] contains ['\000']. *)
+
+  type t
   (** A Git Tree object. Git stores content in a manner similar to a
       UNIX {i filesystem}, but a bit simplified. All the content is
       stored as tree and {!Blob.t} objects, with trees corresponding to
@@ -43,9 +52,13 @@ module type S = sig
       {!Blob.t} or sub-tree with its associated mode, type, and {i
       filename}. *)
 
-  val pp_entry: entry Fmt.t
-  (** Pretty-printer of {!entry}. *)
+  val remove: name:string -> t -> t
+  (** [remove ~name t] is [t] without the entry [name]. *)
 
+  val add: t -> entry -> t
+  (** [add t e] is [t] with the addition of the enty [e]. *)
+
+  val is_empty: t -> bool
   val perm_of_string: string -> perm
   val string_of_perm: perm -> string
 


### PR DESCRIPTION
This allows to check that steps are well-formed only once; add also convenient
fonctions to efficiently add/remove entries in a tree.