### PR TITLE
Simplify the use of temporary directory (for atomic renames)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,7 @@ environment:
     FORK_USER: ocaml
     FORK_BRANCH: master
     CYG_ROOT: C:\cygwin64
-    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. encore.dev:https://github.com/dinosaure/encore.git digestif.dev:https://github.com/digestif/digestif.git decompress.dev:https://github.com/mirage/decompress.git"
-    ALCOTEST_SHOW_ERRORS: true
+    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
   matrix:
   - PACKAGE: "git-mirage.dev"
   - PACKAGE: "git-unix.dev"

--- a/git.opam
+++ b/git.opam
@@ -22,7 +22,7 @@ depends: [
   "fpath"      {>= "0.7.0"}
   "digestif"   {>= "0.5"}
   "lru"        {>= "0.2.0"}
-  "decompress" {>= "0.7"}
+  "decompress" {>= "0.8"}
   "encore"
   "duff"
   "hex"

--- a/src/git-mirage/fs.ml
+++ b/src/git-mirage/fs.ml
@@ -45,11 +45,10 @@ module Make (FS: Mirage_fs_lwt.S) = struct
     fs     : FS.t;
     locks  : Lwt_mutex.t H.t;
     current: Fpath.t;
-    temp   : Fpath.t;
   }
 
-  let v ?(temp_dir=Fpath.v "tmp") ?(current_dir=Fpath.v ".") fs =
-    { fs; locks = H.create 13; current=current_dir; temp=temp_dir }
+  let v ?(current_dir=Fpath.v ".") fs =
+    { fs; locks = H.create 13; current=current_dir }
 
   type error =
     [ `Destroy of Fpath.t * string
@@ -155,7 +154,6 @@ module Make (FS: Mirage_fs_lwt.S) = struct
         (fun exn -> err_listdir dir "%a" Fmt.exn exn)
 
     let current t = Lwt.return (Ok t.current)
-    let temp t = Lwt.return t.temp
   end
 
   module File = struct

--- a/src/git-mirage/fs.mli
+++ b/src/git-mirage/fs.mli
@@ -1,4 +1,4 @@
 module Make (FS: Mirage_fs_lwt.S): sig
   include Git.FS
-  val v: ?temp_dir:Fpath.t -> ?current_dir:Fpath.t -> FS.t -> t
+  val v: ?current_dir:Fpath.t -> FS.t -> t
 end

--- a/src/git-mirage/git_mirage.ml
+++ b/src/git-mirage/git_mirage.ml
@@ -7,9 +7,9 @@ module Store (X: Mirage_fs_lwt.S) = struct
   module S = Git.Store.Make(SHA1)(F)(Git.Inflate)(Git.Deflate)
   include S
 
-  let v ?temp_dir ?current_dir ?root ?dotgit ?compression ?buffer fs =
-    let fs = F.v ?temp_dir ?current_dir fs in
-    create ?root ?dotgit ?compression ?buffer fs
+  let v ?current_dir ?dotgit ?compression ?buffer fs root =
+    let fs = F.v ?current_dir fs in
+    v ?dotgit ?compression ?buffer fs root
 end
 
 module Sync (C: Net.CONDUIT) = Git.Sync.Make(Net.Make(C))

--- a/src/git-mirage/git_mirage.mli
+++ b/src/git-mirage/git_mirage.mli
@@ -10,11 +10,9 @@ module Store (X: Mirage_fs_lwt.S): sig
   include Git.Store.S with module Hash = SHA1
 
   val v:
-    ?temp_dir:Fpath.t ->
     ?current_dir:Fpath.t ->
-    ?root:Fpath.t ->
     ?dotgit:Fpath.t ->
     ?compression:int ->
     ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
-    X.t -> (t, error) result Lwt.t
+    X.t -> Fpath.t -> (t, error) result Lwt.t
 end

--- a/src/git-unix/fs.ml
+++ b/src/git-unix/fs.ml
@@ -6,29 +6,7 @@ let (>|?) = Lwt_result.(>|=)
 let src = Logs.Src.create "git-unix.fs" ~doc:"logs unix file-system's event"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-type t = {
-  temp_dir: Fpath.t;
-}
-
-let temp () =
-  let from_env var ~absent =
-    match try Some (Sys.getenv var) with Not_found -> None with
-    | None -> absent
-    | Some v ->
-      match Fpath.of_string v with
-      | Error _ -> absent
-      | Ok v -> v
-  in
-  (if Sys.os_type = "Win32"
-   then from_env "TEMP  " ~absent:Fpath.(v "./")
-   else from_env "TMPDIR" ~absent:Fpath.(v "/tmp/"))
-
-let v ?temp_dir () =
-  let temp_dir = match temp_dir with
-    | None   -> temp ()
-    | Some t -> t
-  in
-  { temp_dir }
+type t = unit
 
 type error = Fpath.t * [
   | `Stat of string
@@ -261,8 +239,6 @@ module Dir = struct
           err_getcwd Fpath.(v "CWD")
             "get current working directory: %s" (Unix.error_message e)
         | exn -> expected_unix_error exn)
