### PR TITLE
Digestif

### DIFF
--- a/src/git-mirage/git_mirage.ml
+++ b/src/git-mirage/git_mirage.ml
@@ -1,5 +1,5 @@
 module Net = Net
-module SHA1 = Git.Hash.Make(Digestif.SHA1)
+module SHA1 = Git.Hash.SHA1
 module FS = Fs
 
 module Store (X: Mirage_fs_lwt.S) = struct

--- a/src/git-mirage/jbuild
+++ b/src/git-mirage/jbuild
@@ -3,5 +3,6 @@
 (library
  ((name        git_mirage)
   (public_name git-mirage)
-  (libraries   (checkseum.ocaml digestif.ocaml git mirage-flow-lwt mirage-fs-lwt mirage-channel-lwt
-                mirage-conduit cohttp-mirage git-http))))
+  (libraries   (digestif.ocaml checkseum.ocaml
+                git mirage-flow-lwt mirage-fs-lwt mirage-channel-lwt
+                mirage-conduit cohttp-mirage git-http decompress))))

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -16,7 +16,7 @@
 
 module Fs    = Fs
 module Net   = Net
-module SHA1  = Git.Hash.Make(Digestif.SHA1)
+module SHA1  = Git.Hash.SHA1
 module Sync  = Git.Sync.Make(Net)
 module Http  = Http.Make
 module Index = Index

--- a/src/git-unix/jbuild
+++ b/src/git-unix/jbuild
@@ -4,5 +4,5 @@
  ((name        git_unix)
   (public_name git-unix)
   (wrapped     false)
-  (libraries   (checkseum.c git logs.fmt lwt.unix git-http cohttp-lwt-unix
-                digestif.c))))
+  (libraries   (checkseum.c digestif.c
+                git logs.fmt lwt.unix git-http cohttp-lwt-unix))))

--- a/src/git/hash.ml
+++ b/src/git/hash.ml
@@ -18,7 +18,7 @@
 type t = private string
 type hex = string
 
-module Make (D: Digestif_sig.S): S.HASH = struct
+module Make (D: Digestif.S): S.HASH = struct
   type t = D.t
   type nonrec hex = hex
 
@@ -35,21 +35,25 @@ module Make (D: Digestif_sig.S): S.HASH = struct
 
   external unsafe_of_string : string -> t = "%identity"
   external unsafe_to_string : t -> string = "%identity"
+
   let of_string = unsafe_of_string
   let to_string = unsafe_to_string
+
   let get : t -> int -> char = fun t i -> String.get (t:>string) i
 
   let of_hex : hex -> t = fun buf -> D.of_hex buf
   let to_hex : t -> hex = fun x -> D.to_hex x
 
+  (* XXX(dinosaure): Git need a lexicographical comparison function. *)
   let compare : t -> t -> int = fun a b -> String.compare (a:>string) (b:>string)
-  let equal : t -> t -> bool = fun a b -> String.equal (a:>string) (b:>string)
   let hash : t -> int = fun t -> Hashtbl.hash (t:>string)
-  let pp : t Fmt.t = fun ppf hash -> Fmt.string ppf (to_hex hash)
+
+  (* XXX(dinosaure): we use safe equal function provided by digestif. *)
+  let equal = D.eq
+  let pp = D.pp
 
   module Map = Map.Make(struct type nonrec t = t let compare = compare end)
   module Set = Set.Make(struct type nonrec t = t let compare = compare end)
 end
 
-(* XXX: this breaks as jbuilder doesn't the linking trick yet *)
-(* module SHA1 =  Make(Digestif.SHA1) *)
+module SHA1 =  Make(Digestif.SHA1)

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -524,4 +524,4 @@ module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE) = struct
   let has_global_checkout = false
 end
 
-module Store (H : Digestif_sig.S) = Make(Hash.Make(H))(Inflate)(Deflate)
+module Store (H : Digestif.S) = Make(Hash.Make(H))(Inflate)(Deflate)

--- a/src/git/mem.mli
+++ b/src/git/mem.mli
@@ -73,7 +73,7 @@ module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE): sig
 
 end
 
-module Store (H : Digestif_sig.S): sig
+module Store (H : Digestif.S): sig
   include Minimal.S with module Hash    = Hash.Make(H)
                      and module Inflate = Inflate
                      and module Deflate = Deflate

--- a/test/git-unix/jbuild
+++ b/test/git-unix/jbuild
@@ -2,7 +2,7 @@
 
 (executable
  ((name      test)
-  (libraries (checkseum.c test_git git-unix))))
+  (libraries (checkseum.c digestif.c test_git git-unix))))
 
 (alias
  ((name runtest)

--- a/test/git/jbuild
+++ b/test/git/jbuild
@@ -2,7 +2,7 @@
 
 (executable
  ((name      test)
-  (libraries (checkseum.ocaml digestif.ocaml test_git fpath lwt))))
+  (libraries (checkseum.ocaml digestif.ocaml test_git decompress fpath lwt))))
 
 (alias
  ((name runtest)


### PR DESCRIPTION
Move to the last (last) version of `digestif` which move on `jbuilder`/`dune` and the true linking trick.