### PR TITLE
Common sync

### DIFF
--- a/src/git-http/sync.mli
+++ b/src/git-http/sync.mli
@@ -36,7 +36,7 @@ end
 module Lwt_cstruct_flow :
   FLOW with type raw = Cstruct.t and type +'a io = 'a Lwt.t
 
-module type S_EXT = sig
+module type S = sig
   module Web : Web.S
 
   module Client :
@@ -46,235 +46,16 @@ module type S_EXT = sig
      and type uri = Web.uri
      and type resp = Web.resp
 
-  module Store : Git.S
+  module Endpoint : sig
+    type t = {uri: Uri.t; headers: Web.HTTP.headers}
 
-  module Common :
-    Git.Smart.COMMON
-    with type hash := Store.Hash.t
-     and type reference := Store.Reference.t
+    include Git.Sync.ENDPOINT with type t := t
+  end
 
-  module Decoder :
-    Git.Smart.DECODER
-    with module Hash := Store.Hash
-     and module Reference := Store.Reference
-     and module Common := Common
-
-  module Encoder :
-    Git.Smart.ENCODER
-    with module Hash := Store.Hash
-     and module Reference := Store.Reference
-     and module Common := Common
-
-  type error =
-    [`Smart of Decoder.error | `Store of Store.error | `Sync of string]
-
-  val pp_error : error Fmt.t
-
-  val ls :
-       Store.t
-    -> ?headers:Web.HTTP.headers
-    -> ?https:bool
-    -> ?port:int
-    -> ?capabilities:Git.Capability.t list
-    -> string
-    -> string
-    -> (Common.advertised_refs, error) result Lwt.t
-
-  type command =
-    [ `Create of Store.Hash.t * Store.Reference.t
-    | `Delete of Store.Hash.t * Store.Reference.t
-    | `Update of Store.Hash.t * Store.Hash.t * Store.Reference.t ]
-
-  val push :
-       Store.t
-    -> push:(   (Store.Hash.t * Store.Reference.t * bool) list
-             -> (Store.Hash.t list * command list) Lwt.t)
-    -> ?headers:Web.HTTP.headers
-    -> ?https:bool
-    -> ?port:int
-    -> ?capabilities:Git.Capability.t list
-    -> string
-    -> string
-    -> ( (Store.Reference.t, Store.Reference.t * string) result list
-       , error )
-       result
-       Lwt.t
-
-  val fetch :
-       Store.t
-    -> ?shallow:Store.Hash.t list
-    -> ?stdout:(Cstruct.t -> unit Lwt.t)
-    -> ?stderr:(Cstruct.t -> unit Lwt.t)
-    -> ?headers:Web.HTTP.headers
-    -> ?https:bool
-    -> ?capabilities:Git.Capability.t list
-    -> negociate:(   Common.acks
-                  -> 'state
-                  -> ([`Ready | `Done | `Again of Store.Hash.Set.t] * 'state)
-                     Lwt.t)
-                 * 'state
-    -> have:Store.Hash.Set.t
-    -> want:(   (Store.Hash.t * Store.Reference.t * bool) list
-             -> (Store.Reference.t * Store.Hash.t) list Lwt.t)
-    -> ?deepen:[`Depth of int | `Timestamp of int64 | `Ref of Store.Reference.t]
-    -> ?port:int
-    -> string
-    -> string
-    -> ((Store.Reference.t * Store.Hash.t) list * int, error) result Lwt.t
-
-  val clone_ext :
-       Store.t
-    -> ?stdout:(Cstruct.t -> unit Lwt.t)
-    -> ?stderr:(Cstruct.t -> unit Lwt.t)
-    -> ?headers:Web.HTTP.headers
-    -> ?https:bool
-    -> ?port:int
-    -> ?reference:Store.Reference.t
-    -> ?capabilities:Git.Capability.t list
-    -> string
-    -> string
-    -> (Store.Hash.t, error) result Lwt.t
-
-  val fetch_some :
-       Store.t
-    -> ?capabilities:Git.Capability.t list
-    -> ?headers:Web.HTTP.headers
-    -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
-    -> ( Store.Hash.t Store.Reference.Map.t
-         * Store.Reference.t list Store.Reference.Map.t
-       , error )
-       result
-       Lwt.t
-  (** [fetch_some git ?capabilities ~references repository] will fetch some
-      remote references specified by [references].
-
-      [references] is a map which: {ul {- the key is the {b remote} reference.}
-      {- the value is a list of {b local} references - which may not exist
-      yet.}}
-
-      Then, the function will try to download all of these remote references
-      and returns 2 maps:
-
-      {ul {- the first map contains all local references updated by the new
-      hash. This new hash is come from the server as the downloaded remote
-      reference asked by the client by [references]. Then, from associated
-      local references with remote references, we updated them with the
-      associated hash.
-
-      For example, if [references] is: {[ { "refs/heads/master": [
-      "refs/remotes/origin/master" ; "refs/heads/master" ] } ]}
-
-      We will update (or create) "refs/remotes/origin/master" and
-      "refs/heads/master" with the new hash downloaded from the remote
-      reference "refs/heads/master" only if it's necessary (only if we did not
-      find the hash referenced by "refs/heads/master" in the local store).}
-
-      {- the second map is a {b subset} of [references] which contains all
-      binder of:
-
-      {ul {- remote references which does not exist on the server side.} {-
-      remote references which references to an already existing in the local
-      store hash.}}}}
-
-      The client should not put the same local reference as a value of some
-      remote references. The client can define non-existing remote references
-      (then, they appear on the second map). The client can want to set
-      non-existing local references - we will create them.
-
-      If the processus encountered an error when it updates references, it
-      leaves but, it did partially some update on some local references. *)
-
-  val fetch_all :
-       Store.t
-    -> ?capabilities:Git.Capability.t list
-    -> ?headers:Web.HTTP.headers
-    -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
-    -> ( Store.Hash.t Store.Reference.Map.t
-         * Store.Reference.t list Store.Reference.Map.t
-         * Store.Hash.t Store.Reference.Map.t
-       , error )
-       result
-       Lwt.t
-  (** [fetch_all git ?capabilities ~references repository] has the same
-      semantic than {!fetch_some} for any remote references found on
-      [references]. However, [fetch all] will download all remote references
-      available on the server (and whose hash is not available on the local
-      store). If these remote references are not associated with some local
-      references, we return a third map which contains these remote references
-      binded with the new hash downloaded.
-
-      We {b don't} notice any non-downloaded remote references not found on the
-      [references] map and whose hash already exists on the local store.
-
-      Then, the client can bind these new hashes with specific local references
-      or just give up. *)
-
-  val fetch_one :
-       Store.t
-    -> ?capabilities:Git.Capability.t list
-    -> ?headers:Web.HTTP.headers
-    -> reference:Store.Reference.t * Store.Reference.t list
-    -> Uri.t
-    -> ( [`AlreadySync | `Sync of Store.Hash.t Store.Reference.Map.t]
-       , error )
-       result
-       Lwt.t
-  (** [fetch_one git ?capabilities ~reference repository] is a specific call of
-      {!fetch_some} with only one reference. Then, it retuns:
-
-      {ul {- [`AlreadySync] if the hash of the requested reference already
-      exists on the local store} {- [`Sync updated] if we downloaded [new_hash]
-      and set [local_ref] with this new hash.}} *)
-
-  val clone :
-       Store.t
-    -> ?capabilities:Git.Capability.t list
-    -> ?headers:Web.HTTP.headers
-    -> reference:Store.Reference.t * Store.Reference.t
-    -> Uri.t
-    -> (unit, error) result Lwt.t
-
-  val update_and_create :
-       Store.t
-    -> ?capabilities:Git.Capability.t list
-    -> ?headers:Web.HTTP.headers
-    -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
-    -> ( (Store.Reference.t, Store.Reference.t * string) result list
-       , error )
-       result
-       Lwt.t
-  (** As {!fetch_some}, [update git ?capabilities ~references repository] is
-      the other side of the communication with a Git server and update and
-      create remote references when it uploads local hashes.
-
-      [reference] is a map which: {ul {- the key is the {b local} reference.}
-      {- the value is a list of {b remote} references - which may not exist
-      yet.}}
-
-      Then, the function will try to upload all of these local references to
-      the binded remote references. If binded remote reference does not exist
-      on the server, we ask to the server to create and set it to the local
-      hash.
-
-      For each update action, we check if the local store has the remote hash.
-      In other case, we miss this action - that means, the local store is not
-      synchronized with the server (and the client probably needs to
-      {!fetch_some} before).
-
-      Then, it returns a list of results. The [Ok] case with the remote
-      reference which the server updated correctly and the [Error] case with
-      the remote reference which the server encountered an error with a
-      description of this error.
-
-      At this final stage, the function does not encountered any error during
-      the commmunication - if it's the case, we did not do any modification on
-      the server and return an {!error}. *)
+  include Git.Sync.S with module Endpoint := Endpoint
 end
 
-module Make_ext
+module Make
     (W : Web.S
          with type +'a io = 'a Lwt.t
           and type raw = Cstruct.t
@@ -289,10 +70,10 @@ module Make_ext
           and type uri = W.uri
           and type resp = W.resp)
     (G : Git.S) :
-  S_EXT with module Web = W and module Client = C and module Store = G
+  S with module Web = W and module Client = C and module Store = G
 
-module type S =
-  S_EXT
+module type COHTTP_S =
+  S
   with type Web.req = Web_cohttp_lwt.req
    and type Web.resp = Web_cohttp_lwt.resp
    and type 'a Web.io = 'a Web_cohttp_lwt.io
@@ -302,7 +83,7 @@ module type S =
    and type Web.Response.body = Web_cohttp_lwt.Response.body
    and type Web.HTTP.headers = Web_cohttp_lwt.HTTP.headers
 
-module Make
+module CohttpMake
     (C : CLIENT
          with type +'a io = 'a Lwt.t
           and type headers = Web_cohttp_lwt.HTTP.headers
@@ -310,4 +91,4 @@ module Make
           and type meth = Web_cohttp_lwt.HTTP.meth
           and type uri = Web_cohttp_lwt.uri
           and type resp = Web_cohttp_lwt.resp)
-    (S : Git.S) : S with module Client = C and module Store = S
+    (S : Git.S) : COHTTP_S with module Client = C and module Store = S

--- a/src/git-http/sync.mli
+++ b/src/git-http/sync.mli
@@ -66,10 +66,7 @@ module type S_EXT = sig
      and module Common := Common
 
   type error =
-    [ `SmartDecoder of Decoder.error
-    | `Store of Store.error
-    | `Clone of string
-    | `ReportStatus of string ]
+    [`Smart of Decoder.error | `Store of Store.error | `Sync of string]
 
   val pp_error : error Fmt.t
 

--- a/src/git-http/web.ml
+++ b/src/git-http/web.ml
@@ -74,6 +74,9 @@ module type S = sig
       (** [get n hs] is like {!find} but @raise Invalid_argument if [n] is
           undefined in [hs]. *)
 
+      val pp : headers Fmt.t
+      (** Pretty-printer of headers. *)
+
       (** {1:hcst Header name values} *)
 
       val user_agent : name

--- a/src/git-http/web_cohttp_lwt.ml
+++ b/src/git-http/web_cohttp_lwt.ml
@@ -40,6 +40,7 @@ module HTTP = struct
       | Some v -> v
       | None -> raise (Invalid_argument "HTTP.Headers.get: invalid name")
 
+    let pp = Cohttp.Header.pp_hum
     let user_agent = "User-Agent"
     let content_type = "Content-Type"
     let access_control_allow_origin = "Access-Control-Allow-Origin"

--- a/src/git-mirage/git_mirage.ml
+++ b/src/git-mirage/git_mirage.ml
@@ -13,6 +13,6 @@ module Store (X : Mirage_fs_lwt.S) = struct
     v ?dotgit ?compression ?buffer fs root
 end
 
-module Sync (C : Net.CONDUIT) = Git.Sync.Make (Net.Make (C))
+module Sync (C : Net.CONDUIT) = Git.Tcp.Make (Net.Make (C))
 
 (* module HTTP = Git_http.Sync.Make(Client) *)

--- a/src/git-mirage/git_mirage.mli
+++ b/src/git-mirage/git_mirage.mli
@@ -1,8 +1,8 @@
 module Net = Net
 module FS = Fs
 
-module Sync (C : Net.CONDUIT) (S : Git.S) :
-  Git.Sync.S with module Store = S and module Net = Net.Make(C)
+module Sync (C : Net.CONDUIT) (G : Git.S) :
+  Git.Sync.S with module Store = G and module Endpoint = Git.Gri
 
 module Store (X : Mirage_fs_lwt.S) : sig
   include Git.Store.S with module Hash = Git.Hash.Make(Digestif.SHA1)

--- a/src/git-mirage/net.ml
+++ b/src/git-mirage/net.ml
@@ -9,6 +9,7 @@ module Make (C : CONDUIT) = struct
   module Flow = Conduit_mirage.Flow
   module Channel = Mirage_channel_lwt.Make (Flow)
 
+  type endpoint = Git.Gri.t
   type socket = {ic: Channel.t; oc: Channel.t}
   type error = Channel.write_error
 
@@ -54,8 +55,9 @@ module Make (C : CONDUIT) = struct
         (* XXX(dinosaure): Channel.error is not a variant. *)
         Lwt.return_ok 0
 
-  let socket uri =
+  let socket (uri : Git.Gri.t) =
     let open Lwt.Infix in
+    let uri = (uri :> Uri.t) in
     Resolver_lwt.resolve_uri ~uri C.resolver
     >>= fun endp ->
     Conduit_mirage.client endp

--- a/src/git-mirage/net.mli
+++ b/src/git-mirage/net.mli
@@ -5,4 +5,4 @@ module type CONDUIT = sig
   val resolver : Resolver_lwt.t
 end
 
-module Make (C : CONDUIT) : Git.Sync.NET
+module Make (C : CONDUIT) : Git.Tcp.NET with type endpoint = Git.Gri.t

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -16,7 +16,7 @@
 
 module Fs = Fs
 module Net = Net
-module Sync = Git.Sync.Make (Net)
+module Sync = Git.Tcp.Make (Net)
 module Http = Http.Make
 module Index = Index
 

--- a/src/git-unix/git_unix.mli
+++ b/src/git-unix/git_unix.mli
@@ -34,5 +34,7 @@ module Store : sig
     -> (t, error) result Lwt.t
 end
 
-module Sync (S : Git.S) : Git.Sync.S with module Store = S and module Net = Net
+module Sync (G : Git.S) :
+  Git.Sync.S with module Store = G and module Endpoint = Git.Gri
+
 module Http (S : Git.S) : Git_http.Sync.S with module Store = S

--- a/src/git-unix/git_unix.mli
+++ b/src/git-unix/git_unix.mli
@@ -37,4 +37,4 @@ end
 module Sync (G : Git.S) :
   Git.Sync.S with module Store = G and module Endpoint = Git.Gri
 
-module Http (S : Git.S) : Git_http.Sync.S with module Store = S
+module Http (G : Git.S) : Git_http.Sync.S with module Store = G

--- a/src/git-unix/http.ml
+++ b/src/git-unix/http.ml
@@ -54,4 +54,4 @@ module Client = struct
     else Lwt.return {resp; body= snd v}
 end
 
-module Make (S : Git.S) = Git_http.Sync.Make (Client) (S)
+module Make (S : Git.S) = Git_http.Sync.CohttpMake (Client) (S)

--- a/src/git-unix/http.mli
+++ b/src/git-unix/http.mli
@@ -8,4 +8,4 @@ module Client :
    and type resp = Git_http.Web_cohttp_lwt.resp
 
 module Make (S : Git.S) :
-  Git_http.Sync.S with module Client = Client and module Store = S
+  Git_http.Sync.COHTTP_S with module Client = Client and module Store = S

--- a/src/git-unix/net.ml
+++ b/src/git-unix/net.ml
@@ -2,6 +2,7 @@ let src = Logs.Src.create "git-tcp.net" ~doc:"logs git's net I/O event"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
+type endpoint = Git.Gri.t
 type socket = Lwt_unix.file_descr
 type error = [`Unix of exn]
 
@@ -32,8 +33,9 @@ let host uri =
   | None ->
       Fmt.kstrf failwith "Expected a git url with host: %a." Uri.pp_hum uri
 
-let socket uri =
+let socket (uri : Git.Gri.t) =
   let open Lwt.Infix in
+  let uri = (uri :> Uri.t) in
   Log.debug (fun l ->
       l ~header:"socket" "Start to open connection on %a." Uri.pp_hum uri ) ;
   let socket = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in

--- a/src/git-unix/net.mli
+++ b/src/git-unix/net.mli
@@ -1,1 +1,4 @@
-include Git.Sync.NET with type socket = Lwt_unix.file_descr
+include
+  Git.Tcp.NET
+  with type socket = Lwt_unix.file_descr
+   and type endpoint = Git.Gri.t

--- a/src/git-unix/ogit-http-fetch-all/main.ml
+++ b/src/git-unix/ogit-http-fetch-all/main.ml
@@ -93,7 +93,8 @@ let main directory repository =
   Store.v root
   >>!= store_err
   >>?= fun git ->
-  Sync_http.fetch_all git ~references:Store.Reference.Map.empty repository
+  Sync_http.fetch_all git ~references:Store.Reference.Map.empty
+    Sync_http.{uri= repository; headers= Web.HTTP.Headers.empty}
   >>!= sync_err
   >>?= fun _ -> Lwt.return (Ok ())
 

--- a/src/git-unix/ogit-http-fetch/main.ml
+++ b/src/git-unix/ogit-http-fetch/main.ml
@@ -101,7 +101,8 @@ let main references directory repository =
   Store.v root
   >>!= store_err
   >>?= fun git ->
-  Sync_http.fetch_some git ~references repository
+  Sync_http.fetch_some git ~references
+    Sync_http.{uri= repository; headers= Web.HTTP.Headers.empty}
   >>!= sync_err
   >>?= fun _ -> Lwt.return (Ok ())
 

--- a/src/git/git.ml
+++ b/src/git/git.ml
@@ -36,3 +36,5 @@ module Inflate = Inflate
 module Deflate = Deflate
 module Buffer = Cstruct_buffer
 module Hash = Hash
+module Gri = Gri
+module Tcp = Tcp

--- a/src/git/git.mli
+++ b/src/git/git.mli
@@ -32,6 +32,8 @@ module Inflate = Inflate
 module Deflate = Deflate
 module Buffer = Cstruct_buffer
 module Hash = Hash
+module Gri = Gri
+module Tcp = Tcp
 
 module type FILE = S.FILE
 module type MAPPER = S.MAPPER

--- a/src/git/gri.ml
+++ b/src/git/gri.ml
@@ -1,0 +1,19 @@
+type t = Uri.t
+
+let host uri =
+  match Uri.host uri with
+  | Some host -> host
+  | None -> Fmt.invalid_arg "Invalid gri: no host"
+
+let path uri = Uri.path_and_query uri
+let pp ppf x = Fmt.string ppf (Uri.to_string x)
+
+let make : Uri.t -> t =
+ fun uri ->
+  match Uri.scheme uri, Uri.host uri with
+  | Some "git", Some _ -> uri
+  | Some scheme, _ -> Fmt.invalid_arg "Invalid gri: invalid scheme (%s)" scheme
+  | _, None -> Fmt.invalid_arg "Invalid gri: no host"
+  | None, Some _ -> Fmt.invalid_arg "Invalid gri: no scheme"
+
+let of_string x = make (Uri.of_string x)

--- a/src/git/gri.mli
+++ b/src/git/gri.mli
@@ -1,0 +1,7 @@
+type t = private Uri.t
+
+val host : t -> string
+val path : t -> string
+val make : Uri.t -> t
+val of_string : string -> t
+val pp : t Fmt.t

--- a/src/git/sync.ml
+++ b/src/git/sync.ml
@@ -145,12 +145,10 @@ module Common (G : Minimal.S) = struct
   module Store = G
   module Revision = Revision.Make (Store)
 
-  module Log = struct
-    let src =
-      Logs.Src.create "git.common.sync" ~doc:"logs git's common sync event"
+  let src =
+    Logs.Src.create "git.common.sync" ~doc:"logs git's common sync event"
 
-    include (val Logs.src_log src : Logs.LOG)
-  end
+  module Log = (val Logs.src_log src : Logs.LOG)
 
   type command =
     [ `Create of Store.Hash.t * Store.Reference.t
@@ -352,8 +350,7 @@ module Common (G : Minimal.S) = struct
             >>= (function
                   | false ->
                       Log.debug (fun l ->
-                          l ~header:"want_handler"
-                            "We missed the reference %a." Store.Reference.pp
+                          l "We missed the reference %a." Store.Reference.pp
                             remote_ref ) ;
                       Lwt.return None
                   | true -> Lwt.return (Some (remote_ref, remote_hash)))
@@ -448,8 +445,7 @@ module Common (G : Minimal.S) = struct
             Store.mem git local_hash
             >>= fun has_local_hash ->
             Log.debug (fun l ->
-                l ~header:"push_handler"
-                  "Check update command on %a for %a to %a (equal = %b)."
+                l "Check update command on %a for %a to %a (equal = %b)."
                   Store.Reference.pp reference Store.Hash.pp remote_hash
                   Store.Hash.pp local_hash
                   Store.Hash.(equal remote_hash local_hash) ) ;

--- a/src/git/sync.ml
+++ b/src/git/sync.ml
@@ -141,6 +141,11 @@ module type S = sig
        Lwt.t
 end
 
+(* XXX(dinosaure): common module is a module (used by the tcp layer, http layer
+   and ssh layer) about what we need to do locally when we push or fetch. This
+   module needs only an implementation of the store and do some operations on
+   it (update references, walk on branches, etc.). *)
+
 module Common (G : Minimal.S) = struct
   module Store = G
   module Revision = Revision.Make (Store)

--- a/src/git/sync.ml
+++ b/src/git/sync.ml
@@ -148,7 +148,6 @@ end
 
 module Common (G : Minimal.S) = struct
   module Store = G
-  module Revision = Revision.Make (Store)
 
   let src =
     Logs.Src.create "git.common.sync" ~doc:"logs git's common sync event"

--- a/src/git/sync.ml
+++ b/src/git/sync.ml
@@ -15,10 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Lwt.Infix
-
-let ( >>!= ) = Lwt_result.bind_lwt_err
-let ( >>?= ) = Lwt_result.bind
 let src = Logs.Src.create "git.sync" ~doc:"logs git's sync event"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -29,32 +25,19 @@ module Default = struct
     ; `Agent "git/2.0.0"; `Report_status; `No_done ]
 end
 
-module type NET = sig
-  type socket
-  type error
+module type ENDPOINT = sig
+  type t
 
-  val pp_error : Format.formatter -> error -> unit
-  val read : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
-  val write : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
-  val socket : Uri.t -> socket Lwt.t
-  val close : socket -> unit Lwt.t
+  val host : t -> string
+  val path : t -> string
+  val pp : t Fmt.t
 end
 
 module type S = sig
   module Store : Minimal.S
-  module Net : NET
+  module Endpoint : ENDPOINT
 
-  module Client :
-    Smart.CLIENT
-    with module Hash := Store.Hash
-     and module Reference := Store.Reference
-
-  type error =
-    [ `Sync of string
-    | `Store of Store.error
-    | `Net of Net.error
-    | `Smart of Client.Decoder.error
-    | `Not_found ]
+  type error
 
   val pp_error : error Fmt.t
 
@@ -70,7 +53,7 @@ module type S = sig
     -> push:(   (Store.Hash.t * Store.Reference.t * bool) list
              -> (Store.Hash.t list * command list) Lwt.t)
     -> ?capabilities:Capability.t list
-    -> Uri.t
+    -> Endpoint.t
     -> ( (Store.Reference.t, Store.Reference.t * string) result list
        , error )
        result
@@ -79,15 +62,23 @@ module type S = sig
   val ls :
        Store.t
     -> ?capabilities:Capability.t list
-    -> Uri.t
+    -> Endpoint.t
     -> ((Store.Hash.t * Store.Reference.t * bool) list, error) result Lwt.t
 
-  val fetch_ext :
+  type shallow_update =
+    {shallow: Store.Hash.t list; unshallow: Store.Hash.t list}
+
+  type acks =
+    { shallow: Store.Hash.t list
+    ; unshallow: Store.Hash.t list
+    ; acks: (Store.Hash.t * [`Common | `Ready | `Continue | `ACK]) list }
+
+  val fetch :
        Store.t
     -> ?shallow:Store.Hash.t list
     -> ?capabilities:Capability.t list
-    -> notify:(Client.Common.shallow_update -> unit Lwt.t)
-    -> negociate:(   Client.Common.acks
+    -> notify:(shallow_update -> unit Lwt.t)
+    -> negociate:(   acks
                   -> 'state
                   -> ([`Ready | `Done | `Again of Store.Hash.Set.t] * 'state)
                      Lwt.t)
@@ -96,21 +87,14 @@ module type S = sig
     -> want:(   (Store.Hash.t * Store.Reference.t * bool) list
              -> (Store.Reference.t * Store.Hash.t) list Lwt.t)
     -> ?deepen:[`Depth of int | `Timestamp of int64 | `Ref of Reference.t]
-    -> Uri.t
+    -> Endpoint.t
     -> ((Store.Reference.t * Store.Hash.t) list * int, error) result Lwt.t
-
-  val clone_ext :
-       Store.t
-    -> ?reference:Store.Reference.t
-    -> ?capabilities:Capability.t list
-    -> Uri.t
-    -> (Store.Hash.t, error) result Lwt.t
 
   val fetch_some :
        Store.t
     -> ?capabilities:Capability.t list
     -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
+    -> Endpoint.t
     -> ( Store.Hash.t Store.Reference.Map.t
          * Store.Reference.t list Store.Reference.Map.t
        , error )
@@ -121,7 +105,7 @@ module type S = sig
        Store.t
     -> ?capabilities:Capability.t list
     -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
+    -> Endpoint.t
     -> ( Store.Hash.t Store.Reference.Map.t
          * Store.Reference.t list Store.Reference.Map.t
          * Store.Hash.t Store.Reference.Map.t
@@ -133,7 +117,7 @@ module type S = sig
        Store.t
     -> ?capabilities:Capability.t list
     -> reference:Store.Reference.t * Store.Reference.t list
-    -> Uri.t
+    -> Endpoint.t
     -> ( [`AlreadySync | `Sync of Store.Hash.t Store.Reference.Map.t]
        , error )
        result
@@ -143,14 +127,14 @@ module type S = sig
        Store.t
     -> ?capabilities:Capability.t list
     -> reference:Store.Reference.t * Store.Reference.t
-    -> Uri.t
+    -> Endpoint.t
     -> (unit, error) result Lwt.t
 
   val update_and_create :
        Store.t
     -> ?capabilities:Capability.t list
     -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
+    -> Endpoint.t
     -> ( (Store.Reference.t, Store.Reference.t * string) result list
        , error )
        result
@@ -481,556 +465,4 @@ module Common (G : Minimal.S) = struct
             | true -> Lwt.return (Some (action :> command))
             | false -> Lwt.return None ) )
       actions
-end
-
-module Make (N : NET) (S : Minimal.S) = struct
-  module Store = S
-  module Net = N
-  module Client = Smart.Client (Store.Hash) (Store.Reference)
-  module Hash = Store.Hash
-  module Inflate = Store.Inflate
-  module Deflate = Store.Deflate
-  module Revision = Revision.Make (Store)
-
-  module Common : module type of Common (Store) with module Store = Store =
-    Common (Store)
-
-  type error =
-    [ `Sync of string
-    | `Store of Store.error
-    | `Net of Net.error
-    | `Smart of Client.Decoder.error
-    | `Not_found ]
-
-  let pp_error ppf = function
-    | `Sync err -> Helper.ppe ~name:"`Sync" Fmt.string ppf err
-    | `Store err -> Helper.ppe ~name:"`Store" Store.pp_error ppf err
-    | `Net err -> Helper.ppe ~name:"`Net" Net.pp_error ppf err
-    | `Smart err -> Helper.ppe ~name:"`Smart" Client.Decoder.pp_error ppf err
-    | `Not_found -> Fmt.string ppf "`Not_found"
-
-  type command = Common.command
-
-  let pp_command = Common.pp_command
-
-  type t =
-    { socket: Net.socket
-    ; input: Bytes.t
-    ; output: Bytes.t
-    ; ctx: Client.context
-    ; capabilities: Capability.t list }
-
-  let err_unexpected_result result =
-    let buf = Buffer.create 64 in
-    let ppf = Fmt.with_buffer buf in
-    Fmt.pf ppf "Unexpected result: %a%!" (Fmt.hvbox Client.pp_result) result ;
-    Buffer.contents buf
-
-  let rec process t result =
-    match result with
-    | `Read (buffer, off, len, continue) -> (
-        Net.read t.socket t.input 0 len
-        >>= function
-        | Ok len ->
-            Cstruct.blit_from_bytes t.input 0 buffer off len ;
-            process t (continue len)
-        | Error err -> Lwt.return_error (`Net err) )
-    | `Write (buffer, off, len, continue) -> (
-        Cstruct.blit_to_bytes buffer off t.output 0 len ;
-        Net.write t.socket t.output 0 len
-        >>= function
-        | Ok n -> process t (continue n)
-        | Error err -> Lwt.return_error (`Net err) )
-    | `Error (err, buf, committed) ->
-        let raw = Cstruct.sub buf committed (Cstruct.len buf - committed) in
-        Log.err (fun l ->
-            l ~header:"process" "Retrieve an error (%a) on: %a."
-              Client.Decoder.pp_error err
-              (Fmt.hvbox
-                 (Encore.Lole.pp_scalar ~get:Cstruct.get_char
-                    ~length:Cstruct.len))
-              raw ) ;
-        Lwt.return_error (`Smart err)
-        (* TODO *)
-    | #Client.result as result -> Lwt.return_ok result
-
-  module Pack = struct
-    let default_stdout raw =
-      Log.info (fun l ->
-          l ~header:"populate:stdout" "%S" (Cstruct.to_string raw) ) ;
-      Lwt.return ()
-
-    let default_stderr raw =
-      Log.err (fun l ->
-          l ~header:"populate:stderr" "%S" (Cstruct.to_string raw) ) ;
-      Lwt.return ()
-
-    let populate git ?(stdout = default_stdout) ?(stderr = default_stderr) ctx
-        first =
-      let stream, push = Lwt_stream.create () in
-      let cstruct_copy cs =
-        let ln = Cstruct.len cs in
-        let rs = Cstruct.create ln in
-        Cstruct.blit cs 0 rs 0 ln ; rs
-      in
-      let rec dispatch ctx = function
-        | `PACK (`Out raw) ->
-            stdout raw
-            >>= fun () ->
-            Client.run ctx.ctx `ReceivePACK |> process ctx >>?= dispatch ctx
-        | `PACK (`Err raw) ->
-            stderr raw
-            >>= fun () ->
-            Client.run ctx.ctx `ReceivePACK |> process ctx >>?= dispatch ctx
-        | `PACK (`Raw raw) ->
-            push (Some (cstruct_copy raw)) ;
-            Client.run ctx.ctx `ReceivePACK |> process ctx >>?= dispatch ctx
-        | `PACK `End -> push None ; Lwt.return (Ok ())
-        | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
-      in
-      dispatch ctx first
-      >>?= fun () ->
-      Store.Pack.from git (fun () -> Lwt_stream.get stream)
-      >>!= fun err -> Lwt.return (`Store err)
-  end
-
-  let rec clone_handler git reference ?hash t r =
-    match r with
-    | `Negociation _ ->
-        Client.run t.ctx `Done
-        |> process t
-        >>?= clone_handler git reference ?hash t
-    | `NegociationResult _ -> (
-        Client.run t.ctx `ReceivePACK
-        |> process t
-        >>?= Pack.populate git t
-        >>= fun res ->
-        match res, hash with
-        | Ok (_, _), Some hash -> Lwt.return (Ok hash)
-        | Ok (_, _), None ->
-            assert false
-            (* XXX(dinosaure): impossible to retrieve this state on
-               `NegociationResult. *)
-        | (Error _ as err), _ -> Lwt.return err )
-    | `ShallowUpdate _ ->
-        Client.run t.ctx (`Has Hash.Set.empty)
-        |> process t
-        >>?= clone_handler git reference ?hash t
-    | `Refs refs -> (
-      try
-        let hash_head, _, _ =
-          List.find
-            (fun (_, reference', peeled) ->
-              Store.Reference.(equal reference reference') && not peeled )
-            refs.Client.Common.refs
-        in
-        Client.run t.ctx
-          (`UploadRequest
-            { Client.Common.want= hash_head, [hash_head]
-            ; capabilities= t.capabilities
-            ; shallow= []
-            ; deep= None })
-        |> process t
-        >>?= clone_handler git reference ~hash:hash_head t
-      with Not_found -> (
-        Client.run t.ctx `Flush
-        |> process t
-        >>?= function
-        | `Flush -> Lwt.return (Error `Not_found)
-        | result -> Lwt.return (Error (`Sync (err_unexpected_result result))) )
-      )
-    | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
-
-  let ls_handler _ t r =
-    match r with
-    | `Refs refs -> (
-        Client.run t.ctx `Flush
-        |> process t
-        >>?= function
-        | `Flush -> Lwt.return (Ok refs.Client.Common.refs)
-        | result -> Lwt.return (Error (`Sync (err_unexpected_result result))) )
-    | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
-
-  let fetch_handler git ?(shallow = []) ~notify ~negociate:(fn, state) ~have
-      ~want ?deepen t r =
-    let pack asked t =
-      Client.run t.ctx `ReceivePACK
-      |> process t
-      >>?= Pack.populate git t
-      >>= function
-      | Ok (_, n) -> Lwt.return (Ok (asked, n))
-      | Error err -> Lwt.return (Error err)
-    in
-    let rec aux t asked state = function
-      | `ShallowUpdate shallow_update ->
-          notify shallow_update
-          >>= fun () ->
-          Client.run t.ctx (`Has have) |> process t >>?= aux t asked state
-      | `Negociation acks -> (
-          Log.debug (fun l ->
-              l ~header:"fetch_handler" "Retrieve the negotiation: %a."
-                (Fmt.hvbox Client.Common.pp_acks)
-                acks ) ;
-          fn acks state
-          >>= function
-          | `Ready, _ ->
-              Log.debug (fun l ->
-                  l ~header:"fetch_handler"
-                    "Retrieve `Ready ACK from negotiation engine." ) ;
-              Client.run t.ctx `Done |> process t >>?= aux t asked state
-          | `Done, state ->
-              Log.debug (fun l ->
-                  l ~header:"fetch_handler"
-                    "Retrieve `Done ACK from negotiation engine." ) ;
-              Client.run t.ctx `Done |> process t >>?= aux t asked state
-          | `Again have, state ->
-              Log.debug (fun l ->
-                  l ~header:"fetch_handler"
-                    "Retrieve `Again ACK from negotiation engine." ) ;
-              Client.run t.ctx (`Has have) |> process t >>?= aux t asked state
-          )
-      | `NegociationResult _ ->
-          Log.debug (fun l ->
-              l ~header:"fetch_handler" "Retrieve a negotiation result." ) ;
-          pack asked t
-      | `Refs refs -> (
-          want refs.Client.Common.refs
-          >>= function
-          | first :: rest ->
-              Client.run t.ctx
-                (`UploadRequest
-                  { Client.Common.want= snd first, List.map snd rest
-                  ; capabilities= t.capabilities
-                  ; shallow
-                  ; deep= deepen })
-              |> process t
-              >>?= aux t (first :: rest) state
-          | [] -> (
-              Client.run t.ctx `Flush
-              |> process t
-              >>?= function
-              | `Flush -> Lwt.return (Ok ([], 0))
-              (* XXX(dinosaure): better return? *)
-              | result ->
-                  Lwt.return (Error (`Sync (err_unexpected_result result))) ) )
-      | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
-    in
-    aux t [] state r
-
-  let push_handler git ~push t r =
-    let send_pack stream t r =
-      let rec go ?keep t r =
-        let consume ?keep dst =
-          match keep with
-          | Some keep ->
-              let n = min (Cstruct.len keep) (Cstruct.len dst) in
-              Cstruct.blit keep 0 dst 0 n ;
-              let keep = Cstruct.shift keep n in
-              if Cstruct.len keep > 0 then
-                Lwt.return (`Continue (Some keep, n))
-              else Lwt.return (`Continue (None, n))
-          | None -> (
-              stream ()
-              >>= function
-              | Some keep ->
-                  let n = min (Cstruct.len keep) (Cstruct.len dst) in
-                  Cstruct.blit keep 0 dst 0 n ;
-                  let keep = Cstruct.shift keep n in
-                  if Cstruct.len keep > 0 then
-                    Lwt.return (`Continue (Some keep, n))
-                  else Lwt.return (`Continue (None, n))
-              | None -> Lwt.return `Finish )
-        in
-        match r with
-        | `ReadyPACK dst -> (
-            consume ?keep dst
-            >>= function
-            | `Continue (keep, n) ->
-                Client.run t.ctx (`SendPACK n) |> process t >>?= go ?keep t
-            | `Finish -> Client.run t.ctx `FinishPACK |> process t >>?= go t )
-        | `Nothing -> Lwt.return (Ok [])
-        | `ReportStatus {Client.Common.unpack= Ok (); commands} ->
-            Lwt.return (Ok commands)
-        | `ReportStatus {Client.Common.unpack= Error err; _} ->
-            Lwt.return (Error (`Sync err))
-        | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
-      in
-      go t r
-    in
-    let rec aux t refs commands = function
-      | `Refs refs -> (
-          Log.debug (fun l ->
-              l ~header:"push_handler" "Receiving reference: %a."
-                (Fmt.hvbox Client.Common.pp_advertised_refs)
-                refs ) ;
-          let capabilities =
-            List.filter
-              (function
-                | `Report_status | `Delete_refs | `Ofs_delta | `Push_options
-                 |`Agent _ | `Side_band | `Side_band_64k ->
-                    true
-                | _ -> false)
-              t.capabilities
-          in
-          push refs.Client.Common.refs
-          >>= function
-          | _, [] -> (
-              Client.run t.ctx `Flush
-              |> process t
-              >>?= function
-              | `Flush -> Lwt.return_ok []
-              | result ->
-                  Lwt.return_error (`Sync (err_unexpected_result result)) )
-          | shallow, commands ->
-              Log.debug (fun l ->
-                  l ~header:"push_handler" "Sending command(s): %a."
-                    (Fmt.hvbox (Fmt.Dump.list pp_command))
-                    commands ) ;
-              let x, r =
-                List.map
-                  (function
-                    | `Create (hash, r) -> Client.Common.Create (hash, r)
-                    | `Delete (hash, r) -> Client.Common.Delete (hash, r)
-                    | `Update (_of, _to, r) ->
-                        Client.Common.Update (_of, _to, r))
-                  commands
-                |> fun commands -> List.hd commands, List.tl commands
-              in
-              Client.run t.ctx
-                (`UpdateRequest
-                  {Client.Common.shallow; requests= `Raw (x, r); capabilities})
-              |> process t
-              >>?= aux t (Some refs.Client.Common.refs) (Some (x :: r)) )
-      | `ReadyPACK _ as result -> (
-          Log.debug (fun l ->
-              l ~header:"push_handler"
-                "The server is ready to receive the PACK file." ) ;
-          let ofs_delta =
-            List.exists (( = ) `Ofs_delta) (Client.capabilities t.ctx)
-          in
-          let commands =
-            match commands with
-            | Some commands -> commands
-            | None -> assert false
-          in
-          let refs =
-            match refs with Some refs -> refs | None -> assert false
-          in
-          (* XXX(dinosaure): in this case, we can use GADT to describe the
-             protocol by the session-type (like, [`UpdateRequest] makes a [`]
-             response). So, we can constraint some assertions about the context
-             when we catch [`ReadyPACK].
-
-             One of this assertion is about the [commands] variable, which one
-             is previously specified. So, the [None] value can not be catch and
-             it's why we have an [assert false]. *)
-          List.map
-            (function
-              | Client.Common.Create (hash, refname) -> `Create (hash, refname)
-              | Client.Common.Delete (hash, refname) -> `Delete (hash, refname)
-              | Client.Common.Update (a, b, refname) -> `Update (a, b, refname))
-            commands
-          |> Common.packer git ~ofs_delta refs
-          >>= function
-          | Ok (stream, _) -> send_pack stream t result
-          | Error err -> Lwt.return (Error (`Store err)) )
-      | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
-    in
-    aux t None None r
-
-  let port uri = match Uri.port uri with None -> 9418 | Some p -> p
-
-  let host uri =
-    match Uri.host uri with
-    | Some h -> h
-    | None ->
-        Fmt.kstrf failwith "Expected a git url with host: %a." Uri.pp_hum uri
-
-  let path uri = Uri.path_and_query uri
-
-  module N = Negociator.Make (S)
-
-  let push git ~push ?(capabilities = Default.capabilities) uri =
-    Log.debug (fun l -> l "push %a" Uri.pp_hum uri) ;
-    Net.socket uri
-    >>= fun socket ->
-    let ctx, state =
-      Client.context
-        { Client.Common.pathname= path uri
-        ; host= Some (host uri, Some (port uri))
-        ; request_command= `Receive_pack }
-    in
-    let t =
-      { socket
-      ; input= Bytes.create 65535
-      ; output= Bytes.create 65535
-      ; ctx
-      ; capabilities }
-    in
-    Log.debug (fun l -> l ~header:"push" "Start to process the flow") ;
-    process t state
-    >>?= push_handler git ~push t
-    >>= fun v -> Net.close socket >>= fun () -> Lwt.return v
-
-  let ls git ?(capabilities = Default.capabilities) uri =
-    Log.debug (fun l -> l "ls %a" Uri.pp_hum uri) ;
-    Net.socket uri
-    >>= fun socket ->
-    let ctx, state =
-      Client.context
-        { Client.Common.pathname= path uri
-        ; host= Some (host uri, Some (port uri))
-        ; request_command= `Upload_pack }
-    in
-    let t =
-      { socket
-      ; input= Bytes.create 65535
-      ; output= Bytes.create 65535
-      ; ctx
-      ; capabilities }
-    in
-    Log.debug (fun l -> l ~header:"ls" "Start to process the flow.") ;
-    process t state
-    >>?= ls_handler git t
-    >>= fun v -> Net.close socket >>= fun () -> Lwt.return v
-
-  let fetch_ext git ?(shallow = []) ?(capabilities = Default.capabilities)
-      ~notify ~negociate ~have ~want ?deepen uri =
-    Log.debug (fun l -> l "fetch_ext %a" Uri.pp_hum uri) ;
-    Net.socket uri
-    >>= fun socket ->
-    let ctx, state =
-      Client.context
-        { Client.Common.pathname= path uri
-        ; host= Some (host uri, Some (port uri))
-        ; request_command= `Upload_pack }
-    in
-    let t =
-      { socket
-      ; input= Bytes.create 65535
-      ; output= Bytes.create 65535
-      ; ctx
-      ; capabilities }
-    in
-    Log.debug (fun l -> l ~header:"fetch" "Start to process the flow.") ;
-    process t state
-    >>?= fetch_handler git ~shallow ~notify ~negociate ~have ~want ?deepen t
-    >>= fun v -> Net.close socket >>= fun () -> Lwt.return v
-
-  let clone_ext git ?(reference = Store.Reference.master)
-      ?(capabilities = Default.capabilities) uri =
-    Log.debug (fun l -> l "clone_ext %a" Uri.pp_hum uri) ;
-    Net.socket uri
-    >>= fun socket ->
-    let ctx, state =
-      Client.context
-        { Client.Common.pathname= path uri
-        ; host= Some (host uri, Some (port uri))
-        ; request_command= `Upload_pack }
-    in
-    let t =
-      { socket
-      ; input= Bytes.create 65535
-      ; output= Bytes.create 65535
-      ; ctx
-      ; capabilities }
-    in
-    Log.debug (fun l -> l ~header:"clone" "Start to process the flow.") ;
-    process t state
-    >>?= clone_handler git reference t
-    >>= fun v -> Net.close socket >>= fun () -> Lwt.return v
-
-  let fetch_and_set_references git ?capabilities ~choose ~references repository
-      =
-    N.find_common git
-    >>= fun (have, state, continue) ->
-    let continue {Client.Common.acks; shallow; unshallow} state =
-      continue {Negociator.acks; shallow; unshallow} state
-    in
-    let want_handler = Common.want_handler git choose in
-    fetch_ext git ?capabilities
-      ~notify:(fun _ -> Lwt.return ())
-      ~negociate:(continue, state) ~have ~want:want_handler repository
-    >>?= fun (results, _) ->
-    Common.update_and_create git ~references results
-    >>!= fun err -> Lwt.return (`Store err)
-
-  let fetch_all git ?capabilities ~references repository =
-    let choose _ = Lwt.return true in
-    fetch_and_set_references ~choose ?capabilities ~references git repository
-
-  let fetch_some git ?capabilities ~references repository =
-    let choose remote_ref =
-      Lwt.return (Store.Reference.Map.mem remote_ref references)
-    in
-    fetch_and_set_references ~choose ?capabilities ~references git repository
-    >>?= fun (updated, missed, downloaded) ->
-    if Store.Reference.Map.is_empty downloaded then
-      Lwt.return (Ok (updated, missed))
-    else (
-      Log.err (fun l ->
-          l ~header:"fetch_some"
-            "This case should not appear, we download: %a."
-            Fmt.Dump.(list (pair Store.Reference.pp Store.Hash.pp))
-            (Store.Reference.Map.bindings downloaded) ) ;
-      Lwt.return (Ok (updated, missed)) )
-
-  let fetch_one git ?capabilities ~reference:(remote_ref, local_refs)
-      repository =
-    let references = Store.Reference.Map.singleton remote_ref local_refs in
-    let choose remote_ref =
-      Lwt.return (Store.Reference.Map.mem remote_ref references)
-    in
-    fetch_and_set_references ~choose ?capabilities ~references git repository
-    >>?= fun (updated, missed, downloaded) ->
-    if not (Store.Reference.Map.is_empty downloaded) then
-      Log.err (fun l ->
-          l ~header:"fetch_some"
-            "This case should not appear, we downloaded: %a."
-            Fmt.Dump.(list (pair Store.Reference.pp Store.Hash.pp))
-            (Store.Reference.Map.bindings downloaded) ) ;
-    match Store.Reference.Map.(bindings updated, bindings missed) with
-    | [], [_] -> Lwt.return (Ok `AlreadySync)
-    | _ :: _, [] -> Lwt.return (Ok (`Sync updated))
-    | [], missed ->
-        Log.err (fun l ->
-            l ~header:"fetch_one"
-              "This case should not appear, we missed too many references: %a."
-              Fmt.Dump.(
-                list (pair Store.Reference.pp (list Store.Reference.pp)))
-              missed ) ;
-        Lwt.return (Ok `AlreadySync)
-    | _ :: _, missed ->
-        Log.err (fun l ->
-            l ~header:"fetch_one"
-              "This case should not appear, we missed too many references: %a."
-              Fmt.Dump.(
-                list (pair Store.Reference.pp (list Store.Reference.pp)))
-              missed ) ;
-        Lwt.return (Ok (`Sync updated))
-
-  let clone t ?capabilities ~reference:(remote_ref, local_ref) uri =
-    Log.debug (fun l ->
-        l "clone %a:%a" Uri.pp_hum uri S.Reference.pp remote_ref ) ;
-    let _ =
-      if not (Helper.Option.mem (Uri.scheme uri) "git" ~equal:String.equal)
-      then raise (Invalid_argument "Expected a git url")
-    in
-    clone_ext t ?capabilities ~reference:remote_ref uri
-    >>?= function
-    | hash' ->
-        Log.debug (fun l ->
-            l ~header:"easy_clone" "Update reference %a to %a." S.Reference.pp
-              local_ref S.Hash.pp hash' ) ;
-        S.Ref.write t local_ref (S.Reference.Hash hash')
-        >>?= (fun () ->
-               S.Ref.write t S.Reference.head (S.Reference.Ref local_ref) )
-        >>!= fun err -> Lwt.return (`Store err)
-
-  let update_and_create git ?capabilities ~references repository =
-    let push_handler remote_refs =
-      Common.push_handler git references remote_refs
-      >>= fun actions -> Lwt.return ([], actions)
-    in
-    push git ~push:push_handler ?capabilities repository
 end

--- a/src/git/sync.mli
+++ b/src/git/sync.mli
@@ -40,18 +40,10 @@ module type S = sig
 
   (** The error type. *)
   type error =
-    [ `SmartPack of string
-      (** Appear when we retrieve a decoder's error about Smart protocol. *)
+    [ `Sync of string
+      (** Appear when we retrieve an unexpected response from server. *)
     | `Store of Store.error
       (** Appear when we retrieve a PACK error from the {!Store.Pack}. *)
-    | `Clone of string
-      (** Appear when we don't follow operations on the clone command. *)
-    | `Fetch of string
-      (** Appear when we don't follow operations on the fetch command. *)
-    | `Ls of string
-      (** Appear when we don't follow operations on the ls-remote command. *)
-    | `Push of string
-      (** Appear when we don't follow operations on the push command. *)
     | `Net of Net.error  (** Appear when we retrieve an I/O error. *)
     | `Smart of Client.Decoder.error
       (** Appear when internal parser got an error. *)

--- a/src/git/sync.mli
+++ b/src/git/sync.mli
@@ -17,39 +17,19 @@
 
 (** The synchronization commands to a git repository. *)
 
-(** This interface describes the minimal I/O operations to a git repository. *)
-module type NET = sig
-  type socket
-  type error
+module type ENDPOINT = sig
+  type t
 
-  val pp_error : Format.formatter -> error -> unit
-  val read : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
-  val write : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
-  val socket : Uri.t -> socket Lwt.t
-  val close : socket -> unit Lwt.t
+  val host : t -> string
+  val path : t -> string
+  val pp : t Fmt.t
 end
 
 module type S = sig
   module Store : Minimal.S
-  module Net : NET
+  module Endpoint : ENDPOINT
 
-  module Client :
-    Smart.CLIENT
-    with module Hash := Store.Hash
-     and module Reference := Store.Reference
-
-  (** The error type. *)
-  type error =
-    [ `Sync of string
-      (** Appear when we retrieve an unexpected response from server. *)
-    | `Store of Store.error
-      (** Appear when we retrieve a PACK error from the {!Store.Pack}. *)
-    | `Net of Net.error  (** Appear when we retrieve an I/O error. *)
-    | `Smart of Client.Decoder.error
-      (** Appear when internal parser got an error. *)
-    | `Not_found
-      (** Appear when we don't find the reference requested by the client on
-          the server. *) ]
+  type error
 
   val pp_error : error Fmt.t
   (** Pretty-printer of {!error}. *)
@@ -67,12 +47,20 @@ module type S = sig
   val pp_command : command Fmt.t
   (** Pretty-printer of {!command}. *)
 
+  type shallow_update =
+    {shallow: Store.Hash.t list; unshallow: Store.Hash.t list}
+
+  type acks =
+    { shallow: Store.Hash.t list
+    ; unshallow: Store.Hash.t list
+    ; acks: (Store.Hash.t * [`Common | `Ready | `Continue | `ACK]) list }
+
   val push :
        Store.t
     -> push:(   (Store.Hash.t * Store.Reference.t * bool) list
              -> (Store.Hash.t list * command list) Lwt.t)
     -> ?capabilities:Capability.t list
-    -> Uri.t
+    -> Endpoint.t
     -> ( (Store.Reference.t, Store.Reference.t * string) result list
        , error )
        result
@@ -81,15 +69,15 @@ module type S = sig
   val ls :
        Store.t
     -> ?capabilities:Capability.t list
-    -> Uri.t
+    -> Endpoint.t
     -> ((Store.Hash.t * Store.Reference.t * bool) list, error) result Lwt.t
 
-  val fetch_ext :
+  val fetch :
        Store.t
     -> ?shallow:Store.Hash.t list
     -> ?capabilities:Capability.t list
-    -> notify:(Client.Common.shallow_update -> unit Lwt.t)
-    -> negociate:(   Client.Common.acks
+    -> notify:(shallow_update -> unit Lwt.t)
+    -> negociate:(   acks
                   -> 'state
                   -> ([`Ready | `Done | `Again of Store.Hash.Set.t] * 'state)
                      Lwt.t)
@@ -98,21 +86,14 @@ module type S = sig
     -> want:(   (Store.Hash.t * Store.Reference.t * bool) list
              -> (Store.Reference.t * Store.Hash.t) list Lwt.t)
     -> ?deepen:[`Depth of int | `Timestamp of int64 | `Ref of Reference.t]
-    -> Uri.t
+    -> Endpoint.t
     -> ((Store.Reference.t * Store.Hash.t) list * int, error) result Lwt.t
-
-  val clone_ext :
-       Store.t
-    -> ?reference:Store.Reference.t
-    -> ?capabilities:Capability.t list
-    -> Uri.t
-    -> (Store.Hash.t, error) result Lwt.t
 
   val fetch_some :
        Store.t
     -> ?capabilities:Capability.t list
     -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
+    -> Endpoint.t
     -> ( Store.Hash.t Store.Reference.Map.t
          * Store.Reference.t list Store.Reference.Map.t
        , error )
@@ -161,7 +142,7 @@ module type S = sig
        Store.t
     -> ?capabilities:Capability.t list
     -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
+    -> Endpoint.t
     -> ( Store.Hash.t Store.Reference.Map.t
          * Store.Reference.t list Store.Reference.Map.t
          * Store.Hash.t Store.Reference.Map.t
@@ -186,7 +167,7 @@ module type S = sig
        Store.t
     -> ?capabilities:Capability.t list
     -> reference:Store.Reference.t * Store.Reference.t list
-    -> Uri.t
+    -> Endpoint.t
     -> ( [`AlreadySync | `Sync of Store.Hash.t Store.Reference.Map.t]
        , error )
        result
@@ -202,14 +183,14 @@ module type S = sig
        Store.t
     -> ?capabilities:Capability.t list
     -> reference:Store.Reference.t * Store.Reference.t
-    -> Uri.t
+    -> Endpoint.t
     -> (unit, error) result Lwt.t
 
   val update_and_create :
        Store.t
     -> ?capabilities:Capability.t list
     -> references:Store.Reference.t list Store.Reference.Map.t
-    -> Uri.t
+    -> Endpoint.t
     -> ( (Store.Reference.t, Store.Reference.t * string) result list
        , error )
        result
@@ -240,6 +221,10 @@ module type S = sig
       At this final stage, the function does not encountered any error during
       the commmunication - if it's the case, we did not do any modification on
       the server and return an {!error}. *)
+end
+
+module Default : sig
+  val capabilities : Capability.t list
 end
 
 module Common (G : Minimal.S) :
@@ -289,6 +274,3 @@ module Common (G : Minimal.S) :
       -> command list Lwt.t
   end
   with module Store = G
-
-module Make (N : NET) (S : Minimal.S) :
-  S with module Store = S and module Net = N

--- a/src/git/tcp.ml
+++ b/src/git/tcp.ml
@@ -1,0 +1,548 @@
+module type NET = sig
+  type endpoint
+  type socket
+  type error
+
+  val pp_error : Format.formatter -> error -> unit
+  val read : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
+  val write : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
+  val socket : endpoint -> socket Lwt.t
+  val close : socket -> unit Lwt.t
+end
+
+open Lwt.Infix
+
+let ( >>!= ) = Lwt_result.bind_lwt_err
+let ( >>?= ) = Lwt_result.bind
+let src = Logs.Src.create "git.tcp" ~doc:"logs git's tcp event"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Make (N : NET with type endpoint = Gri.t) (G : Minimal.S) :
+  Sync.S with module Store = G with module Endpoint = Gri = struct
+  module Store = G
+  module Net = N
+  module Client = Smart.Client (Store.Hash) (Store.Reference)
+  module Encoder = Client.Encoder
+  module Decoder = Client.Decoder
+  module Hash = Store.Hash
+  module Inflate = Store.Inflate
+  module Deflate = Store.Deflate
+  module Endpoint = Gri
+
+  module Common :
+    module type of Sync.Common (Store) with module Store = Store =
+    Sync.Common (Store)
+
+  type error =
+    [ `Sync of string
+    | `Store of Store.error
+    | `Net of Net.error
+    | `Smart of Decoder.error
+    | `Not_found ]
+
+  let pp_error ppf = function
+    | `Sync err -> Helper.ppe ~name:"`Sync" Fmt.string ppf err
+    | `Store err -> Helper.ppe ~name:"`Store" Store.pp_error ppf err
+    | `Net err -> Helper.ppe ~name:"`Net" Net.pp_error ppf err
+    | `Smart err -> Helper.ppe ~name:"`Smart" Decoder.pp_error ppf err
+    | `Not_found -> Fmt.string ppf "`Not_found"
+
+  (* XXX(dinosaure): we need to export some definitions about the Smart
+     protocol to export a low level API (which let the end-user to choose
+     negotiation engine). *)
+
+  type shallow_update = Client.Common.shallow_update =
+    {shallow: Store.Hash.t list; unshallow: Store.Hash.t list}
+
+  type acks = Client.Common.acks =
+    { shallow: Store.Hash.t list
+    ; unshallow: Store.Hash.t list
+    ; acks: (Store.Hash.t * [`Common | `Ready | `Continue | `ACK]) list }
+
+  type command = Common.command
+
+  let pp_command = Common.pp_command
+
+  type t =
+    { socket: Net.socket
+    ; input: Bytes.t
+    ; output: Bytes.t
+    ; ctx: Client.context
+    ; capabilities: Capability.t list }
+
+  let make ~socket ~ctx ~capabilities =
+    { socket
+    ; input= Bytes.create 65535
+    ; output= Bytes.create 65535
+    ; ctx
+    ; capabilities }
+
+  let err_unexpected_result result =
+    let buf = Buffer.create 64 in
+    let ppf = Fmt.with_buffer buf in
+    Fmt.pf ppf "Unexpected result: %a%!" (Fmt.hvbox Client.pp_result) result ;
+    Buffer.contents buf
+
+  let rec process t result =
+    match result with
+    | `Read (buffer, off, len, continue) -> (
+        Net.read t.socket t.input 0 len
+        >>= function
+        | Ok len ->
+            Cstruct.blit_from_bytes t.input 0 buffer off len ;
+            process t (continue len)
+        | Error err -> Lwt.return_error (`Net err) )
+    | `Write (buffer, off, len, continue) -> (
+        Cstruct.blit_to_bytes buffer off t.output 0 len ;
+        Net.write t.socket t.output 0 len
+        >>= function
+        | Ok n -> process t (continue n)
+        | Error err -> Lwt.return_error (`Net err) )
+    | `Error (err, buf, committed) ->
+        let raw = Cstruct.sub buf committed (Cstruct.len buf - committed) in
+        Log.err (fun l ->
+            l "Retrieve an error (%a) on: %a." Client.Decoder.pp_error err
+              (Fmt.hvbox
+                 (Encore.Lole.pp_scalar ~get:Cstruct.get_char
+                    ~length:Cstruct.len))
+              raw ) ;
+        Lwt.return_error (`Smart err)
+        (* TODO *)
+    | #Client.result as result -> Lwt.return_ok result
+
+  module Pack = struct
+    let default_stdout raw =
+      Log.info (fun l -> l "%S" (Cstruct.to_string raw)) ;
+      Lwt.return ()
+
+    let default_stderr raw =
+      Log.err (fun l -> l "%S" (Cstruct.to_string raw)) ;
+      Lwt.return ()
+
+    let populate git ?(stdout = default_stdout) ?(stderr = default_stderr) ctx
+        first =
+      let stream, push = Lwt_stream.create () in
+      let cstruct_copy cs =
+        let ln = Cstruct.len cs in
+        let rs = Cstruct.create ln in
+        Cstruct.blit cs 0 rs 0 ln ; rs
+      in
+      let rec dispatch ctx = function
+        | `PACK (`Out raw) ->
+            stdout raw
+            >>= fun () ->
+            Client.run ctx.ctx `ReceivePACK |> process ctx >>?= dispatch ctx
+        | `PACK (`Err raw) ->
+            stderr raw
+            >>= fun () ->
+            Client.run ctx.ctx `ReceivePACK |> process ctx >>?= dispatch ctx
+        | `PACK (`Raw raw) ->
+            (* XXX(dinosaure): we don't have the ownership on [raw] and need to
+               copy it because it will be updated by [Client.run]. *)
+            push (Some (cstruct_copy raw)) ;
+            Client.run ctx.ctx `ReceivePACK |> process ctx >>?= dispatch ctx
+        | `PACK `End -> push None ; Lwt.return (Ok ())
+        | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
+      in
+      dispatch ctx first
+      >>?= fun () ->
+      Store.Pack.from git (fun () -> Lwt_stream.get stream)
+      >>!= fun err -> Lwt.return (`Store err)
+  end
+
+  let rec clone_handler git reference ?hash t r =
+    match r with
+    | `Negociation _ ->
+        Client.run t.ctx `Done
+        |> process t
+        >>?= clone_handler git reference ?hash t
+    | `NegociationResult _ -> (
+        Client.run t.ctx `ReceivePACK
+        |> process t
+        >>?= Pack.populate git t
+        >>= fun res ->
+        match res, hash with
+        | Ok (_, _), Some hash -> Lwt.return (Ok hash)
+        | Ok (_, _), None ->
+            assert false
+            (* XXX(dinosaure): impossible to retrieve this state on
+               `NegociationResult. *)
+        | (Error _ as err), _ -> Lwt.return err )
+    | `ShallowUpdate _ ->
+        Client.run t.ctx (`Has Hash.Set.empty)
+        |> process t
+        >>?= clone_handler git reference ?hash t
+    | `Refs refs -> (
+      try
+        let hash_head, _, _ =
+          List.find
+            (fun (_, reference', peeled) ->
+              Store.Reference.(equal reference reference') && not peeled )
+            refs.Client.Common.refs
+        in
+        Client.run t.ctx
+          (`UploadRequest
+            { Client.Common.want= hash_head, [hash_head]
+            ; capabilities= t.capabilities
+            ; shallow= []
+            ; deep= None })
+        |> process t
+        >>?= clone_handler git reference ~hash:hash_head t
+      with Not_found -> (
+        Client.run t.ctx `Flush
+        |> process t
+        >>?= function
+        | `Flush -> Lwt.return (Error `Not_found)
+        | result -> Lwt.return (Error (`Sync (err_unexpected_result result))) )
+      )
+    | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
+
+  let ls_handler _ t r =
+    match r with
+    | `Refs refs -> (
+        Client.run t.ctx `Flush
+        |> process t
+        >>?= function
+        | `Flush -> Lwt.return (Ok refs.Client.Common.refs)
+        | result -> Lwt.return (Error (`Sync (err_unexpected_result result))) )
+    | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
+
+  let fetch_handler git ?(shallow = []) ~notify ~negociate:(fn, state) ~have
+      ~want ?deepen t r =
+    (* XXX(dinosaure): purpose of [asked]? TODO! *)
+    let pack asked t =
+      Client.run t.ctx `ReceivePACK
+      |> process t
+      >>?= Pack.populate git t
+      >>= function
+      | Ok (_, n) -> Lwt.return (Ok (asked, n))
+      | Error err -> Lwt.return (Error err)
+    in
+    let rec aux t asked state = function
+      | `ShallowUpdate shallow_update ->
+          notify shallow_update
+          >>= fun () ->
+          Client.run t.ctx (`Has have) |> process t >>?= aux t asked state
+      | `Negociation acks -> (
+          Log.debug (fun l ->
+              l "Retrieve the negotiation: %a."
+                (Fmt.hvbox Client.Common.pp_acks)
+                acks ) ;
+          fn acks state
+          >>= function
+          | `Ready, _ ->
+              Log.debug (fun l ->
+                  l "Retrieve `Ready ACK from negotiation engine." ) ;
+              Client.run t.ctx `Done |> process t >>?= aux t asked state
+          | `Done, state ->
+              Log.debug (fun l ->
+                  l "Retrieve `Done ACK from negotiation engine." ) ;
+              Client.run t.ctx `Done |> process t >>?= aux t asked state
+          | `Again have, state ->
+              Log.debug (fun l ->
+                  l "Retrieve `Again ACK from negotiation engine." ) ;
+              Client.run t.ctx (`Has have) |> process t >>?= aux t asked state
+          )
+      | `NegociationResult _ ->
+          Log.debug (fun l -> l "Retrieve a negotiation result.") ;
+          pack asked t
+      | `Refs refs -> (
+          want refs.Client.Common.refs
+          >>= function
+          | first :: rest ->
+              Client.run t.ctx
+                (`UploadRequest
+                  { Client.Common.want= snd first, List.map snd rest
+                  ; capabilities= t.capabilities
+                  ; shallow
+                  ; deep= deepen })
+              |> process t
+              >>?= aux t (first :: rest) state
+          | [] -> (
+              Client.run t.ctx `Flush
+              |> process t
+              >>?= function
+              | `Flush -> Lwt.return (Ok ([], 0))
+              (* XXX(dinosaure): better return? *)
+              | result ->
+                  Lwt.return (Error (`Sync (err_unexpected_result result))) ) )
+      | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
+    in
+    aux t [] state r
+
+  let push_handler git ~push t r =
+    let send_pack stream t r =
+      let rec go ?keep t r =
+        let consume ?keep dst =
+          match keep with
+          | Some keep ->
+              let n = min (Cstruct.len keep) (Cstruct.len dst) in
+              Cstruct.blit keep 0 dst 0 n ;
+              let keep = Cstruct.shift keep n in
+              if Cstruct.len keep > 0 then
+                Lwt.return (`Continue (Some keep, n))
+              else Lwt.return (`Continue (None, n))
+          | None -> (
+              stream ()
+              >>= function
+              | Some keep ->
+                  let n = min (Cstruct.len keep) (Cstruct.len dst) in
+                  Cstruct.blit keep 0 dst 0 n ;
+                  let keep = Cstruct.shift keep n in
+                  if Cstruct.len keep > 0 then
+                    Lwt.return (`Continue (Some keep, n))
+                  else Lwt.return (`Continue (None, n))
+              | None -> Lwt.return `Finish )
+        in
+        match r with
+        | `ReadyPACK dst -> (
+            consume ?keep dst
+            >>= function
+            | `Continue (keep, n) ->
+                Client.run t.ctx (`SendPACK n) |> process t >>?= go ?keep t
+            | `Finish -> Client.run t.ctx `FinishPACK |> process t >>?= go t )
+        | `Nothing -> Lwt.return (Ok [])
+        | `ReportStatus {Client.Common.unpack= Ok (); commands} ->
+            Lwt.return (Ok commands)
+        | `ReportStatus {Client.Common.unpack= Error err; _} ->
+            Lwt.return (Error (`Sync err))
+        | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
+      in
+      go t r
+    in
+    let rec aux t refs commands = function
+      | `Refs refs -> (
+          Log.debug (fun l ->
+              l "Receiving reference: %a."
+                (Fmt.hvbox Client.Common.pp_advertised_refs)
+                refs ) ;
+          let capabilities =
+            List.filter
+              (function
+                | `Report_status | `Delete_refs | `Ofs_delta | `Push_options
+                 |`Agent _ | `Side_band | `Side_band_64k ->
+                    true
+                | _ -> false)
+              t.capabilities
+          in
+          push refs.Client.Common.refs
+          >>= function
+          | _, [] -> (
+              Client.run t.ctx `Flush
+              |> process t
+              >>?= function
+              | `Flush -> Lwt.return_ok []
+              | result ->
+                  Lwt.return_error (`Sync (err_unexpected_result result)) )
+          | shallow, commands ->
+              Log.debug (fun l ->
+                  l "Sending command(s): %a."
+                    (Fmt.hvbox (Fmt.Dump.list pp_command))
+                    commands ) ;
+              let x, r =
+                List.map
+                  (function
+                    | `Create (hash, r) -> Client.Common.Create (hash, r)
+                    | `Delete (hash, r) -> Client.Common.Delete (hash, r)
+                    | `Update (_of, _to, r) ->
+                        Client.Common.Update (_of, _to, r))
+                  commands
+                |> fun commands -> List.hd commands, List.tl commands
+              in
+              Client.run t.ctx
+                (`UpdateRequest
+                  {Client.Common.shallow; requests= `Raw (x, r); capabilities})
+              |> process t
+              >>?= aux t (Some refs.Client.Common.refs) (Some (x :: r)) )
+      | `ReadyPACK _ as result -> (
+          Log.debug (fun l -> l "The server is ready to receive the PACK file.") ;
+          let ofs_delta =
+            List.exists (( = ) `Ofs_delta) (Client.capabilities t.ctx)
+          in
+          let commands =
+            match commands with
+            | Some commands -> commands
+            | None -> assert false
+          in
+          let refs =
+            match refs with Some refs -> refs | None -> assert false
+          in
+          (* XXX(dinosaure): in this case, we can use GADT to describe the
+             protocol by the session-type (like, [`UpdateRequest] makes a [`]
+             response). So, we can constraint some assertions about the context
+             when we catch [`ReadyPACK].
+
+             One of this assertion is about the [commands] variable, which one
+             is previously specified. So, the [None] value can not be catch and
+             it's why we have an [assert false]. It's the same for [refs]. *)
+          List.map
+            (function
+              | Client.Common.Create (hash, refname) -> `Create (hash, refname)
+              | Client.Common.Delete (hash, refname) -> `Delete (hash, refname)
+              | Client.Common.Update (a, b, refname) -> `Update (a, b, refname))
+            commands
+          |> Common.packer git ~ofs_delta refs
+          >>= function
+          | Ok (stream, _) -> send_pack stream t result
+          | Error err -> Lwt.return (Error (`Store err)) )
+      | result -> Lwt.return (Error (`Sync (err_unexpected_result result)))
+    in
+    aux t None None r
+
+  let port uri = match Uri.port uri with None -> 9418 | Some p -> p
+  let host uri = Endpoint.host uri
+  let path uri = Endpoint.path uri
+
+  module N = Negociator.Make (G)
+
+  let push git ~push ?(capabilities = Sync.Default.capabilities) endpoint =
+    Net.socket endpoint
+    >>= fun socket ->
+    let ctx, state =
+      Client.context
+        { Client.Common.pathname= path endpoint
+        ; host= Some (host endpoint, Some (port (endpoint :> Uri.t)))
+        ; request_command= `Receive_pack }
+    in
+    let t = make ~socket ~ctx ~capabilities in
+    process t state
+    >>?= push_handler git ~push t
+    >>= fun v -> Net.close socket >>= fun () -> Lwt.return v
+
+  let ls git ?(capabilities = Sync.Default.capabilities) endpoint =
+    Net.socket endpoint
+    >>= fun socket ->
+    let ctx, state =
+      Client.context
+        { Client.Common.pathname= path endpoint
+        ; host= Some (host endpoint, Some (port (endpoint :> Uri.t)))
+        ; request_command= `Upload_pack }
+    in
+    let t = make ~socket ~ctx ~capabilities in
+    process t state
+    >>?= ls_handler git t
+    >>= fun v -> Net.close socket >>= fun () -> Lwt.return v
+
+  let fetch git ?(shallow = []) ?(capabilities = Sync.Default.capabilities)
+      ~notify ~negociate ~have ~want ?deepen endpoint =
+    Net.socket endpoint
+    >>= fun socket ->
+    let ctx, state =
+      Client.context
+        { Client.Common.pathname= path endpoint
+        ; host= Some (host endpoint, Some (port (endpoint :> Uri.t)))
+        ; request_command= `Upload_pack }
+    in
+    let t = make ~socket ~ctx ~capabilities in
+    process t state
+    >>?= fetch_handler git ~shallow ~notify ~negociate ~have ~want ?deepen t
+    >>= fun v -> Net.close socket >>= fun () -> Lwt.return v
+
+  (* XXX(dinosaure): replaced by [clone] below, this function handles only the
+     Smart protocol, the next version set [reference] to the new hash. *)
+  let clone git ?(reference = Store.Reference.master)
+      ?(capabilities = Sync.Default.capabilities) endpoint =
+    Net.socket endpoint
+    >>= fun socket ->
+    let ctx, state =
+      Client.context
+        { Client.Common.pathname= path endpoint
+        ; host= Some (host endpoint, Some (port (endpoint :> Uri.t)))
+        ; request_command= `Upload_pack }
+    in
+    let t = make ~socket ~ctx ~capabilities in
+    process t state
+    >>?= clone_handler git reference t
+    >>= fun v -> Net.close socket >>= fun () -> Lwt.return v
+
+  let fetch_and_set_references git ?capabilities ~choose ~references repository
+      =
+    N.find_common git
+    >>= fun (have, state, continue) ->
+    let continue {Client.Common.acks; shallow; unshallow} state =
+      continue {Negociator.acks; shallow; unshallow} state
+    in
+    let want_handler = Common.want_handler git choose in
+    fetch git ?capabilities
+      ~notify:(fun shallow_update ->
+        Log.debug (fun l ->
+            l "Notify %a."
+              (Fmt.hvbox Client.Common.pp_shallow_update)
+              shallow_update ) ;
+        Lwt.return () )
+      ~negociate:(continue, state) ~have ~want:want_handler repository
+    >>?= fun (results, _) ->
+    Common.update_and_create git ~references results
+    >>!= fun err -> Lwt.return (`Store err)
+
+  let fetch_all git ?capabilities ~references repository =
+    let choose _ = Lwt.return true in
+    fetch_and_set_references ~choose ?capabilities ~references git repository
+
+  let fetch_some git ?capabilities ~references repository =
+    let choose remote_ref =
+      Lwt.return (Store.Reference.Map.mem remote_ref references)
+    in
+    fetch_and_set_references ~choose ?capabilities ~references git repository
+    >>?= fun (updated, missed, downloaded) ->
+    if Store.Reference.Map.is_empty downloaded then
+      Lwt.return (Ok (updated, missed))
+    else (
+      Log.err (fun l ->
+          l "This case should not appear, we download: %a."
+            Fmt.Dump.(list (pair Store.Reference.pp Store.Hash.pp))
+            (Store.Reference.Map.bindings downloaded) ) ;
+      Lwt.return (Ok (updated, missed)) )
+
+  let fetch_one git ?capabilities ~reference:(remote_ref, local_refs)
+      repository =
+    let references = Store.Reference.Map.singleton remote_ref local_refs in
+    let choose remote_ref =
+      Lwt.return (Store.Reference.Map.mem remote_ref references)
+    in
+    fetch_and_set_references ~choose ?capabilities ~references git repository
+    >>?= fun (updated, missed, downloaded) ->
+    if not (Store.Reference.Map.is_empty downloaded) then
+      Log.err (fun l ->
+          l "This case should not appear, we downloaded: %a."
+            Fmt.Dump.(list (pair Store.Reference.pp Store.Hash.pp))
+            (Store.Reference.Map.bindings downloaded) ) ;
+    match Store.Reference.Map.(bindings updated, bindings missed) with
+    | [], [_] -> Lwt.return (Ok `AlreadySync)
+    | _ :: _, [] -> Lwt.return (Ok (`Sync updated))
+    | [], missed ->
+        Log.err (fun l ->
+            l "This case should not appear, we missed too many references: %a."
+              Fmt.Dump.(
+                list (pair Store.Reference.pp (list Store.Reference.pp)))
+              missed ) ;
+        Lwt.return (Ok `AlreadySync)
+    | _ :: _, missed ->
+        Log.err (fun l ->
+            l "This case should not appear, we missed too many references: %a."
+              Fmt.Dump.(
+                list (pair Store.Reference.pp (list Store.Reference.pp)))
+              missed ) ;
+        Lwt.return (Ok (`Sync updated))
+
+  let clone t ?capabilities ~reference:(remote_ref, local_ref) endpoint =
+    clone t ?capabilities ~reference:remote_ref endpoint
+    >>?= function
+    | hash' ->
+        Log.debug (fun l ->
+            l "Update reference %a to %a." Store.Reference.pp local_ref
+              Store.Hash.pp hash' ) ;
+        Store.Ref.write t local_ref (Store.Reference.Hash hash')
+        >>?= (fun () ->
+               Store.Ref.write t Store.Reference.head
+                 (Store.Reference.Ref local_ref) )
+        >>!= fun err -> Lwt.return (`Store err)
+
+  let update_and_create git ?capabilities ~references repository =
+    let push_handler remote_refs =
+      Common.push_handler git references remote_refs
+      >>= fun actions -> Lwt.return ([], actions)
+    in
+    push git ~push:push_handler ?capabilities repository
+end

--- a/src/git/tcp.mli
+++ b/src/git/tcp.mli
@@ -1,0 +1,15 @@
+(** This interface describes the minimal I/O operations to a git repository. *)
+module type NET = sig
+  type endpoint
+  type socket
+  type error
+
+  val pp_error : Format.formatter -> error -> unit
+  val read : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
+  val write : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
+  val socket : endpoint -> socket Lwt.t
+  val close : socket -> unit Lwt.t
+end
+
+module Make (N : NET with type endpoint = Gri.t) (G : Minimal.S) :
+  Sync.S with module Store = G and module Endpoint = Gri

--- a/test/common/dune
+++ b/test/common/dune
@@ -1,4 +1,4 @@
 (library
   (name      test_git)
   (wrapped   false)
-  (libraries git mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))
+  (libraries git git-http mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))

--- a/test/common/dune
+++ b/test/common/dune
@@ -1,4 +1,4 @@
 (library
   (name      test_git)
   (wrapped   false)
-  (libraries git git-http mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))
+  (libraries git mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))

--- a/test/git-mirage/test.ml
+++ b/test/git-mirage/test.ml
@@ -126,10 +126,12 @@ module TCP = Test_sync.Make (struct
   module M = Git_mirage.Sync (MirageConduit) (Store)
   module Store = Store
 
+  type endpoint = Git.Gri.t
   type error = M.error
 
   let pp_error = M.pp_error
   let clone t ~reference uri = M.clone t ~reference:(reference, reference) uri
+  let endpoint_of_uri = Git.Gri.make
 
   let fetch_all t ~references uri =
     let open Lwt.Infix in
@@ -151,7 +153,7 @@ let () =
     ; Test_smart.suite "smart" (module MirageStore)
     ; Test_data.suite "mirage" (module Test_data.Usual) (module MirageStore)
     ; Test_data.suite "mirage" (module Test_data.Bomb) (module MirageStore)
-    ; TCP.test_fetch "tcp-sync-fetch" ["git://localhost/"]
+    ; TCP.test_fetch "tcp-sync-fetch" [Uri.of_string "git://localhost/"]
     ; TCP.test_clone "tcp-sync-clone"
-        [ "git://localhost/", "master"
-        ; "git://github.com/mirage/ocaml-git.git", "master" ] ]
+        [ Uri.of_string "git://localhost/", "master"
+        ; Uri.of_string "git://github.com/mirage/ocaml-git.git", "master" ] ]

--- a/test/git-unix/test.ml
+++ b/test/git-unix/test.ml
@@ -22,9 +22,11 @@ module Tcp (S : Test_store.S) = Test_sync.Make (struct
   module Store = S
 
   type error = M.error
+  type endpoint = Git.Gri.t
 
   let pp_error = M.pp_error
   let clone t ~reference uri = M.clone t ~reference:(reference, reference) uri
+  let endpoint_of_uri = Git.Gri.make
 
   let fetch_all t ~references uri =
     let open Lwt.Infix in
@@ -43,9 +45,11 @@ module Http (Store : Test_store.S) = Test_sync.Make (struct
   module Store = Store
 
   type error = M.error
+  type endpoint = M.Endpoint.t
 
   let pp_error = M.pp_error
   let clone t ~reference uri = M.clone t ~reference:(reference, reference) uri
+  let endpoint_of_uri uri = M.Endpoint.{uri; headers= M.Web.HTTP.Headers.empty}
 
   let fetch_all t ~references uri =
     let open Lwt.Infix in
@@ -64,9 +68,11 @@ module Https (Store : Test_store.S) = Test_sync.Make (struct
   module Store = Store
 
   type error = M.error
+  type endpoint = M.Endpoint.t
 
   let pp_error = M.pp_error
   let clone t ~reference uri = M.clone t ~reference:(reference, reference) uri
+  let endpoint_of_uri uri = M.Endpoint.{uri; headers= M.Web.HTTP.Headers.empty}
 
   let fetch_all t ~references uri =
     let open Lwt.Infix in
@@ -93,9 +99,11 @@ module Thin = Test_thin.Make (struct
   module Store = Fs_store
 
   type error = M.error
+  type endpoint = M.Endpoint.t
 
   let pp_error = M.pp_error
   let clone t ~reference uri = M.clone t ~reference:(reference, reference) uri
+  let endpoint_of_uri uri = M.Endpoint.{uri; headers= M.Web.HTTP.Headers.empty}
 
   let fetch_all t ~references uri =
     let open Lwt.Infix in
@@ -135,16 +143,17 @@ let () =
         (module Test_data.Usual)
         (module Fs_store)
         (module Test_rev_list.Usual (Fs_store))
-    ; Tcp1.test_fetch "mem-local-tcp-sync" ["git://localhost/"]
+    ; Tcp1.test_fetch "mem-local-tcp-sync" [Uri.of_string "git://localhost/"]
     ; Tcp1.test_clone "mem-remote-tcp-sync"
-        [ "git://github.com/mirage/ocaml-git.git", "master"
-        ; "git://github.com/mirage/ocaml-git.git", "gh-pages" ]
-    ; Tcp2.test_fetch "fs-local-tcp-sync" ["git://localhost/"]
+        [ Uri.of_string "git://github.com/mirage/ocaml-git.git", "master"
+        ; Uri.of_string "git://github.com/mirage/ocaml-git.git", "gh-pages" ]
+    ; Tcp2.test_fetch "fs-local-tcp-sync" [Uri.of_string "git://localhost/"]
     ; Tcp2.test_clone "fs-remote-tcp-sync"
-        [ "git://github.com/mirage/ocaml-git.git", "master"
-        ; "git://github.com/mirage/ocaml-git.git", "gh-pages" ]
+        [ Uri.of_string "git://github.com/mirage/ocaml-git.git", "master"
+        ; Uri.of_string "git://github.com/mirage/ocaml-git.git", "gh-pages" ]
     ; Http1.test_clone "mem-http-sync"
-        ["http://github.com/mirage/ocaml-git.git", "gh-pages"]
+        [Uri.of_string "http://github.com/mirage/ocaml-git.git", "gh-pages"]
     ; Http2.test_clone "fs-https-sync"
-        ["https://github.com/mirage/ocaml-git.git", "gh-pages"]
-    ; Thin.test_thin ]
+        [Uri.of_string "https://github.com/mirage/ocaml-git.git", "gh-pages"]
+    ; Thin.test_thin (Uri.of_string "https://github.com/mirage/decompress.git")
+    ]


### PR DESCRIPTION
This purpose of this PR is to be able to make a switch _à la conduit_ from an URI and choose automatically the TCP back-end (`git` package) or HTTP back-end (`git-http`). Now, these implementations share the same interface `Git.Sync.S` which provide high level API and low level API.

Endpoint (URI or URI with headers) is abstracted on this interface.

PR is huge and this biggest addition/deletion is a move of the TCP implementation from `Git.Sync` to `Git.Tcp`. Now, `Git.Sync` exports only common interface (`S` and `ENDPOINT`) and common implementation about some operations on the store when we `fetch` or `push` (independently from network layer - this is only a module about _local_ operations). 