### PR TITLE
Replace eq with equal

### DIFF
--- a/src/git/hash.ml
+++ b/src/git/hash.ml
@@ -21,7 +21,7 @@ module Make (H : Digestif.S) = struct
   module X = struct
     type t = H.t
 
-    let equal = eq
+    let equal = H.equal
     let hash = Hashtbl.hash
     let compare = H.unsafe_compare
   end

--- a/src/git/reference.ml
+++ b/src/git/reference.ml
@@ -184,7 +184,7 @@ module Make (Hash : S.HASH) = struct
   let equal_head_contents a b =
     match a, b with
     | Ref a', Ref b' -> equal a' b'
-    | Hash a', Hash b' -> Hash.eq a' b'
+    | Hash a', Hash b' -> Hash.equal a' b'
     | _, _ -> false
 
   let compare_head_contents a b =


### PR DESCRIPTION
ocaml-git isn't building due to `eq` being renamed to `equal`.  This can also be observed in the CI logs for irmin: https://github.com/mirage/irmin/pull/552.

Feel free to close this if it's already being dealt with!