-
-  let temp t = Lwt.return t.temp_dir
 
 end
 

--- a/src/git-unix/fs.mli
+++ b/src/git-unix/fs.mli
@@ -1,3 +1,1 @@
-include Git.FS
-
-val v: ?temp_dir:Fpath.t -> unit -> t
+include Git.FS with type t = unit

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -24,6 +24,6 @@ module Index = Index
 module Store = struct
   include Git.Store.Make(SHA1)(Fs)(Git.Inflate)(Git.Deflate)
 
-  let v ?temp_dir ?root ?dotgit ?compression ?buffer ?(fs = Fs.v ?temp_dir ()) () =
-    create ?root ?dotgit ?compression ?buffer fs
+  let v ?dotgit ?compression ?buffer root =
+    v ?dotgit ?compression ?buffer () root
 end

--- a/src/git-unix/git_unix.mli
+++ b/src/git-unix/git_unix.mli
@@ -28,13 +28,10 @@ module Store: sig
            and module FS := Fs
 
   val v:
-    ?temp_dir:Fpath.t ->
-    ?root:Fpath.t ->
     ?dotgit:Fpath.t ->
     ?compression:int ->
     ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
-    ?fs:Fs.t ->
-    unit -> (t, error) result Lwt.t
+    Fpath.t -> (t, error) result Lwt.t
 end
 
 module Sync (S: Git.S): Git.Sync.S with module Store = S and module Net = Net

--- a/src/git-unix/index.ml
+++ b/src/git-unix/index.ml
@@ -1652,7 +1652,7 @@ module IO (Hash: Git.HASH) (FS: Git.FS) (Entry: ENTRY with type hash := Hash.t) 
       end in
     let state = IEnc.default entries in
     let module E = Git.Helper.Encoder(E)(FS) in
-    E.to_file fs Fpath.(root / "index") raw state
+    E.to_file fs ~temp_dir:Fpath.(root / "tmp") Fpath.(root / "index") raw state
     >|= function
     | Ok hash ->
        Log.debug (fun l -> l "Saved index file with the hash: %a." Hash.pp hash);

--- a/src/git-unix/ogit-cat-file/main.ml
+++ b/src/git-unix/ogit-cat-file/main.ml
@@ -116,7 +116,7 @@ let main show hash =
 
   let ( >!= ) v f = map_err f v in
 
-  Store.v ~root () >!= store_err >>= fun git ->
+  Store.v root  >!= store_err >>= fun git ->
 
   match show with
   | `Inflate ->

--- a/src/git-unix/ogit-dot/main.ml
+++ b/src/git-unix/ogit-dot/main.ml
@@ -54,9 +54,11 @@ let () = Fmt.set_style_renderer Fmt.stderr `Ansi_tty
 let () = Logs.set_reporter (reporter Fmt.stderr)
 let () = Logs.set_level ~all:true (Some Logs.Debug)
 
+let root = Fpath.(v (Sys.getcwd ()))
+
 let main ppf =
   let open Lwt_result in
-  Store.v () >>= fun t ->
+  Store.v root >>= fun t ->
   Lwt.Infix.(Graph.to_dot t ppf >>= fun () -> Lwt.return (Ok ()))
 
 let () =

--- a/src/git-unix/ogit-http-clone/main.ml
+++ b/src/git-unix/ogit-http-clone/main.ml
@@ -130,13 +130,8 @@ let main ppf progress origin branch repository directory =
     else None in
 
   let https = Option.eq ~eq:((=) "https") (Uri.scheme repository) in
-  let temp_dir = Fpath.(root / ".git" / "temp") in
-  let fs = Fs.v ~temp_dir () in
 
