### PR TITLE
Fixed clone/pull/analyze of the pack on unpack.ml

### DIFF
--- a/src/git/unpack.ml
+++ b/src/git/unpack.ml
@@ -15,6 +15,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+[@@@warning "-27"]
+
 let src = Logs.Src.create "git.unpack" ~doc:"logs git's unpack event"
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -2431,8 +2433,10 @@ struct
         | None -> None
       in
       let promote (abs_off, _, _) = function
-        | Ok (kind, raw, depth, metadata) ->
-            cache.Cache.promote abs_off (kind, raw, depth, metadata)
+        | Ok (kind, raw, depth, metadata) -> ()
+        (* XXX(dinosaure): TODO, ownership, bad hash, bad [Cstruct.t] and so
+           on. *)
+        (* cache.Cache.promote abs_off (kind, raw, depth, metadata) *)
         | Error _ -> ()
       in
       let memoized_go = memoize_rec ~promote ~find go in


### PR DESCRIPTION
This commit is a regression about performance I think but fix a problem about ownership on `Cstruct.t` and caches used to the second pass of the analyze of the PACK file. If @samoht can test it and bench it ...

About performance issues, in a point of view of algorithm, we can not do something better (and we already follow what `git` does). However, we should do something about `Cstruct.t`, copy, cache and so on ... So, it's better to do something which works correctly and then, think about performance. But it's not totally the case yet. So, yeah, `ocaml-git` is slow ...