### PR TITLE
use digestif hashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
+    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. digestif.dev:--dev"
   matrix:
     - OCAML_VERSION=4.06 PACKAGE="git.dev"
     - OCAML_VERSION=4.04 PACKAGE="git-unix.dev"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     FORK_USER: ocaml
     FORK_BRANCH: master
     CYG_ROOT: C:\cygwin64
-    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
+    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. digestif.dev:--dev"
   matrix:
   - PACKAGE: "git-mirage.dev"
   - PACKAGE: "git-unix.dev"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     FORK_USER: ocaml
     FORK_BRANCH: master
     CYG_ROOT: C:\cygwin64
+    OPAM_SWITCH: 4.06.1+mingw64c
     PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. digestif.dev:--dev"
   matrix:
   - PACKAGE: "git-mirage.dev"

--- a/git.opam
+++ b/git.opam
@@ -20,7 +20,7 @@ depends: [
   "lwt"        {>= "2.4.7"}
   "angstrom"   {>= "0.9.0"}
   "fpath"      {>= "0.7.0"}
-  "digestif"   {>= "0.5"}
+  "digestif"   {>= "0.7.0"}
   "lru"        {>= "0.2.0"}
   "decompress" {>= "0.8"}
   "encore"

--- a/src/git-http/sync.ml
+++ b/src/git-http/sync.ml
@@ -80,12 +80,12 @@ module type S_EXT = sig
     with type hash := Store.Hash.t
      and type reference := Store.Reference.t
   module Decoder: Git.Smart.DECODER
-    with module Hash = Store.Hash
-     and module Reference = Store.Reference
+    with module Hash := Store.Hash
+     and module Reference := Store.Reference
      and module Common := Common
   module Encoder: Git.Smart.ENCODER
-    with module Hash = Store.Hash
-     and module Reference = Store.Reference
+    with module Hash := Store.Hash
+     and module Reference := Store.Reference
      and module Common := Common
 
   type error =

--- a/src/git-http/sync.mli
+++ b/src/git-http/sync.mli
@@ -52,12 +52,12 @@ module type S_EXT = sig
     with type hash := Store.Hash.t
      and type reference := Store.Reference.t
   module Decoder: Git.Smart.DECODER
-    with module Hash = Store.Hash
-     and module Reference = Store.Reference
+    with module Hash := Store.Hash
+     and module Reference := Store.Reference
      and module Common := Common
   module Encoder: Git.Smart.ENCODER
-    with module Hash = Store.Hash
-     and module Reference = Store.Reference
+    with module Hash := Store.Hash
+     and module Reference := Store.Reference
      and module Common := Common
 
   type error =

--- a/src/git-mirage/fs.ml
+++ b/src/git-mirage/fs.ml
@@ -105,6 +105,9 @@ module Make (FS: Mirage_fs_lwt.S) = struct
 
   module Dir = struct
 
+    type nonrec t = t
+    type nonrec error = error
+
     let exists t path =
       Log.debug (fun l -> l "Dir.exists %s" @@ fpath_to_string path);
       is_dir t path >|= function
@@ -157,6 +160,9 @@ module Make (FS: Mirage_fs_lwt.S) = struct
   end
 
   module File = struct
+
+    type nonrec t = t
+    type nonrec error = error
 
     (* Note: all the operations (including reads) need to be locked
        because of the lack of atomic moves in MirageOS's FS
@@ -280,6 +286,8 @@ module Make (FS: Mirage_fs_lwt.S) = struct
 
   module Mapper = struct
 
+    type nonrec t = t
+    type nonrec error = error
     let pp_error = pp_error
 
     type fd = { t: t; path: Fpath.t ; sz: int64 }

--- a/src/git-mirage/git_mirage.ml
+++ b/src/git-mirage/git_mirage.ml
@@ -1,10 +1,12 @@
 module Net = Net
-module SHA1 = Git.Hash.SHA1
 module FS = Fs
 
 module Store (X: Mirage_fs_lwt.S) = struct
   module F = Fs.Make(X)
-  module S = Git.Store.Make(SHA1)(F)(Git.Inflate)(Git.Deflate)
+  module I = Git.Inflate
+  module D = Git.Deflate
+  module S = Git.Store.Make(Digestif.SHA1)(F)(I)(D)
+
   include S
 
   let v ?current_dir ?dotgit ?compression ?buffer fs root =

--- a/src/git-mirage/git_mirage.mli
+++ b/src/git-mirage/git_mirage.mli
@@ -1,5 +1,4 @@
 module Net = Net
-module SHA1: Git.HASH
 module FS = Fs
 
 module Sync (C: Net.CONDUIT) (S: Git.S): Git.Sync.S
@@ -7,7 +6,7 @@ module Sync (C: Net.CONDUIT) (S: Git.S): Git.Sync.S
    and module Net = Net.Make(C)
 
 module Store (X: Mirage_fs_lwt.S): sig
-  include Git.Store.S with module Hash = SHA1
+  include Git.Store.S with module Hash = Git.Hash.Make(Digestif.SHA1)
 
   val v:
     ?current_dir:Fpath.t ->

--- a/src/git-unix/fs.ml
+++ b/src/git-unix/fs.ml
@@ -113,6 +113,9 @@ let result_map f a = match a with
 
 module Dir = struct
 
+  type nonrec t = t
+  type nonrec error = error
+
   let create t dir =
     let mode = 0o755 in
     let mkdir d =
@@ -244,6 +247,9 @@ end
 
 module File = struct
 
+  type nonrec t = t
+    type nonrec error = error
+
   type 'a fd = {
     path: Fpath.t;
     fd  : Lwt_unix.file_descr;
@@ -311,6 +317,8 @@ end
 
 module Mapper = struct
 
+  type nonrec t = t
+  type nonrec error = error
   let pp_error = pp_error
 
   type fd = {

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -16,13 +16,15 @@
 
 module Fs    = Fs
 module Net   = Net
-module SHA1  = Git.Hash.SHA1
 module Sync  = Git.Sync.Make(Net)
 module Http  = Http.Make
 module Index = Index
 
 module Store = struct
-  include Git.Store.Make(SHA1)(Fs)(Git.Inflate)(Git.Deflate)
+  module I = Git.Inflate
+  module D = Git.Deflate
+
+  include Git.Store.Make(Digestif.SHA1)(Fs)(I)(D)
 
   let v ?dotgit ?compression ?buffer root =
     v ?dotgit ?compression ?buffer () root

--- a/src/git-unix/git_unix.mli
+++ b/src/git-unix/git_unix.mli
@@ -16,15 +16,13 @@
 
 (** Unix backend. *)
 
-module SHA1:  Git.HASH
-
 module Fs = Fs
 module Net = Net
 module Index = Index
 
 module Store: sig
   include Git.Store.S
-          with module Hash = SHA1
+          with module Hash = Git.Hash.Make(Digestif.SHA1)
            and module FS := Fs
 
   val v:

--- a/src/git-unix/ogit-http-clone/main.ml
+++ b/src/git-unix/ogit-http-clone/main.ml
@@ -20,8 +20,8 @@ let () = Random.self_init ()
 open Git_unix
 
 module Sync_http = Http(Store)
-module Entry = Index.Entry(SHA1)
-module Index = Index.Make(SHA1)(Store)(Fs)(Entry)
+module Entry = Index.Entry(Digestif.SHA1)
+module Index = Index.Make(Store)(Fs)(Entry)
 
 module Option =
 struct

--- a/src/git-unix/ogit-write-tree/main.ml
+++ b/src/git-unix/ogit-write-tree/main.ml
@@ -66,8 +66,8 @@ let setup_logs style_renderer level =
   let quiet = match style_renderer with Some _ -> true | None -> false in
   quiet, Fmt.stdout
 
-module Entry = Index.Entry(SHA1)
-module Index = Index.Make(SHA1)(Store)(Fs)(Entry)
+module Entry = Index.Entry(Digestif.SHA1)
+module Index = Index.Make(Store)(Fs)(Entry)
 
 let store_err err = Lwt.return (`Store err)
 let index_err err = Lwt.return (`Index err)

--- a/src/git/blob.mli
+++ b/src/git/blob.mli
@@ -17,12 +17,9 @@
 
 (** A Git Blob object. *)
 
-type t = private Cstruct.t
-(** A Git Blob object which store entirely your file of your Git repository. *)
-
 module type S = sig
 
-  type nonrec t = t
+  type t
   (** The Git Blob is structurally a {!Cstruct.t} independantly of the
       hash implementation. *)
 
@@ -34,6 +31,7 @@ module type S = sig
   module D: S.DECODER with type t = t and type init = Cstruct.t and type error = Error.Decoder.t
   module E: S.ENCODER with type t = t and type error = Error.never
   include S.DIGEST    with type t := t and type hash := Hash.t
+
   include S.BASE      with type t := t
 
   val length: t -> int64
@@ -58,6 +56,6 @@ module type S = sig
       value - in other words, the content of your file. *)
 end
 
-module Make (Hash: S.HASH): S with module Hash = Hash
+module Make (Hash: S.HASH): S with module Hash := Hash
 (** The {i functor} to make the OCaml representation of the Git Blob
     object by a specific hash implementation. *)

--- a/src/git/commit.mli
+++ b/src/git/commit.mli
@@ -48,7 +48,8 @@ module type S = sig
   module M: S.DESC    with type 'a t = 'a Encore.Encoder.t and type e = t
   module D: S.DECODER with type t = t and type init = Cstruct.t and type error = Error.Decoder.t
   module E: S.ENCODER with type t = t and type init = int * t and type error = Error.never
-  include S.DIGEST    with type t := t and type hash = Hash.t
+  include S.DIGEST    with type t := t and type hash := Hash.t
+
   include S.BASE      with type t := t
 
   val length: t -> int64
@@ -78,6 +79,6 @@ module type S = sig
       behaviour. *)
 end
 
-module Make (Hash: S.HASH): S with module Hash = Hash
+module Make (Hash: S.HASH): S with module Hash := Hash
 (** The {i functor} to make the OCaml representation of the Git Commit
     object by a specific hash implementation. *)

--- a/src/git/git.ml
+++ b/src/git/git.ml
@@ -1,5 +1,3 @@
-let () = Printexc.record_backtrace true
-
 include S
 module type S = Minimal.S
 

--- a/src/git/git.mli
+++ b/src/git/git.mli
@@ -44,7 +44,7 @@ module type FILE = S.FILE
 module type MAPPER = S.MAPPER
 module type DIR = S.DIR
 module type FS = S.FS
-module type HASH = S.HASH
 module type DIGEST = S.DIGEST
+module type HASH = S.HASH
 
 module type S = Minimal.S

--- a/src/git/hash.mli
+++ b/src/git/hash.mli
@@ -15,6 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (D: Digestif.S): S.HASH
-
-module SHA1: S.HASH
+module Make (H: Digestif.S):
+  S.HASH with type t = H.t
+          and type ctx = H.ctx
+          and type kind = H.kind

--- a/src/git/helper.mli
+++ b/src/git/helper.mli
@@ -111,7 +111,7 @@ module MakeDeflater (Z: S.DEFLATE) (M: S.DESC with type 'a t = 'a Encore.Encoder
     [tmp] is aan internal buffer used to store the stream of the
     encoder and used by [Hash.digest]. *)
 val fdigest:
-  (module S.IDIGEST with type t = 'hash) ->
+  (module S.HASH with type t = 'hash) ->
   (module S.ENCODER
     with type t = 't
      and type init = int * 't

--- a/src/git/index_pack.mli
+++ b/src/git/index_pack.mli
@@ -72,7 +72,7 @@ module type LAZY = sig
   val cardinal: t -> int
 end
 
-module Lazy (H: S.HASH): LAZY with module Hash = H
+module Lazy (Hash: S.HASH): LAZY with module Hash := Hash
 (** The {i functor} to make the {i lazy} decoder of the IDX file.
     Internally, we use a [Cstruct.t] representation of the IDX file
     notified to the [make] function. This [Cstruct.t] should never
@@ -148,8 +148,7 @@ sig
       decoder can't continue and sticks in this situation.}} *)
 end
 
-module Decoder (H: S.HASH)
- : DECODER with module Hash = H
+module Decoder (Hash: S.HASH) : DECODER with module Hash := Hash
 (** The {i functor} to make the decoder module by a specific hash
     implementation. We constraint the {!Hash.S} module to compute a
     {Cstruct.t} flow. This module is a {i non-blocking} decoder with a
@@ -220,6 +219,6 @@ sig
       encoder can't continue and sticks in this situation.}} *)
 end
 
-module Encoder (H: S.HASH): ENCODER with module Hash = H
+module Encoder (Hash: S.HASH): ENCODER with module Hash := Hash
 (** The {i functor} to make the encoder module by a specific hash
     implementation. *)

--- a/src/git/loose.mli
+++ b/src/git/loose.mli
@@ -18,8 +18,15 @@
 
 module type S = sig
 
-  module FS: S.FS
-  module Value: Value.S
+  module FS     : S.FS
+  module Hash   : S.HASH
+  module Deflate: S.DEFLATE
+  module Inflate: S.INFLATE
+
+  module Value: Value.S with module Hash    := Hash
+                         and module Deflate := Deflate
+                         and module Inflate := Inflate
+
   include module type of Value
 
   type error =
@@ -106,9 +113,9 @@ module Make
     (FS: S.FS)
     (I: S.INFLATE)
     (D: S.DEFLATE)
-  : S with module Hash = H
-       and module Inflate = I
-       and module Deflate = D
+  : S with module Hash    := H
+       and module Inflate := I
+       and module Deflate := D
        and module FS = FS
        and module Blob = Blob.Make(H)
        and module Commit = Commit.Make(H)

--- a/src/git/mem.mli
+++ b/src/git/mem.mli
@@ -35,7 +35,7 @@
     back-end).
 *)
 
-module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE): sig
+module Make (H: Digestif.S) (Inflate: S.INFLATE) (Deflate: S.DEFLATE): sig
 
 (** The {i functor} needs 4 modules:
 
@@ -55,9 +55,9 @@ module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE): sig
     understand the Deflate module. For example, use [zlib] to inflate
     and [brotli] to deflate does not work. *)
 
-  include Minimal.S with module Hash = H
-                     and module Inflate = I
-                     and module Deflate = D
+  include Minimal.S with module Hash    = Hash.Make(H)
+                     and module Inflate = Inflate
+                     and module Deflate = Deflate
 
   val v:
     ?dotgit:Fpath.t ->
@@ -72,8 +72,8 @@ module Make (H: S.HASH) (I: S.INFLATE) (D: S.DEFLATE): sig
 
 end
 
-module Store (H : Digestif.S): sig
-  include Minimal.S with module Hash    = Hash.Make(H)
+module Store: sig
+  include Minimal.S with module Hash    = Hash.Make(Digestif.SHA1)
                      and module Inflate = Inflate
                      and module Deflate = Deflate
 

--- a/src/git/minimal.ml
+++ b/src/git/minimal.ml
@@ -1,20 +1,20 @@
 module type S = sig
 
-  module Hash: S.HASH
+  module Hash   : S.HASH
   module Inflate: S.INFLATE
   module Deflate: S.DEFLATE
 
   module Value: Value.S
-    with module Hash = Hash
-     and module Inflate = Inflate
-     and module Deflate = Deflate
-     and module Blob = Blob.Make(Hash)
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module Deflate := Deflate
+     and module Blob   = Blob.Make(Hash)
      and module Commit = Commit.Make(Hash)
-     and module Tree = Tree.Make(Hash)
-     and module Tag = Tag.Make(Hash)
+     and module Tree   = Tree.Make(Hash)
+     and module Tag    = Tag.Make(Hash)
      and type t = Value.Make(Hash)(Inflate)(Deflate).t
 
-  module Reference: Reference.S with module Hash = Hash
+  module Reference: Reference.S with module Hash := Hash
 
   (** The type of the git repository. *)
   type t
@@ -132,8 +132,6 @@ module type S = sig
     type stream = unit -> Cstruct.t option Lwt.t
     (** The stream contains the PACK flow. *)
 
-    module Map: Map.S with type key = Hash.t
-
     val from: t -> stream -> (Hash.t * int, error) result Lwt.t
     (** [from git stream] populates the Git repository [git] from the
         PACK flow [stream]. If any error is encountered, any Git
@@ -144,7 +142,7 @@ module type S = sig
       -> ?window:[ `Object of int | `Memory of int ]
       -> ?depth:int
       -> Value.t list
-      -> (stream * (Crc32.t * int64) Map.t Lwt_mvar.t, error) result Lwt.t
+      -> (stream * (Crc32.t * int64) Hash.Map.t Lwt_mvar.t, error) result Lwt.t
     (** [make ?window ?depth values] makes a PACK stream from a list
         of {!Value.t}.
 

--- a/src/git/negociator.mli
+++ b/src/git/negociator.mli
@@ -26,8 +26,8 @@ module type S = sig
     with type hash := Store.Hash.t
      and type reference := Store.Reference.t
   module Decoder: Smart.DECODER
-    with module Hash = Store.Hash
-     and module Reference = Store.Reference
+    with module Hash := Store.Hash
+     and module Reference := Store.Reference
      and module Common := Common
 
   type state

--- a/src/git/pack.mli
+++ b/src/git/pack.mli
@@ -118,7 +118,7 @@ module type H = sig
       buffer noticed to the previous call of {!eval}. *)
 end
 
-module Hunk (Hash: S.HASH): H with module Hash = Hash
+module Hunk (Hash: S.HASH): H with module Hash := Hash
 
 (** The entry module. It used to able to manipulate the meta-data only
    needed by the delta-ification of the Git object (and avoid to
@@ -204,7 +204,7 @@ module type ENTRY = sig
       delta-ification. *)
 end
 
-module Entry (Hash: S.HASH): ENTRY with module Hash = Hash
+module Entry (Hash: S.HASH): ENTRY with module Hash := Hash
 
 (** This module is the engine to delta-ify Git objects together. The
    current implementation is a stop the world process which can not
@@ -294,10 +294,8 @@ module type DELTA = sig
         code. *)
 end
 
-module Delta
-    (Hash: S.HASH)
-    (Entry: ENTRY with module Hash := Hash)
-  : DELTA with module Hash = Hash
+module Delta (Hash: S.HASH) (Entry: ENTRY with module Hash := Hash)
+  : DELTA with module Hash  := Hash
            and module Entry := Entry
 
 (** Interface which describes the encoder of the PACK file. *)
@@ -313,7 +311,6 @@ module type P = sig
      and module Entry := Entry
 
   module Hunk: H with module Hash := Hash
-  module Map: Map.S with type key = Hash.t
   (** The Map tree zhich zill represent the IDX file of the PACK
       stream. *)
 
@@ -363,7 +360,7 @@ module type P = sig
       inflated raw, it access on it only as a read-only flow (that
       means, the src {!Cstruct.t} could be physicaly the same. *)
 
-  val idx: t -> (Crc32.t * int64) Map.t
+  val idx: t -> (Crc32.t * int64) Hash.Map.t
   (** [idx t] returns a {!Map} tree which contains the CRC-32
       checksum and the absolute offset for each Git object serialized.
       The client is able to use it only when {!eval} returns
@@ -403,23 +400,23 @@ module type P = sig
 end
 
 module Pack
-    (Hash: S.HASH)
+    (Hash   : S.HASH)
     (Deflate: S.DEFLATE)
     (Entry: ENTRY with module Hash := Hash)
     (Delta: DELTA with module Hash := Hash
                    and module Entry := Entry)
     (Hunk: H with module Hash := Hash)
-  : P with module Hash = Hash
-       and module Deflate = Deflate
-       and module Entry := Entry
-       and module Delta := Delta
-       and module Hunk := Hunk
+  : P with module Hash    := Hash
+       and module Deflate := Deflate
+       and module Entry   := Entry
+       and module Delta   := Delta
+       and module Hunk    := Hunk
 (** The {i functor} to make the PACK encoder by a specific hash
     implementation and a specific deflate algorithm. *)
 
 module Stream
-    (Hash: S.HASH)
+    (Hash   : S.HASH)
     (Deflate: S.DEFLATE) : sig
   include P
-end with module Hash = Hash
-     and module Deflate = Deflate
+end with module Hash    := Hash
+     and module Deflate := Deflate

--- a/src/git/pack_engine.mli
+++ b/src/git/pack_engine.mli
@@ -17,39 +17,38 @@
 
 module type S = sig
 
-  module Hash: S.HASH
+  module Hash   : S.HASH
   module Inflate: S.INFLATE
   module Deflate: S.DEFLATE
-  module FS: S.FS
+  module FS     : S.FS
 
   module HDec: Unpack.H with module Hash := Hash
   module PDec: Unpack.P
-    with module Hash := Hash
+    with module Hash    := Hash
      and module Inflate := Inflate
-     and module Hunk := HDec
+     and module Hunk    := HDec
   module RPDec: Unpack.D
-    with module Hash := Hash
-     and type Mapper.fd = FS.Mapper.fd
-     and type Mapper.error = FS.error
+    with module Hash    := Hash
      and module Inflate := Inflate
-     and module Hunk := HDec
-     and module Pack := PDec
+     and module Hunk    := HDec
+     and module Pack    := PDec
+     and module Mapper  := FS.Mapper
 
   module PEnc: Pack.P
-    with module Hash = Hash
-     and module Deflate = Deflate
+    with module Hash    := Hash
+     and module Deflate := Deflate
 
   module IDec: Index_pack.LAZY
-    with module Hash = Hash
+    with module Hash := Hash
 
   module IEnc: Index_pack.ENCODER
-    with module Hash = Hash
+    with module Hash := Hash
 
   module PInfo: Pack_info.S
-    with module Hash = Hash
-     and module Inflate = Inflate
-     and module HDec := HDec
-     and module PDec := PDec
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module HDec    := HDec
+     and module PDec    := PDec
 
   type t
 
@@ -115,24 +114,23 @@ module type S = sig
 end
 
 module Make
-    (Hash: S.HASH)
-    (FS: S.FS)
+    (Hash   : S.HASH)
+    (FS     : S.FS)
     (Inflate: S.INFLATE)
     (Deflate: S.DEFLATE)
-    (HDec: Unpack.H with module Hash := Hash)
-    (PDec: Unpack.P with module Hash := Hash
+    (HDec: Unpack.H with module Hash    := Hash)
+    (PDec: Unpack.P with module Hash    := Hash
                      and module Inflate := Inflate
-                     and module Hunk := HDec)
-    (RPDec: Unpack.D with module Hash := Hash
-                      and type Mapper.fd = FS.Mapper.fd
-                      and type Mapper.error = FS.error
+                     and module Hunk    := HDec)
+    (RPDec: Unpack.D with module Hash    := Hash
                       and module Inflate := Inflate
-                      and module Hunk := HDec
-                      and module Pack := PDec)
-  : S with module Hash = Hash
-       and module Inflate = Inflate
-       and module Deflate = Deflate
-       and module FS = FS
-       and module HDec := HDec
-       and module PDec := PDec
-       and module RPDec := RPDec
+                      and module Hunk    := HDec
+                      and module Pack    := PDec
+                      and module Mapper  := FS.Mapper)
+  : S with module Hash    := Hash
+       and module Inflate := Inflate
+       and module Deflate := Deflate
+       and module FS      := FS
+       and module HDec    := HDec
+       and module PDec    := PDec
+       and module RPDec   := RPDec

--- a/src/git/pack_info.mli
+++ b/src/git/pack_info.mli
@@ -15,16 +15,16 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module type S =
-sig
-  module Hash: S.HASH
+module type S = sig
+
+  module Hash   : S.HASH
   module Inflate: S.INFLATE
 
   module HDec: Unpack.H with module Hash := Hash
   module PDec: Unpack.P
-    with module Hash := Hash
+    with module Hash    := Hash
      and module Inflate := Inflate
-     and module Hunk := HDec
+     and module Hunk    := HDec
 
   type error =
     [ `Unexpected_end_of_input
@@ -64,13 +64,13 @@ sig
 end
 
 module Make
-    (Hash: S.HASH)
+    (Hash   : S.HASH)
     (Inflate: S.INFLATE)
-    (HDec: Unpack.H with module Hash := Hash)
-    (PDec: Unpack.P with module Hash := Hash
-                     and module Inflate := Inflate
-                     and module Hunk := HDec)
-  : S with module Hash = Hash
-       and module Inflate = Inflate
-       and module HDec := HDec
-       and module PDec := PDec
+    (HDec   : Unpack.H with module Hash    := Hash)
+    (PDec   : Unpack.P with module Hash    := Hash
+                        and module Inflate := Inflate
+                        and module Hunk    := HDec)
+  : S with module Hash    := Hash
+       and module Inflate := Inflate
+       and module HDec    := HDec
+       and module PDec    := PDec

--- a/src/git/packed_refs.ml
+++ b/src/git/packed_refs.ml
@@ -41,9 +41,8 @@ module type S = sig
     (t, error) result Lwt.t
 end
 
-module Make (H: S.HASH) (FS: S.FS) = struct
+module Make (Hash:S.HASH) (FS: S.FS) = struct
 
-  module Hash = H
   module FS = Helper.FS(FS)
 
   type t = [ `Peeled of hash | `Ref of string * hash ] list
@@ -56,7 +55,7 @@ module Make (H: S.HASH) (FS: S.FS) = struct
     type 'a t = 'a Angstrom.t
 
     let hash =
-      take (Hash.Digest.length * 2)
+      take (Hash.digest_size * 2)
       >>| Hash.of_hex
 
     let end_of_line =

--- a/src/git/packed_refs.mli
+++ b/src/git/packed_refs.mli
@@ -43,6 +43,4 @@ module type S = sig
     (t, error) result Lwt.t
 end
 
-module Make (H: S.HASH) (FS: S.FS):
-  S with module FS = FS
-     and module Hash = H
+module Make (H: S.HASH) (FS: S.FS): S with module FS := FS and module Hash := H

--- a/src/git/reference.mli
+++ b/src/git/reference.mli
@@ -199,10 +199,10 @@ module type IO = sig
       This function can returns an {!error}. *)
 end
 
-module Make (Hash: S.HASH): S with module Hash = Hash
+module Make (Hash: S.HASH): S with module Hash := Hash
 (** The {i functor} to make the OCaml representation of the Git
     Reference object by a specific hash. *)
 
-module IO (Hash: S.HASH) (FS: S.FS): IO with module Hash = Hash and module FS = FS
+module IO (H: S.HASH) (FS: S.FS): IO with module Hash := H and module FS := FS
 (** The {i functor} to make a module which implements I/O operations
     on references on a file-system. *)

--- a/src/git/s.ml
+++ b/src/git/s.ml
@@ -106,33 +106,17 @@ module type DEFLATE = sig
   val eval       : src:Cstruct.t -> dst:Cstruct.t -> t -> [ `Flush of t | `Await of t | `Error of (t * error) | `End of t ]
 end
 
-module type IDIGEST = sig
-  type t
-  type ctx
-
-  val init   : unit -> ctx
-  val feed_c : ctx -> Cstruct.t -> ctx
-  val feed_s : ctx -> string -> ctx
-  val feed_b : ctx -> bytes -> ctx
-  val get    : ctx -> t
-
-  val length : int
-end
-
 module type HASH = sig
-  include BASE with type t = private string
+  include Digestif.S
 
-  module Digest : IDIGEST with type t = t
+  val feed_cstruct: ctx -> Cstruct.t -> ctx
+  val compare: t -> t -> int
+  val hash: t -> int
+  val equal: t -> t -> bool
+  val read: t -> int -> int
 
-  val get : t -> int -> char
-
-  val to_string : t -> string
-  val of_string : string -> t
-
-  type hex = string
-
-  val to_hex : t -> hex
-  val of_hex : hex -> t
+  module Set: Set.S with type elt = t
+  module Map: Map.S with type key = t
 end
 
 module type DIGEST = sig
@@ -189,9 +173,9 @@ module type FS = sig
   val is_dir: t -> Fpath.t -> (bool, error) result Lwt.t
   val is_file: t -> Fpath.t -> (bool, error) result Lwt.t
 
-  module File  : FILE with type t := t and type error := error
-  module Dir   : DIR with type t := t and type error := error
-  module Mapper: MAPPER with type t := t and type error := error
+  module File  : FILE with type t = t and type error = error
+  module Dir   : DIR with type t = t and type error = error
+  module Mapper: MAPPER with type t = t and type error = error
 
   val has_global_watches: bool
   val has_global_checkout: bool

--- a/src/git/second_pass.mli
+++ b/src/git/second_pass.mli
@@ -16,28 +16,31 @@
  *)
 
 module type S = sig
-  module Hash: S.HASH
+  module FS     : S.FS
+
+  module Hash   : S.HASH
   module Inflate: S.INFLATE
   module Deflate: S.DEFLATE
-  module FS: S.FS
 
   module HDec: Unpack.H with module Hash := Hash
+
   module PDec: Unpack.P
-    with module Hash := Hash
+    with module Hash    := Hash
      and module Inflate := Inflate
-     and module Hunk := HDec
+     and module Hunk    := HDec
+
   module PInfo: Pack_info.S
-    with module Hash := Hash
+    with module Hash    := Hash
      and module Inflate := Inflate
-     and module HDec := HDec
-     and module PDec := PDec
+     and module HDec    := HDec
+     and module PDec    := PDec
+
   module RPDec: Unpack.D
-    with module Hash := Hash
-     and type Mapper.fd = FS.Mapper.fd
-     and type Mapper.error = FS.error
+    with module Hash    := Hash
      and module Inflate := Inflate
-     and module Hunk := HDec
-     and module Pack := PDec
+     and module Hunk    := HDec
+     and module Pack    := PDec
+     and module Mapper  := FS.Mapper
 
   type status =
     | Resolved of Crc32.t * Hash.t
@@ -52,29 +55,28 @@ module type S = sig
 end
 
 module Make
-    (Hash: S.HASH)
-    (FS: S.FS)
+    (Hash   : S.HASH)
+    (FS     : S.FS)
     (Inflate: S.INFLATE)
     (Deflate: S.DEFLATE)
-    (HDec: Unpack.H with module Hash := Hash)
-    (PDec: Unpack.P with module Hash := Hash
-                     and module Inflate := Inflate
-                     and module Hunk := HDec)
-    (PInfo: Pack_info.S with module Hash := Hash
+    (HDec: Unpack.H with module Hash        := Hash)
+    (PDec: Unpack.P with module Hash        := Hash
+                     and module Inflate     := Inflate
+                     and module Hunk        := HDec)
+    (PInfo: Pack_info.S with module Hash    := Hash
                          and module Inflate := Inflate
-                         and module HDec := HDec
-                         and module PDec := PDec)
-    (RPDec: Unpack.D with module Hash := Hash
-                      and type Mapper.fd = FS.Mapper.fd
-                      and type Mapper.error = FS.error
-                      and module Inflate := Inflate
-                      and module Hunk := HDec
-                      and module Pack := PDec)
-  : S with module Hash = Hash
-       and module Inflate = Inflate
-       and module Deflate = Deflate
-       and module FS = FS
-       and module HDec := HDec
-       and module PDec := PDec
-       and module PInfo := PInfo
-       and module RPDec := RPDec
+                         and module HDec    := HDec
+                         and module PDec    := PDec)
+    (RPDec: Unpack.D with module Hash       := Hash
+                      and module Inflate    := Inflate
+                      and module Hunk       := HDec
+                      and module Pack       := PDec
+                      and module Mapper     := FS.Mapper)
+  : S with module Hash    := Hash
+       and module Inflate := Inflate
+       and module Deflate := Deflate
+       and module FS      := FS
+       and module HDec    := HDec
+       and module PDec    := PDec
+       and module PInfo   := PInfo
+       and module RPDec   := RPDec

--- a/src/git/smart.mli
+++ b/src/git/smart.mli
@@ -226,18 +226,19 @@ sig
   val equal_http_upload_request: http_upload_request equal
 end
 
-module Common (Hash: S.HASH) (Reference: Reference.S)
+module Common (Hash: S.HASH) (Reference: Reference.S with module Hash := Hash)
   : COMMON
     with type hash := Hash.t
      and type reference := Reference.t
 
 (** The Smart protocol including the encoder and the decoder. *)
 
-module type DECODER =
-sig
-  module Hash: S.HASH
-  module Reference: Reference.S
-  module Common: COMMON with type hash := Hash.t and type reference := Reference.t
+module type DECODER = sig
+
+  module Hash     : S.HASH
+  module Reference: Reference.S with module Hash := Hash
+  module Common   : COMMON with type hash := Hash.t
+                            and type reference := Reference.t
 
   type decoder
   (** The type decoder. *)
@@ -342,19 +343,22 @@ sig
 end
 
 module Decoder
-    (Hash: S.HASH)
-    (Reference: Reference.S)
-    (Common: COMMON with type hash := Hash.t and type reference := Reference.t)
-  : DECODER with module Hash = Hash
-             and module Reference = Reference
-             and module Common = Common
+    (Hash     : S.HASH)
+    (Reference: Reference.S with module Hash := Hash)
+    (Common   : COMMON with type hash := Hash.t
+                        and type reference := Reference.t)
+  : DECODER with module Hash      := Hash
+             and module Reference := Reference
+             and module Common    := Common
 (** The {i functor} to make the Decoder by a specific hash
     implementation. *)
 
 module type ENCODER = sig
+
   module Hash: S.HASH
-  module Reference: Reference.S
-  module Common: COMMON with type hash := Hash.t and type reference := Reference.t
+  module Reference: Reference.S with module Hash := Hash
+  module Common: COMMON with type hash := Hash.t
+                         and type reference := Reference.t
 
   type encoder
   (** The type encoder. *)
@@ -410,33 +414,33 @@ module type ENCODER = sig
 end
 
 module Encoder
-    (Hash: S.HASH)
-    (Reference: Reference.S)
-    (Common: COMMON with type hash := Hash.t and type reference := Reference.t)
-  : ENCODER with module Hash = Hash
-             and module Reference = Reference
-             and module Common = Common
+    (Hash     : S.HASH)
+    (Reference: Reference.S with module Hash := Hash)
+    (Common   : COMMON with type hash := Hash.t and type reference := Reference.t)
+  : ENCODER with module Hash      := Hash
+             and module Reference := Reference
+             and module Common    := Common
 (** The {i functor} to make the Encoder by a specific hash
     implementation. *)
 
 module type CLIENT =
 sig
-  module Hash: S.HASH
-  module Reference: Reference.S
+  module Hash     : S.HASH
+  module Reference: Reference.S with module Hash := Hash
 
   module Common: COMMON
     with type hash := Hash.t
      and type reference := Reference.t
 
   module Decoder: DECODER
-    with module Hash = Hash
-     and module Reference = Reference
+    with module Hash := Hash
+     and module Reference := Reference
      and module Common := Common
   (** The {!Decoder} module constrained by the same [Hash] module. *)
 
   module Encoder: ENCODER
-    with module Hash = Hash
-     and module Reference = Reference
+    with module Hash := Hash
+     and module Reference := Reference
      and module Common := Common
   (** The {!Encoder} module constrained by the same [Hash] module. *)
 
@@ -506,9 +510,9 @@ sig
 end
 
 module Client
-    (Hash: S.HASH)
-    (Reference: Reference.S)
-  : CLIENT with module Hash = Hash
-            and module Reference = Reference
+    (Hash     : S.HASH)
+    (Reference: Reference.S with module Hash := Hash)
+  : CLIENT with module Hash      := Hash
+            and module Reference := Reference
 (** The {i functor} to make the Client by a specific hash
     implementation. *)

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -35,19 +35,20 @@ module type LOOSE = sig
     | `Tag
     | `Blob ]
 
-  module Hash: S.HASH
   module FS : S.FS
+
+  module Hash   : S.HASH
   module Inflate: S.INFLATE
   module Deflate: S.DEFLATE
 
   module Value: Value.S
-    with module Hash = Hash
-     and module Inflate = Inflate
-     and module Deflate = Deflate
-     and module Blob = Blob.Make(Hash)
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module Deflate := Deflate
+     and module Blob   = Blob.Make(Hash)
      and module Commit = Commit.Make(Hash)
-     and module Tree = Tree.Make(Hash)
-     and module Tag = Tag.Make(Hash)
+     and module Tree   = Tree.Make(Hash)
+     and module Tag    = Tag.Make(Hash)
      and type t = Value.Make(Hash)(Inflate)(Deflate).t
 
   val mem: state -> Hash.t -> bool Lwt.t
@@ -79,32 +80,40 @@ module type PACK = sig
   type state
   type error
 
-  module Hash: S.HASH
   module FS: S.FS
+
+  module Hash   : S.HASH
   module Inflate: S.INFLATE
   module Deflate: S.DEFLATE
 
   module HDec: Unpack.H
-    with module Hash = Hash
+    with module Hash := Hash
+
   module PDec: Unpack.P
-    with module Hash = Hash
-     and module Inflate = Inflate
+    with module Hash := Hash
+     and module Inflate := Inflate
      and module Hunk := HDec
+
   module RPDec: Unpack.D
-    with module Hash = Hash
-     and module Inflate = Inflate
+    with module Hash := Hash
+     and module Inflate := Inflate
      and module Hunk := HDec
      and module Pack := PDec
+     and module Mapper := FS.Mapper
+
   module PEnc: Pack.P
-    with module Hash = Hash
-     and module Deflate = Deflate
+    with module Hash := Hash
+     and module Deflate := Deflate
+
   module IDec: Index_pack.LAZY
-    with module Hash = Hash
+    with module Hash := Hash
+
   module IEnc: Index_pack.ENCODER
-    with module Hash = Hash
+    with module Hash := Hash
+
   module PInfo: Pack_info.S
-    with module Hash = Hash
-     and module Inflate = Inflate
+    with module Hash := Hash
+     and module Inflate := Inflate
      and module HDec := HDec
      and module PDec := PDec
 
@@ -115,72 +124,73 @@ module type PACK = sig
   val size: state -> Hash.t -> (int, error) result Lwt.t
 
   type stream = unit -> Cstruct.t option Lwt.t
-  module Map: Map.S with type key = Hash.t
 
   val from: state -> stream -> (Hash.t * int, error) result Lwt.t
   val make: state
     -> ?window:[ `Object of int | `Memory of int ]
     -> ?depth:int
     -> value list
-    -> (stream * (Crc32.t * int64) Map.t Lwt_mvar.t, error) result Lwt.t
+    -> (stream * (Crc32.t * int64) Hash.Map.t Lwt_mvar.t, error) result Lwt.t
 end
 
 module type S = sig
 
   type t
 
-  module Hash: S.HASH
-  module Inflate: S.INFLATE
-  module Deflate: S.DEFLATE
   module FS: S.FS
 
+  module Hash   : S.HASH
+  module Inflate: S.INFLATE
+  module Deflate: S.DEFLATE
+
   module Value: Value.S
-    with module Hash = Hash
-     and module Inflate = Inflate
-     and module Deflate = Deflate
-     and module Blob = Blob.Make(Hash)
-     and module Commit = Commit.Make(Hash)
-     and module Tree = Tree.Make(Hash)
-     and module Tag = Tag.Make(Hash)
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module Deflate := Deflate
+     and module Blob     = Blob.Make(Hash)
+     and module Commit   = Commit.Make(Hash)
+     and module Tree     = Tree.Make(Hash)
+     and module Tag      = Tag.Make(Hash)
      and type t = Value.Make(Hash)(Inflate)(Deflate).t
 
   module Reference: Reference.IO
-    with module Hash = Hash
-     and module FS = FS
+    with module Hash := Hash
+     and module FS   := FS
 
   module HDec: Unpack.H
-    with module Hash = Hash
+    with module Hash := Hash
 
   module PDec: Unpack.P
-    with module Hash = Hash
-     and module Inflate = Inflate
-     and module Hunk := HDec
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module Hunk    := HDec
 
   module RPDec: Unpack.D
-    with module Hash = Hash
-     and module Inflate = Inflate
-     and module Hunk := HDec
-     and module Pack := PDec
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module Hunk    := HDec
+     and module Pack    := PDec
+     and module Mapper  := FS.Mapper
 
   module PEnc: Pack.P
-    with module Hash = Hash
-     and module Deflate = Deflate
+    with module Hash    := Hash
+     and module Deflate := Deflate
 
   module IDec: Index_pack.LAZY
-    with module Hash = Hash
+    with module Hash := Hash
 
   module IEnc: Index_pack.ENCODER
-    with module Hash = Hash
+    with module Hash := Hash
 
   module PInfo: Pack_info.S
-    with module Hash = Hash
-     and module Inflate = Inflate
-     and module HDec := HDec
-     and module PDec := PDec
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module HDec    := HDec
+     and module PDec    := PDec
 
   module Packed_refs: Packed_refs.S
-    with module Hash = Hash
-     and module FS = FS
+    with module Hash := Hash
+     and module FS   := FS
 
   type error =
     [ `Delta             of PEnc.Delta.error
@@ -203,22 +213,22 @@ module type S = sig
     with type t = Value.t
      and type state = t
      and type error = error
-     and module Hash = Hash
-     and module Inflate = Inflate
-     and module Deflate = Deflate
-     and module FS = FS
+     and module Hash    := Hash
+     and module Inflate := Inflate
+     and module Deflate := Deflate
+     and module FS      := FS
 
   module Pack: PACK
     with type t = RPDec.Object.t
      and type value = Value.t
      and type state = t
      and type error = error
-     and module Hash = Hash
-     and module FS = FS
-     and module Inflate = Inflate
-     and module HDec := HDec
-     and module PDec := PDec
-     and module RPDec := RPDec
+     and module Hash    := Hash
+     and module FS      := FS
+     and module Inflate := Inflate
+     and module HDec    := HDec
+     and module PDec    := PDec
+     and module RPDec   := RPDec
 
   type kind =
     [ `Commit
@@ -277,9 +287,9 @@ module type S = sig
   val has_global_checkout: bool
 end
 
-module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
+module Make (H: Digestif.S) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
 
-  module Hash = H
+  module Hash = Hash.Make(H)
   module Inflate = I
   module Deflate = D
   module FS = FS
@@ -291,41 +301,18 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
 
   module HDec = Unpack.Hunk(Hash)
   module PDec = Unpack.Pack(Hash)(Inflate)(HDec)
-  module RPDec = Unpack.Decoder(Hash)(struct
-      type t = FS.t
-      type error = FS.error
-      include FS.Mapper
-    end)(Inflate)(HDec)(PDec)
+  module RPDec = Unpack.Decoder(Hash)(FS.Mapper)(Inflate)(HDec)(PDec)
 
-  module PackImpl
-    : Pack_engine.S
-      with module Hash = Hash
-       and module FS = FS
-       and module Inflate = Inflate
-       and module Deflate = Deflate
-       and module HDec := HDec
-       and module PDec := PDec
-       and module RPDec := RPDec
-    = Pack_engine.Make(H)(FS)(I)(D)(HDec)(PDec)(RPDec)
+  module PackImpl = Pack_engine.Make(Hash)(FS)(I)(D)(HDec)(PDec)(RPDec)
 
-  module Value
-    : Value.S
-      with module Hash = H
-       and module Inflate = I
-       and module Deflate = D
-       and module Blob = Blob.Make(Hash)
-       and module Commit = Commit.Make(Hash)
-       and module Tree = Tree.Make(Hash)
-       and module Tag = Tag.Make(Hash)
-       and type t = Value.Make(Hash)(Inflate)(Deflate).t
-    = Value.Make(Hash)(Inflate)(Deflate)
+  module Value = Value.Make(Hash)(Inflate)(Deflate)
 
   module PEnc = PackImpl.PEnc
   module IDec = PackImpl.IDec
   module IEnc = PackImpl.IEnc
   module PInfo = PackImpl.PInfo
   module Packed_refs = Packed_refs.Make(Hash)(FS)
-  module Reference = Reference.IO(H)(FS)
+  module Reference = Reference.IO(Hash)(FS)
 
   module DoubleHash = struct
     type t = Hash.t * Hash.t
@@ -348,19 +335,24 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
       (DoubleHash)
       (struct type t = RPDec.Object.t let weight _ = 1 end)
 
+  module H = struct
+    type t = Hash.t
+    let hash = Hashtbl.hash
+    let equal x y = Hash.unsafe_compare x y = 0
+  end
   module CacheValue =
     Lru.M.Make
-      (Hash)
+      (H)
       (struct type t = Value.t let weight _ = 1 end)
 
   module CachePack =
     Lru.M.Make
-      (Hash)
+      (H)
       (struct type t = PDec.t let weight _ = 1 end) (* fixed size *)
 
   module CacheIndex =
     Lru.M.Make
-      (Hash)
+      (H)
       (* not fixed size by consider than it's ok. *)
       (struct type t = IDec.t let weight _ = 1 end)
 
@@ -680,8 +672,9 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
     module GC =
       Collector.Make(struct
         module Hash = Hash
-        module Value = Value
+        module Inflate = Inflate
         module Deflate = Deflate
+        module Value = Value
         module PEnc = PEnc
 
         type nonrec t = state
@@ -692,8 +685,6 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
         let read_inflated = extern
         let contents _ = assert false
       end)
-
-    module Map = GC.Graph
 
     let make = GC.make_stream
 
@@ -819,6 +810,8 @@ module Make (H: S.HASH) (FS: S.FS) (I: S.INFLATE) (D: S.DEFLATE) = struct
   module T =
     Traverse_bfs.Make(struct
       module Hash = Hash
+      module Inflate = Inflate
+      module Deflate = Deflate
       module Value = Value
 
       type nonrec t = t

--- a/src/git/sync.ml
+++ b/src/git/sync.ml
@@ -50,8 +50,8 @@ module type S = sig
   module Store: Minimal.S
   module Net: NET
   module Client: Smart.CLIENT
-    with module Hash = Store.Hash
-     and module Reference = Store.Reference
+    with module Hash      := Store.Hash
+     and module Reference := Store.Reference
 
   type error =
     [ `SmartPack of string

--- a/src/git/sync.mli
+++ b/src/git/sync.mli
@@ -33,8 +33,8 @@ module type S = sig
   module Store: Minimal.S
   module Net: NET
   module Client: Smart.CLIENT
-    with module Hash = Store.Hash
-     and module Reference = Store.Reference
+    with module Hash      := Store.Hash
+     and module Reference := Store.Reference
 
   (** The error type. *)
   type error =
@@ -245,7 +245,7 @@ sig
     Store.t ->
     ofs_delta:bool ->
     (Store.Hash.t * Store.Reference.t * bool) list -> command list ->
-    (Store.Pack.stream * (Crc32.t * int64) Store.Pack.Map.t Lwt_mvar.t, Store.error) result Lwt.t
+    (Store.Pack.stream * (Crc32.t * int64) Store.Hash.Map.t Lwt_mvar.t, Store.error) result Lwt.t
 
   val want_handler:
     Store.t ->

--- a/src/git/tag.mli
+++ b/src/git/tag.mli
@@ -53,7 +53,8 @@ module type S = sig
   module M: S.DESC    with type 'a t = 'a Encore.Encoder.t and type e = t
   module D: S.DECODER with type t = t and type init = Cstruct.t and type error = Error.Decoder.t
   module E: S.ENCODER with type t = t and type init = int * t and type error = Error.never
-  include S.DIGEST    with type t := t and type hash = Hash.t
+  include S.DIGEST    with type t := t and type hash := Hash.t
+
   include S.BASE      with type t := t
 
   val length: t -> int64
@@ -70,6 +71,6 @@ module type S = sig
   val tagger: t -> User.t option
 end
 
-module Make (Hash: S.HASH): S with module Hash = Hash
+module Make (Hash: S.HASH): S with module Hash := Hash
 (** The {i functor} to make the OCaml representation of the Git Tag
     object by a specific hash implementation. *)

--- a/src/git/traverse_bfs.ml
+++ b/src/git/traverse_bfs.ml
@@ -15,9 +15,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+let src = Logs.Src.create "git.traverse" ~doc:"logs git's traverse event"
+module Log = (val Logs.src_log src : Logs.LOG)
+
 module type STORE = sig
   module Hash: S.HASH
-  module Value: Value.S with module Hash = Hash
+  module Inflate: S.INFLATE
+  module Deflate: S.DEFLATE
+
+  module Value: Value.S
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module Deflate := Deflate
 
   type t
   type error
@@ -26,14 +35,8 @@ module type STORE = sig
   val read : t -> Hash.t -> (Value.t, error) result Lwt.t
 end
 
-module Make (S : STORE) = struct
+module Make (S: STORE) = struct
   open S
-
-  module Log =
-  struct
-    let src = Logs.Src.create "git.traverse" ~doc:"logs git's traverse event"
-    include (val Logs.src_log src : Logs.LOG)
-  end
 
   (* XXX(dinosaure): convenience and common part between the
      file-system and the mem back-end - to avoid redundant code. *)

--- a/src/git/traverse_bfs.mli
+++ b/src/git/traverse_bfs.mli
@@ -17,7 +17,13 @@
 
 module type STORE = sig
   module Hash: S.HASH
-  module Value: Value.S with module Hash = Hash
+  module Inflate: S.INFLATE
+  module Deflate: S.DEFLATE
+
+  module Value: Value.S
+    with module Hash    := Hash
+     and module Inflate := Inflate
+     and module Deflate := Deflate
 
   type t
   type error
@@ -26,7 +32,7 @@ module type STORE = sig
   val read : t -> Hash.t -> (Value.t, error) result Lwt.t
 end
 
-module Make (S : STORE): sig
+module Make (S: STORE): sig
 
   val fold:
     S.t -> ('a -> ?name:Fpath.t -> length:int64 -> S.Hash.t -> S.Value.t -> 'a Lwt.t) ->

--- a/src/git/tree.mli
+++ b/src/git/tree.mli
@@ -68,7 +68,8 @@ module type S = sig
   module M: S.DESC    with type 'a t = 'a Encore.Encoder.t and type e = t
   module D: S.DECODER with type t = t and type init = Cstruct.t and type error = Error.Decoder.t
   module E: S.ENCODER with type t = t and type init = int * t and type error = Error.never
-  include S.DIGEST    with type t := t and type hash = Hash.t
+  include S.DIGEST    with type t := t and type hash := Hash.t
+
   include S.BASE      with type t := t
 
   val length: t -> int64
@@ -82,6 +83,6 @@ module type S = sig
   val iter: (entry -> unit) -> t -> unit
 end
 
-module Make (Hash: S.HASH): S with module Hash = Hash
+module Make (Hash: S.HASH): S with module Hash := Hash
 (** The {i functor} to make the OCaml representation of the Git Tree
     object by a specific hash implementation. *)

--- a/src/git/unpack.mli
+++ b/src/git/unpack.mli
@@ -177,14 +177,14 @@ module type H = sig
       when he {!make} the new decoder. *)
 end
 
-module Hunk (Hash : S.HASH) : H with module Hash = Hash
+module Hunk (Hash: S.HASH): H with module Hash := Hash
 
 (** The non-blocking decoder of the PACK stream. *)
 module type P = sig
 
-  module Hash: S.HASH
+  module Hash   : S.HASH
   module Inflate: S.INFLATE
-  module Hunk: H with module Hash := Hash
+  module Hunk   : H with module Hash := Hash
 
   (** The type error. *)
   type error =
@@ -425,24 +425,24 @@ module type P = sig
 end
 
 module Pack
-    (Hash: S.HASH)
+    (Hash   : S.HASH)
     (Inflate: S.INFLATE)
-    (Hunk: H with module Hash := Hash)
-  : P with module Hash = Hash
-       and module Inflate = Inflate
-       and module Hunk := Hunk
+    (Hunk   : H with module Hash := Hash)
+  : P with module Hash    := Hash
+       and module Inflate := Inflate
+       and module Hunk    := Hunk
 
 (** The toolbox about the PACK file. *)
 module type D = sig
 
-  module Hash: S.HASH
-  module Mapper: S.MAPPER
+  module Hash   : S.HASH
+  module Mapper : S.MAPPER
   module Inflate: S.INFLATE
   module Hunk: H with module Hash := Hash
   module Pack: P
-    with module Hash := Hash
+    with module Hash    := Hash
      and module Inflate := Inflate
-     and module Hunk := Hunk
+     and module Hunk    := Hunk
 
   (** The type error. *)
   type error =
@@ -694,31 +694,31 @@ module type D = sig
 end
 
 module Decoder
-    (Hash: S.HASH)
-    (Mapper: S.MAPPER)
+    (Hash   : S.HASH)
+    (Mapper : S.MAPPER)
     (Inflate: S.INFLATE)
     (Hunk: H with module Hash := Hash)
     (Pack: P with module Hash := Hash
-                      and module Inflate := Inflate
-                      and module Hunk := Hunk)
-  : D with module Hash = Hash
-       and module Mapper = Mapper
-       and module Inflate = Inflate
-       and module Hunk := Hunk
-       and module Pack := Pack
+              and module Inflate := Inflate
+              and module Hunk    := Hunk)
+  : D with module Hash    := Hash
+       and module Mapper  := Mapper
+       and module Inflate := Inflate
+       and module Hunk    := Hunk
+       and module Pack    := Pack
 
 module Stream
-    (Hash: S.HASH)
+    (Hash   : S.HASH)
     (Inflate: S.INFLATE) : sig
   include P
-end with module Hash = Hash
-     and module Inflate = Inflate
+end with module Hash    := Hash
+     and module Inflate := Inflate
 
 module Random_access
-    (Hash: S.HASH)
-    (Mapper: S.MAPPER)
+    (Hash   : S.HASH)
+    (Mapper : S.MAPPER)
     (Inflate: S.INFLATE) : sig
   include D
-end with module Hash = Hash
-     and module Mapper = Mapper
-     and module Inflate = Inflate
+end with module Hash    := Hash
+     and module Mapper  := Mapper
+     and module Inflate := Inflate

--- a/src/git/value.mli
+++ b/src/git/value.mli
@@ -20,14 +20,14 @@
 (** Interface which describes the Git object. *)
 module type S = sig
 
-  module Hash: S.HASH
+  module Hash   : S.HASH
   module Inflate: S.INFLATE
   module Deflate: S.DEFLATE
 
-  module Blob: Blob.S with module Hash = Hash
-  module Commit: Commit.S with module Hash = Hash
-  module Tree: Tree.S with module Hash = Hash
-  module Tag: Tag.S with module Hash = Hash
+  module Blob  : Blob.S   with module Hash := Hash
+  module Commit: Commit.S with module Hash := Hash
+  module Tree  : Tree.S   with module Hash := Hash
+  module Tag   : Tag.S    with module Hash := Hash
 
   type t =
     | Blob   of Blob.t   (** The {!Blob.t} OCaml value. *)
@@ -77,7 +77,14 @@ end
     serialization/unserialization to a {!Cstruct.t}. *)
 module type RAW = sig
 
-  module Value: S
+  module Hash   : S.HASH
+  module Inflate: S.INFLATE
+  module Deflate: S.DEFLATE
+
+  module Value: S with module Hash    := Hash
+                   and module Inflate := Inflate
+                   and module Deflate := Deflate
+
   include module type of Value
 
   module EncoderRaw: S.ENCODER with type t = t and type init = int * t and type error = Error.never
@@ -119,13 +126,13 @@ module type RAW = sig
 end
 
 module Make (Hash: S.HASH) (Inflate: S.INFLATE) (Deflate: S.DEFLATE): S
-  with module Hash = Hash
-   and module Inflate = Inflate
-   and module Deflate = Deflate
-   and module Blob = Blob.Make(Hash)
-   and module Commit = Commit.Make(Hash)
-   and module Tree = Tree.Make(Hash)
-   and module Tag = Tag.Make(Hash)
+  with module Hash    := Hash
+   and module Inflate := Inflate
+   and module Deflate := Deflate
+   and module Blob     = Blob.Make(Hash)
+   and module Commit   = Commit.Make(Hash)
+   and module Tree     = Tree.Make(Hash)
+   and module Tag      = Tag.Make(Hash)
 (** The {i functor} to make the OCaml representation of the Git object
     by a specific hash implementation, an {!S.INFLATE} implementation
     for the decompression and a {!S.DEFLATE} implementation for the
@@ -144,14 +151,14 @@ module Make (Hash: S.HASH) (Inflate: S.INFLATE) (Deflate: S.DEFLATE): S
 *)
 
 module Raw (Hash: S.HASH) (Inflate: S.INFLATE) (Deflate: S.DEFLATE): RAW
-  with module Hash = Hash
-   and module Inflate = Inflate
-   and module Deflate = Deflate
-   and module Value = Make(Hash)(Inflate)(Deflate)
-   and module Blob = Blob.Make(Hash)
-   and module Commit = Commit.Make(Hash)
-   and module Tree = Tree.Make(Hash)
-   and module Tag = Tag.Make(Hash)
+  with module Hash    := Hash
+   and module Inflate := Inflate
+   and module Deflate := Deflate
+   and module Blob     = Blob.Make(Hash)
+   and module Commit   = Commit.Make(Hash)
+   and module Tree     = Tree.Make(Hash)
+   and module Tag      = Tag.Make(Hash)
+   and module Value    = Make(Hash)(Inflate)(Deflate)
    and type t = Make(Hash)(Inflate)(Deflate).t
 (** The {i functor} to make the OCaml representation of the Git object
     by a specific hash implementation, and {!S.INFLATE} implementation

--- a/test/common/test_data.ml
+++ b/test/common/test_data.ml
@@ -77,7 +77,7 @@ module Make0 (Source : SOURCE) (Store : S) = struct
       Astring.String.for_all
         (function 'a' .. 'f' | 'A' .. 'F' | '0' .. '9' -> true | _ -> false)
         s
-      && String.length s = Store.Hash.Digest.length * 2
+      && String.length s = Store.Hash.digest_size * 2
     in
     List.fold_left
       (fun acc line ->
@@ -136,7 +136,7 @@ module Make0 (Source : SOURCE) (Store : S) = struct
       | `Flush t ->
           Git.Buffer.add buf (Cstruct.sub ctmp 0 (E.used_out t)) ;
           let ctx =
-            Store.Hash.Digest.feed_c ctx (Cstruct.sub ctmp 0 (E.used_out t))
+            Store.Hash.feed_cstruct ctx (Cstruct.sub ctmp 0 (E.used_out t))
           in
           go ctx (E.flush 0 (Cstruct.len ctmp) t)
       | `Error (_, err) ->
@@ -145,12 +145,12 @@ module Make0 (Source : SOURCE) (Store : S) = struct
       | `End t ->
           if E.used_out t > 0 then (
             Git.Buffer.add buf (Cstruct.sub ctmp 0 (E.used_out t)) ;
-            Store.Hash.Digest.feed_c ctx (Cstruct.sub ctmp 0 (E.used_out t)) )
+            Store.Hash.feed_cstruct ctx (Cstruct.sub ctmp 0 (E.used_out t)) )
           else ctx
     in
     let _ =
       go
-        (Store.Hash.Digest.init ())
+        (Store.Hash.init ())
         (E.default (fun f -> R.iter (fun k v -> f (k, v)) tree) hash_pack)
     in
     if String.equal (load_file Source.idx) (Git.Buffer.contents buf) then

--- a/test/git-mirage/test.ml
+++ b/test/git-mirage/test.ml
@@ -125,7 +125,7 @@ module MirageConduit: Git_mirage.Net.CONDUIT = struct
 end
 
 module Store = struct
-  include Git.Mem.Store(Digestif.SHA1)
+  include Git.Mem.Store
   let v root = v root
 end
 

--- a/test/git-unix/test.ml
+++ b/test/git-unix/test.ml
@@ -84,7 +84,7 @@ module Https (Store: Test_store.S) = Test_sync.Make(struct
   end)
 
 module Mem_store = struct
-  include Git.Mem.Store(Digestif.SHA1)
+  include Git.Mem.Store
   let v root = v root
 end
 

--- a/test/git/test.ml
+++ b/test/git/test.ml
@@ -17,7 +17,7 @@
 open Test_common
 
 module Store = struct
-  include Git.Mem.Store(Digestif.SHA1)
+  include Git.Mem.Store
   let v root = v root
 end
 

--- a/test/smart/test_smart.ml
+++ b/test/smart/test_smart.ml
@@ -19,7 +19,9 @@ struct
     let cs = Cstruct.create 8 in
     Cstruct.BE.set_uint64 cs 0 Int64.(of_float (t *. 1000.));
     Nocrypto.Rng.reseed cs;
-    Nocrypto.Rng.generate S.Hash.Digest.length |> Cstruct.to_string |> S.Hash.of_string
+    Nocrypto.Rng.generate S.Hash.digest_size
+    |> Cstruct.to_string
+    |> S.Hash.of_raw_string
 
   let generate_hashes n =
     let ar = Array.init n (fun _ -> generate_hash ()) in
@@ -39,7 +41,7 @@ struct
     ; "refs/remotes/origin/server"
     ; "refs/remotes/upstream/server"
     ; "refs/remotes/upstream/clean" ]
-    |> List.map S.Reference.of_string 
+    |> List.map S.Reference.of_string
 
   module Data =
   struct
@@ -222,7 +224,7 @@ struct
       ; git_proto_request3, git_proto_request_result3 ]
 
     let zero =
-      let s = String.make (S.Hash.Digest.length * 2) '0' in
+      let s = String.make (S.Hash.digest_size * 2) '0' in
       S.Hash.of_hex s
 
     let update_request0, update_request_result0 =


### PR DESCRIPTION
Use Digestif.S instead of custom hash signature

The patch is too invasive to my taste, but I had to flatten a lot of the modules hiearchies to make everyting compile...