-  Fs.Dir.create fs temp_dir
-  >>!= (fun err -> `Store (Git.Error.FS.err_create temp_dir err))
-  >>?= fun _ ->
-  Store.v ~root ~fs ()
+  Store.v root
   >>!= store_err
   >>?= fun git ->
   Sync_http.clone_ext git ?stdout ?stderr ~https
@@ -162,7 +157,7 @@ let main ppf progress origin branch repository directory =
     Store.Reference.head
     (Store.Reference.Ref branch)
   >>!= store_err
-  >>?= fun _ -> Index.Snapshot.from_reference git fs Store.Reference.head
+  >>?= fun _ -> Index.Snapshot.from_reference git () Store.Reference.head
   >>!= index_err
   >>?= fun _ -> Lwt.return (Ok ())
 

--- a/src/git-unix/ogit-http-fetch-all/main.ml
+++ b/src/git-unix/ogit-http-fetch-all/main.ml
@@ -109,7 +109,7 @@ let main directory repository =
   Log.debug (fun l -> l ~header:"main" "root:%a, repository:%a.\n"
                 Fpath.pp root Uri.pp_hum repository);
 
-  Store.v ~root ()
+  Store.v root
   >>!= store_err
   >>?= fun git ->
   Sync_http.fetch_all git ~references:Store.Reference.Map.empty repository

--- a/src/git-unix/ogit-http-fetch/main.ml
+++ b/src/git-unix/ogit-http-fetch/main.ml
@@ -112,7 +112,7 @@ let main references directory repository =
       Store.Reference.Map.empty references
   in
 
-  Store.v ~root ()
+  Store.v root
   >>!= store_err
   >>?= fun git ->
   Sync_http.fetch_some git ~references repository

--- a/src/git-unix/ogit-http-ls/main.ml
+++ b/src/git-unix/ogit-http-ls/main.ml
@@ -102,7 +102,7 @@ let main show_tags show_heads repository =
 
   let https = Option.eq ~eq:((=) "https") (Uri.scheme repository) in
 
-  Store.v ~root ()
+  Store.v root
   >>!= store_err
   >>?= fun git ->
   Sync_http.ls git ~https ?port:(Uri.port repository)

--- a/src/git-unix/ogit-write-tree/main.ml
+++ b/src/git-unix/ogit-write-tree/main.ml
@@ -129,12 +129,10 @@ let hash_of_root ~bucket (Index.Root entries) =
 
 let main ?prefix:_ _ =
   let dtmp = Cstruct.create 0x8000 in
-
   let root = Fpath.(v (Sys.getcwd ())) in
-  let fs = Fs.v () in
 
-  Store.v ~root () >!= store_err >?= fun t ->
-    Index.IO.load fs ~root:(Store.dotgit t) ~dtmp >!= index_err >?= fun (entries, _) ->
+  Store.v root >!= store_err >?= fun t ->
+    Index.IO.load () ~root:(Store.dotgit t) ~dtmp >!= index_err >?= fun (entries, _) ->
       let root = Index.of_entries entries in
       let tree = Hashtbl.create 128 in
       let root_hash = hash_of_root ~bucket:tree root in

--- a/src/git/helper.mli
+++ b/src/git/helper.mli
@@ -171,7 +171,8 @@ module Encoder (E: ENCODER) (FS: S.FS): sig
       returned 0.
 
       If [atomic] is set, the operation is guaranteed to be atomic. *)
-  val to_file: ?limit:int -> ?atomic:bool -> FS.t -> Fpath.t -> Cstruct.t ->
+  val to_file: ?limit:int -> ?atomic:bool -> FS.t ->
+    temp_dir:Fpath.t -> Fpath.t -> Cstruct.t ->
     E.state -> (E.result, error) result Lwt.t
 
 end
@@ -190,7 +191,7 @@ module FS (FS: S.FS): sig
       file-descriptor. When [f] completes, the file-descriptor is
       closed. Failure to close that file-descriptor is ignored. *)
 
-  val with_open_w: ?atomic:bool -> FS.t -> Fpath.t ->
+  val with_open_w: ?atomic:bool -> FS.t -> temp_dir:Fpath.t -> Fpath.t ->
     ([ `Write ] FS.File.fd ->
      ('a, [> `Open of Fpath.t * FS.error
           | `Move of Fpath.t * Fpath.t * FS.error ] as 'e) result Lwt.t) ->

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -90,11 +90,11 @@ module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE) = struct
   let dotgit t = t.dotgit
   let compression t = t.compression
 
-  let default_root = Fpath.v "root"
-
-  let v
-      ?(root = default_root) ?(dotgit = Fpath.(default_root / ".git"))
-      ?(compression = 6) ?buffer () =
+  let v ?dotgit ?(compression = 6) ?buffer root =
+    let dotgit = match dotgit with
+      | Some d -> d
+      | None   -> Fpath.(root / ".git")
+    in
     if compression < 0 || compression > 9
     then failwith "level should be between 0 and 9";
     let buffer = match buffer with

--- a/src/git/mem.mli
+++ b/src/git/mem.mli
@@ -60,11 +60,10 @@ module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE): sig
                      and module Deflate = D
 
   val v:
-    ?root:Fpath.t ->
     ?dotgit:Fpath.t ->
     ?compression:int ->
     ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
-    unit -> (t, error) result Lwt.t
+    Fpath.t -> (t, error) result Lwt.t
   (** [create ?root ?dotgit ?compression ()] creates a new store
       represented by the path [root] (default is ["."]), where the Git
       objects are located in [dotgit] (default is [root / ".git"] and
@@ -79,9 +78,8 @@ module Store (H : Digestif.S): sig
                      and module Deflate = Deflate
 
   val v:
-    ?root:Fpath.t ->
     ?dotgit:Fpath.t ->
     ?compression:int ->
     ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
-    unit -> (t, error) result Lwt.t
+    Fpath.t -> (t, error) result Lwt.t
 end

--- a/src/git/pack_engine.ml
+++ b/src/git/pack_engine.ml
@@ -677,7 +677,8 @@ module Make
       let encoder_idx = IEnc.default sequence hash_pack in
       let raw = Cstruct.create 0x8000 in (* XXX(dinosaure): as argument? *)
       let path = Fpath.(root / "objects" / "pack" / file) in
-      EIDX.to_file fs path raw encoder_idx >|= function
+      let temp_dir = Fpath.(root / "tmp") in
+      EIDX.to_file fs ~temp_dir path raw encoder_idx >|= function
       | Ok ()                  -> Ok ()
       | Error (`Encoder err)   -> Error (`Idx_encoder err)
       | Error #fs_error as err -> err
@@ -974,18 +975,18 @@ module Make
       for i = 0 to len - 1 do Bytes.set raw i (gen ()) done;
       Bytes.unsafe_to_string raw
 
-    let store_pack_file ~fs fmt entries get =
+    let store_pack_file ~fs ~root fmt entries get =
       let ztmp = Cstruct.create 0x8000 in
       let file = fmt (random_string 10) in
       let state = PEnc.default ztmp entries in
-      FS.Dir.temp fs >>= fun temp ->
-      let path = Fpath.(temp / file) in
+      let temp_dir = Fpath.(root / "tmp") in
+      let path = Fpath.(temp_dir / file) in
       let rawo = Cstruct.create 0x8000 in
       let state = { EPACK.E.get; src = None; pack = state } in
       Lwt.catch
         (fun () ->
            (* XXX(dinosaure): why is not atomic? *)
-           EPACK.to_file fs ~atomic:false path rawo state >|= function
+           EPACK.to_file fs ~atomic:false ~temp_dir path rawo state >|= function
            | Ok { EPACK.E.tree; hash; } ->
              let index = Hashtbl.create (PEnc.Map.cardinal tree) in
              let paths = Hashtbl.create (PEnc.Map.cardinal tree) in
@@ -1018,7 +1019,7 @@ module Make
                  Patch { hunks = max hunks_a hunks_b; target = max target_a target_b; src = merge abs_off src_a src_b } in
              let path = Hashtbl.fold merge paths (Load 0) in
 
-             Ok (Fpath.(temp / file)
+             Ok (Fpath.(temp_dir / file)
                 , (index, path)
                 , hash)
            | Error #fs_error as err -> err
@@ -1129,7 +1130,7 @@ module Make
       >>= function
       | Error err -> Lwt.return_error (`Delta err)
       | Ok entries ->
-        store_pack_file ~fs (Fmt.strf "pack-%s.pack") entries read_inflated
+        store_pack_file ~fs (Fmt.strf "pack-%s.pack") ~root entries read_inflated
         >>= function
         | Error _ as err -> Lwt.return err
         | Ok (path, (index, delta_path), hash_pack) ->

--- a/src/git/reference.ml
+++ b/src/git/reference.ml
@@ -315,11 +315,12 @@ module IO (Hash: S.HASH) (FS: S.FS) = struct
   let write ~fs ~root ?(capacity = 0x100) ~raw reference value =
     let state = E.default (capacity, value) in
     let path = Fpath.(root // (to_path reference)) in
+    let temp_dir = Fpath.(root / "tmp") in
     FS.Dir.create fs (Fpath.parent path)
     >>= function
     | Error err -> Lwt.return Error.(v @@ FS.err_create (Fpath.parent path) err)
     | Ok (true | false) ->
-      Encoder.to_file fs path raw state >|= function
+      Encoder.to_file fs ~temp_dir path raw state >|= function
       | Ok _                   -> Ok ()
       | Error #fs_error as err -> err
       | Error (`Encoder #Error.never) -> assert false

--- a/src/git/s.ml
+++ b/src/git/s.ml
@@ -178,7 +178,6 @@ module type DIR = sig
   val delete: t -> Fpath.t -> (unit, error) result Lwt.t
   val contents: t -> ?rel:bool -> Fpath.t -> (Fpath.t list, error) result Lwt.t
   val current: t -> (Fpath.t, error) result Lwt.t
-  val temp: t -> Fpath.t Lwt.t
 end
 
 module type FS = sig

--- a/src/git/store.mli
+++ b/src/git/store.mli
@@ -705,13 +705,12 @@ module Make (H: S.HASH) (F: S.FS) (I: S.INFLATE) (D: S.DEFLATE): sig
              and module Deflate = D
              and module FS      = F
 
-  val create :
-    ?root:Fpath.t ->
+  val v:
     ?dotgit:Fpath.t ->
     ?compression:int ->
     ?buffer:((buffer -> unit Lwt.t) -> unit Lwt.t) ->
-    FS.t -> (t, error) result Lwt.t
- (** [create ?root ?dotgit ?compression ?buffer fs] creates a
+    FS.t -> Fpath.t -> (t, error) result Lwt.t
+ (** [create ?dotgit ?compression ?buffer fs root] creates a
       new store represented by the path [root] (default is ["."]),
       where the Git objects are located in [dotgit] (default is [root
       / ".git"] and when Git objects are compressed by the [level]

--- a/test/common/test_thin.ml
+++ b/test/common/test_thin.ml
@@ -26,7 +26,7 @@ module Make (Sync: Test_sync.SYNC) = struct
   let uri = Uri.of_string "http://github.com/mirage/decompress.git"
 
   let run name tests: unit Alcotest.test =
-    name, List.map (fun (msg, f) -> msg, `Quick, fun () -> Test_store.run f) tests
+    name, List.map (fun (msg, f) -> msg, `Slow, fun () -> Test_store.run f) tests
 
   let test_clone () =
     Test_store.create ~root () >>= fun t ->

--- a/test/git-mirage/test.ml
+++ b/test/git-mirage/test.ml
@@ -90,12 +90,11 @@ end
 module MirageStore = struct
   include Git_mirage.Store(M)
 
-  let temp_dir = Fpath.(v M.root / "temp")
   let current_dir = Fpath.v M.root
 
   let v root =
     M.connect () >>= fun fs ->
-    v ~temp_dir ~current_dir ~root fs
+    v ~current_dir fs root
 end
 
 module MirageConduit: Git_mirage.Net.CONDUIT = struct
@@ -127,7 +126,7 @@ end
 
 module Store = struct
   include Git.Mem.Store(Digestif.SHA1)
-  let v root = v ~root ()
+  let v root = v root
 end
 
 module TCP = Test_sync.Make(struct

--- a/test/git-unix/test.ml
+++ b/test/git-unix/test.ml
@@ -85,12 +85,12 @@ module Https (Store: Test_store.S) = Test_sync.Make(struct
 
 module Mem_store = struct
   include Git.Mem.Store(Digestif.SHA1)
-  let v root = v ~root ()
+  let v root = v root
 end
 
 module Fs_store = struct
   include Git_unix.Store
-  let v root = v ~root ()
+  let v root = v root
 end
 
 module Thin = Test_thin.Make(struct

--- a/test/git-unix/test_index.ml
+++ b/test/git-unix/test_index.ml
@@ -260,7 +260,7 @@ let update_index_remove_one_file t fs path =
 let run ~root ~pp_error f () =
   let open Lwt.Infix in
 
-  match Lwt_main.run (Store.v ~root () >>= function
+  match Lwt_main.run (Store.v root >>= function
                       | Ok t -> f t >>= fun v -> Lwt.return (Ok v)
                       | Error err -> Lwt.return (Error err)) with
   | Ok (Ok _) -> ()
@@ -568,8 +568,7 @@ let test015 root fs : unit Alcotest.test_case =
         Lwt.return (Ok ()))
 
 let suite root =
-  let fs = Git_unix.Fs.v () in
-  "index", List.map (fun f -> f root fs)
+  "index", List.map (fun f -> f root ())
              [ test000
              ; test001
              ; test002

--- a/test/git/test.ml
+++ b/test/git/test.ml
@@ -18,7 +18,7 @@ open Test_common
 
 module Store = struct
   include Git.Mem.Store(Digestif.SHA1)
-  let v root = v ~root ()
+  let v root = v root
 end
 
 let () =


### PR DESCRIPTION
Always use `.git/tmp` to avoid isues with cross-device links.