### PR TITLE
Allocation

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -2,5 +2,5 @@ module-item-spacing=compact
 break-struct=natural
 break-infix=fit-or-vertical
 parens-tuple=multi-line-only
-wrap-comments=true
+wrap-comments=false
 break-collection-expressions=wrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
+    - PINS="git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. encore.dev:--dev ke.dev:--dev"
   matrix:
     - OCAML_VERSION=4.06 PACKAGE="git.dev"
     - OCAML_VERSION=4.04 PACKAGE="git-unix.dev"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     FORK_BRANCH: master
     CYG_ROOT: C:\cygwin64
     OPAM_SWITCH: 4.06.1+mingw64c
-    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:."
+    PINS: "git.dev:. git-http.dev:. git-unix.dev:. git-mirage.dev:. ke.dev:--dev encore.dev:--dev"
   matrix:
   - PACKAGE: "git-mirage.dev"
   - PACKAGE: "git-unix.dev"

--- a/src/git/commit.ml
+++ b/src/git/commit.ml
@@ -45,7 +45,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = t
-     and type init = int * t
+     and type init = Cstruct.t * t
      and type error = Error.never
 
   include S.DIGEST with type t := t and type hash := Hash.t
@@ -232,7 +232,8 @@ module Make (Hash : S.HASH) = struct
 
   let digest value =
     let tmp = Cstruct.create 0x100 in
-    Helper.fdigest (module Hash) (module E) ~tmp ~kind:"commit" ~length value
+    let etmp = Cstruct.create 0x100 in
+    Helper.digest (module Hash) (module E) ~etmp ~tmp ~kind:"commit" ~length value
 
   let equal = ( = )
   let hash = Hashtbl.hash

--- a/src/git/commit.mli
+++ b/src/git/commit.mli
@@ -57,7 +57,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = t
-     and type init = int * t
+     and type init = Cstruct.t * t
      and type error = Error.never
 
   include S.DIGEST with type t := t and type hash := Hash.t

--- a/src/git/helper.mli
+++ b/src/git/helper.mli
@@ -81,7 +81,7 @@ module MakeInflater (Z : S.INFLATE) (A : S.DESC with type 'a t = 'a Angstrom.t) 
 module MakeEncoder (M : S.DESC with type 'a t = 'a Encore.Encoder.t) :
   S.ENCODER
   with type t = M.e
-   and type init = int * M.e
+   and type init = Cstruct.t * M.e
    and type error = Error.never
 
 (** [MakeDeflater] makes a module which respects the interface {!S.ENCODER}
@@ -95,15 +95,15 @@ module MakeDeflater
     (M : S.DESC with type 'a t = 'a Encore.Encoder.t) :
   S.ENCODER
   with type t = M.e
-   and type init = int * M.e * int * Cstruct.t
+   and type init = Cstruct.t * M.e * int * Cstruct.t
    and type error = [`Deflate of Z.error]
 
-val fdigest :
+val digest :
      (module S.HASH with type t = 'hash)
   -> (module
       S.ENCODER
-        with type t = 't and type init = int * 't and type error = Error.never)
-  -> ?capacity:int
+        with type t = 't and type init = Cstruct.t * 't and type error = Error.never)
+  -> etmp:Cstruct.t
   -> tmp:Cstruct.t
   -> kind:string
   -> length:('t -> int64)

--- a/src/git/index_pack.ml
+++ b/src/git/index_pack.ml
@@ -524,15 +524,15 @@ module Decoder (Hash : S.HASH) = struct
     let get_byte = get_byte ~ctor:(fun k -> Hashes k)
 
     let get_hash k src t =
-      let res = Cstruct.create Hash.digest_size in
+      let res = Bytes.create Hash.digest_size in
       (* XXX(dinosaure): we can replace it by an internal buffer allocated in
          {!default}. *)
       let rec loop i src t =
-        if i = Hash.digest_size then k res src t
+        if i = Hash.digest_size then k (Bytes.unsafe_to_string res) src t
         else
           get_byte
             (fun byte src t ->
-              Cstruct.set_uint8 res i byte ;
+              Bytes.set res i (Char.unsafe_chr byte) ;
               (loop [@tailcall]) (i + 1) src t )
             src t
       in
@@ -563,13 +563,13 @@ module Decoder (Hash : S.HASH) = struct
     (* don't use [await] function. *)
 
     let get_hash k src t =
-      let res = Cstruct.create Hash.digest_size in
+      let res = Bytes.create Hash.digest_size in
       let rec loop i src t =
-        if i = Hash.digest_size then k res src t
+        if i = Hash.digest_size then k (Bytes.unsafe_to_string res) src t
         else
           get_byte
             (fun byte src t ->
-              Cstruct.set_uint8 res i byte ;
+              Bytes.set res i (Char.unsafe_chr byte) ;
               (loop [@tailcall]) (i + 1) src t )
             src t
       in
@@ -604,8 +604,8 @@ module Decoder (Hash : S.HASH) = struct
     aux
     @@ fun hash_idx src t ->
     let produce = Hash.get t.hash in
-    let hash_idx = Cstruct.to_string hash_idx |> Hash.of_raw_string in
-    let hash_pack = Cstruct.to_string hash_pack |> Hash.of_raw_string in
+    let hash_idx = Hash.of_raw_string hash_idx in
+    let hash_pack = Hash.of_raw_string hash_pack in
     if hash_idx <> produce then
       error t (Invalid_hash (Hash.get t.hash, hash_idx))
     else rest ?boffsets (hash_idx, hash_pack) src t )
@@ -647,7 +647,7 @@ module Decoder (Hash : S.HASH) = struct
     else
       KHashes.get_hash
         (fun hash src t ->
-          let hash = Cstruct.to_string hash |> Hash.of_raw_string in
+          let hash = Hash.of_raw_string hash in
           Queue.add hash t.hashes ;
           (hashes [@tailcall]) (Int32.succ idx) max src t )
         src t

--- a/src/git/index_pack.mli
+++ b/src/git/index_pack.mli
@@ -127,18 +127,23 @@ module type DECODER = sig
        | `End of t * Hash.t
        | `Hash of t * (Hash.t * Checkseum.Crc32.t * int64)
        | `Error of t * error ]
-  (** [eval src t] is:
+    (** [eval src t] is:
 
       {ul
 
       {- [`Await t] iff [t] needs more input storage. The client must use
-      {!refill} to provide a new buffer and then call {!eval} with [`Await]
-      until other value returned.} {- [`End (t, hash)] when [t] is done. We
-      returns the hash of the IDX file.} {- [`Hash (t, (hash, crc, offset))]
-      when [t] can returns a new value [(hash, crc, offset)]. The client can
-      call {!eval} to continue the process. The value will be consumed then.}
+       {!refill} to provide a new buffer and then call {!eval} with [`Await]
+       until other value returned.}
+
+      {- [`End (t, hash)] when [t] is done. We returns the hash of the IDX
+       file.}
+
+      {- [`Hash (t, (hash, crc, offset))] when [t] can returns a new value
+       [(hash, crc, offset)]. The client can call {!eval} to continue the
+       process. The value will be consumed then.}
+
       {- [`Error (t, exn)] iff the decoder meet an {!error} [exn]. The decoder
-      can't continue and sticks in this situation.}} *)
+       can't continue and sticks in this situation.}} *)
 end
 
 (** The {i functor} to make the decoder module by a specific hash

--- a/src/git/loose.ml
+++ b/src/git/loose.ml
@@ -101,7 +101,7 @@ module type S = sig
        fs:FS.t
     -> root:Fpath.t
     -> temp_dir:Fpath.t
-    -> ?capacity:int
+    -> etmp:Cstruct.t
     -> ?level:int
     -> ztmp:Cstruct.t
     -> raw:Cstruct.t
@@ -397,11 +397,11 @@ struct
     include Helper.Encoder (E) (FS)
   end
 
-  let write ~fs ~root:dotgit ~temp_dir ?(capacity = 0x100) ?(level = 4) ~ztmp
+  let write ~fs ~root:dotgit ~temp_dir ~etmp ?(level = 4) ~ztmp
       ~raw value =
     let hash = digest value in
     let first, rest = explode hash in
-    let encoder = E.default (capacity, value, level, ztmp) in
+    let encoder = E.default (etmp, value, level, ztmp) in
     let path = Fpath.(dotgit / "objects" / first / rest) in
     Log.debug (fun l -> l "Writing a new loose object %a." Fpath.pp path) ;
     FS.Dir.create fs Fpath.(dotgit / "objects" / first)

--- a/src/git/loose.mli
+++ b/src/git/loose.mli
@@ -105,7 +105,7 @@ module type S = sig
        fs:FS.t
     -> root:Fpath.t
     -> temp_dir:Fpath.t
-    -> ?capacity:int
+    -> etmp:Cstruct.t
     -> ?level:int
     -> ztmp:Cstruct.t
     -> raw:Cstruct.t

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -44,7 +44,7 @@ struct
     let window = Inflate.window () in
     {ztmp; window}
 
-  let buffer ?ztmp ?dtmp:_ ?raw:_ ?window () =
+  let buffer ?ztmp ?etmp:_ ?dtmp:_ ?raw:_ ?window () =
     let ztmp = match ztmp with None -> Cstruct.create 0x800 | Some x -> x in
     let window = match window with None -> Inflate.window () | Some x -> x in
     {ztmp; window}
@@ -129,9 +129,11 @@ struct
       | Value.Tree _ -> `Tree
       | Value.Tag _ -> `Tag
     in
+    let raw = Cstruct.create 0x100 in
+    let etmp = Cstruct.create 0x100 in
     if Hashtbl.mem t.values hash then Lwt.return (Ok (hash, 0))
     else
-      match Value.to_raw value with
+      match Value.to_raw ~raw ~etmp value with
       | Error `Never -> assert false
       | Ok inflated ->
           Hashtbl.add t.values hash (lazy value) ;
@@ -181,7 +183,9 @@ struct
         | Value.Tree _ -> `Tree
         | Value.Tag _ -> `Tag
       in
-      match Value.to_raw_without_header value with
+      let raw = Cstruct.create 0x100 in
+      let etmp = Cstruct.create 0x100 in
+      match Value.to_raw_without_header ~raw ~etmp value with
       | Ok raw -> Lwt.return (Some (kind, Cstruct.of_string raw))
       | Error `Never -> assert false
     with Not_found -> Lwt.return None

--- a/src/git/mem.mli
+++ b/src/git/mem.mli
@@ -35,18 +35,24 @@
 module Make (H : Digestif.S) (Inflate : S.INFLATE) (Deflate : S.DEFLATE) : sig
   (** The {i functor} needs 4 modules:
 
-      {ul {- The hash algorithm like [SHA1].} {- A lock implementation to
-      protect references against data-race condition - this module expects a
-      [Lwt] monad.} {- An inflate algorithm implementation - usually [zlib].}
+      {ul
+
+      {- The hash algorithm like [SHA1].}
+
+      {- A lock implementation to protect references against data-race condition
+     - this module expects a [Lwt] monad.}
+
+      {- An inflate algorithm implementation - usually [zlib].}
+
       {- A deflate algorithm implementation - usually [zlib].}}
 
       From the Inflate and the Deflate module, usually, we use a [zlib]
-      implementation provided by [camlzip] or [decompress]. However, you can
-      use an other (better) implementation which needs to respect these
-      interfaces - or provide an implementation which does not inflate/deflate
-      a stream (it's possible). The only {i non-described by type} constraint
-      is the Inflate module needs to understand the Deflate module. For
-      example, use [zlib] to inflate and [brotli] to deflate does not work. *)
+     implementation provided by [camlzip] or [decompress]. However, you can use
+     an other (better) implementation which needs to respect these interfaces -
+     or provide an implementation which does not inflate/deflate a stream (it's
+     possible). The only {i non-described by type} constraint is the Inflate
+     module needs to understand the Deflate module. For example, use [zlib] to
+     inflate and [brotli] to deflate does not work. *)
 
   include
     Minimal.S

--- a/src/git/minimal.ml
+++ b/src/git/minimal.ml
@@ -33,6 +33,7 @@ module type S = sig
 
   val buffer :
        ?ztmp:Cstruct.t
+       -> ?etmp:Cstruct.t
     -> ?dtmp:Cstruct.t
     -> ?raw:Cstruct.t
     -> ?window:Inflate.window
@@ -93,28 +94,35 @@ module type S = sig
     -> Hash.t
     -> 'acc Lwt.t
   (** [fold state f ~path acc hash] iters on any git objects reachable by the
-      git object [hash] which located in [path] (for example, if you iter on a
-      commit, [path] should be ["."] - however, if you iter on a tree, [path]
-      should be the directory path represented by your tree). For each git
-      objects, we notice the path [name] (derived from [path]) if the object is
-      a Blob or a Tree, the [length] or the git object (see {!size}), the
-      [hash] and the [value].
+     git object [hash] which located in [path] (for example, if you iter on a
+     commit, [path] should be ["."] - however, if you iter on a tree, [path]
+     should be the directory path represented by your tree). For each git
+     objects, we notice the path [name] (derived from [path]) if the object is a
+     Blob or a Tree, the [length] or the git object (see {!size}), the [hash]
+     and the [value].
 
       If the [hash] points to:
 
-      {ul {- {!Value.Blob.t}: [f] is called only one time with the OCaml value
-      of the {i blob}.} {- {!Value.Tree.t}: [f] is called firstly with the
-      Ocaml value of the pointed {i tree} by the hash [hash]. Then, we {i iter}
-      (and call [f] for each iteration) in the list of entries of the {i tree}.
-      Finally, we retrieve recursively all sub-tree objects and do an ascending
-      walk. [f] is never called more than one time for each hash.} {-
-      {!Value.Commit.t}: [f] is called firstly with the OCaml value of the
-      pointed {i commit} by the hash [hash]. Then, it follozs recursively all
-      parents of the current commit, Finallym it starts a [fold] inside the
-      pointed root {i tree} git object of each {i commit} previously retrieved.
-      [f] never called more than one time for each hash.} {- {!Value.Tag.t}:
-      [f] is called firstly with the OCaml value of the pointed {i tag} by the
-      hash [hash]. Then, it follows the git object pointed by the {i tag}.}}
+      {ul
+
+      {- {!Value.Blob.t}: [f] is called only one time with the OCaml value of
+     the {i blob}.}
+
+      {- {!Value.Tree.t}: [f] is called firstly with the Ocaml value of the
+     pointed {i tree} by the hash [hash]. Then, we {i iter} (and call [f] for
+     each iteration) in the list of entries of the {i tree}. Finally, we
+     retrieve recursively all sub-tree objects and do an ascending walk. [f] is
+     never called more than one time for each hash.}
+
+      {- {!Value.Commit.t}: [f] is called firstly with the OCaml value of the
+     pointed {i commit} by the hash [hash]. Then, it follozs recursively all
+     parents of the current commit, Finallym it starts a [fold] inside the
+     pointed root {i tree} git object of each {i commit} previously retrieved.
+     [f] never called more than one time for each hash.}
+
+      {- {!Value.Tag.t}: [f] is called firstly with the OCaml value of the
+     pointed {i tag} by the hash [hash]. Then, it follows the git object pointed
+     by the {i tag}.}}
 
       Any retrieved {!error} is missed. *)
 

--- a/src/git/pack.mli
+++ b/src/git/pack.mli
@@ -85,14 +85,21 @@ module type H = sig
     -> [`Await of t | `Flush of t | `End of t | `Error of t * error]
   (** [eval src t] is:
 
-      {ul {- [`Await t] iff [t] needs more input storage. The client must use
-      {!refill} to provide a new buffer and then call {!eval} with [`Await]
-      until other value returned.} {- [`Flush t] iff [t] needs more output
-      storage. The client must use {!flush} to provide a new buffer and then
-      call {!eval} with [`Flush] until [`End] is returned.} {- [`End t] when
-      [t] is done. Then, [t] sticks on this situation, the client can remove
-      it.} {- [`Error (t, exn)] iff the encoder [t] meet an {!error} [exn]. The
-      encoder can't continue and sticks in this situation.}} *)
+      {ul
+
+      {- [`Await t] iff [t] needs more input storage. The client must use
+     {!refill} to provide a new buffer and then call {!eval} with [`Await] until
+     other value returned.}
+
+      {- [`Flush t] iff [t] needs more output storage. The client must use
+     {!flush} to provide a new buffer and then call {!eval} with [`Flush] until
+     [`End] is returned.}
+
+      {- [`End t] when [t] is done. Then, [t] sticks on this situation, the
+     client can remove it.}
+
+      {- [`Error (t, exn)] iff the encoder [t] meet an {!error} [exn]. The
+     encoder can't continue and sticks in this situation.}} *)
 
   val used_in : t -> int
   (** [used_in ŧ] returns how many byte [t] consumed in the current buffer
@@ -140,15 +147,23 @@ module type ENTRY = sig
     -> t
   (** [make hash ?name ?preferred ?delta kind length] returns a new entry when:
 
-      {ul {- [hash] corresponds to the unique ID of the git object.} {- [name]
-      corresponds to the optional name of the git object. For a [Tree] or a
-      [Blob], the client should notice the given name (to optimize the
-      delta-ification).} {- [preferred] notices to the delta-ification
-      algorithm to prefer to use this entry as a source.} {- [delta] notices an
-      existing user specified source for the entry (and the delta-ification
-      algorithm will use it).} {- [kind] corresponds to the kind of the
-      object.} {- [length] corresponds to the real inflated length of the
-      object.}} *)
+      {ul
+
+      {- [hash] corresponds to the unique ID of the git object.}
+
+      {- [name] corresponds to the optional name of the git object. For a [Tree]
+     or a [Blob], the client should notice the given name (to optimize the
+     delta-ification).}
+
+      {- [preferred] notices to the delta-ification algorithm to prefer to use
+     this entry as a source.}
+
+      {- [delta] notices an existing user specified source for the entry (and
+     the delta-ification algorithm will use it).}
+
+      {- [kind] corresponds to the kind of the object.}
+
+      {- [length] corresponds to the real inflated length of the object.}} *)
 
   val kind : t -> Kind.t
   val preferred : t -> bool
@@ -337,17 +352,24 @@ module type P = sig
     -> Cstruct.t
     -> t
     -> [`Flush of t | `Await of t | `End of t * Hash.t | `Error of t * error]
-  (** [eval src t] is:
+    (** [eval src t] is:
 
-      {ul {- [`Await t] iff [t] needs more input storage. The client must use
-      {!refill} to provide a new buffer and then call {!eval} with [`Await]
-      until other value returned.} {- [`Flush t] iff [t] needs more output
-      storage. The client must use {!flush} to provide a new buffer and then
-      call {!eval} with [`Flush] until other value returned.} {- [`End (t,
-      hash)] when [t] is done. Then, [t] sticks on this situation, the client
-      can remove it. [hash] is the hash calculated of the PACK stream.} {-
-      [`Error (t, exn)] iff the encoder [t] meet an {!error} [exn]. The encoder
-      can't continue and sticks in this situation.}} *)
+      {ul
+
+      {- [`Await t] iff [t] needs more input storage. The client must use
+       {!refill} to provide a new buffer and then call {!eval} with [`Await]
+       until other value returned.}
+
+      {- [`Flush t] iff [t] needs more output storage. The client must use
+       {!flush} to provide a new buffer and then call {!eval} with [`Flush]
+       until other value returned.}
+
+      {- [`End (t, hash)] when [t] is done. Then, [t] sticks on this situation,
+       the client can remove it. [hash] is the hash calculated of the PACK
+       stream.}
+
+      {- [`Error (t, exn)] iff the encoder [t] meet an {!error} [exn]. The
+       encoder can't continue and sticks in this situation.}} *)
 end
 
 (** The {i functor} to make the PACK encoder by a specific hash implementation

--- a/src/git/packed_refs.ml
+++ b/src/git/packed_refs.ml
@@ -30,7 +30,7 @@ module type S = sig
      and type init = Cstruct.t
      and type error = Error.Decoder.t
 
-  module E : S.ENCODER with type t = t and type init = int * t
+  module E : S.ENCODER with type t = t and type init = Cstruct.t * t
 
   type error = [Error.Decoder.t | FS.error Error.FS.t]
 
@@ -40,7 +40,7 @@ module type S = sig
        fs:FS.t
     -> root:Fpath.t
     -> temp_dir:Fpath.t
-    -> ?capacity:int
+    -> etmp:Cstruct.t
     -> raw:Cstruct.t
     -> t
     -> (unit, error) result Lwt.t
@@ -187,8 +187,8 @@ module Make (Hash : S.HASH) (FS : S.FS) = struct
     include Helper.Encoder (E) (FS)
   end
 
-  let write ~fs ~root:dotgit ~temp_dir ?(capacity = 0x100) ~raw value =
-    let state = E.default (capacity, value) in
+  let write ~fs ~root:dotgit ~temp_dir ~etmp ~raw value =
+    let state = E.default (etmp, value) in
     let path = Fpath.(dotgit / "packed-refs") in
     Encoder.to_file fs ~temp_dir path raw state
     >|= function

--- a/src/git/packed_refs.mli
+++ b/src/git/packed_refs.mli
@@ -30,7 +30,7 @@ module type S = sig
      and type init = Cstruct.t
      and type error = Error.Decoder.t
 
-  module E : S.ENCODER with type t = t and type init = int * t
+  module E : S.ENCODER with type t = t and type init = Cstruct.t * t
 
   type error = [Error.Decoder.t | FS.error Error.FS.t]
 
@@ -40,7 +40,7 @@ module type S = sig
        fs:FS.t
     -> root:Fpath.t
     -> temp_dir:Fpath.t
-    -> ?capacity:int
+    -> etmp:Cstruct.t
     -> raw:Cstruct.t
     -> t
     -> (unit, error) result Lwt.t

--- a/src/git/reference.ml
+++ b/src/git/reference.ml
@@ -107,7 +107,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = head_contents
-     and type init = int * head_contents
+     and type init = Cstruct.t * head_contents
      and type error = Error.never
 end
 
@@ -132,7 +132,7 @@ module type IO = sig
        fs:FS.t
     -> root:Fpath.t
     -> temp_dir:Fpath.t
-    -> ?capacity:int
+    -> etmp:Cstruct.t
     -> raw:Cstruct.t
     -> t
     -> head_contents
@@ -315,9 +315,9 @@ module IO (H : S.HASH) (FS : S.FS) = struct
     | Error (`Decoder err) -> Error.(v @@ Error.Decoder.with_path path err)
     | Error #fs_error as err -> err
 
-  let write ~fs ~root:dotgit ~temp_dir ?(capacity = 0x100) ~raw reference value
+  let write ~fs ~root:dotgit ~temp_dir ~etmp ~raw reference value
       =
-    let state = E.default (capacity, value) in
+    let state = E.default (etmp, value) in
     let path = Path.(dotgit + to_path reference) in
     FS.Dir.create fs (Fpath.parent path)
     >>= function

--- a/src/git/reference.mli
+++ b/src/git/reference.mli
@@ -153,7 +153,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = head_contents
-     and type init = int * head_contents
+     and type init = Cstruct.t * head_contents
      and type error = Error.never
 end
 
@@ -190,7 +190,7 @@ module type IO = sig
        fs:FS.t
     -> root:Fpath.t
     -> temp_dir:Fpath.t
-    -> ?capacity:int
+    -> etmp:Cstruct.t
     -> raw:Cstruct.t
     -> t
     -> head_contents

--- a/src/git/reference.mli
+++ b/src/git/reference.mli
@@ -64,20 +64,29 @@ val of_string : string -> t
 (** [of_string s] returns a valid reference value. A valid value means:
 
     A [refname] is a hierarchical octet string beginning with ["refs/"] and not
-    violating the [git-check-ref-format] command's validation rules. More
-    specifically, they:
+   violating the [git-check-ref-format] command's validation rules. More
+   specifically, they:
 
-    {ul {- They can include slash ['/'] for hierarchical (directory) grouping,
-    but no slash-separated component can begin with a dot ['.'].} {- They must
-    contain at least one ['/']. This enforces the presence of a category like
-    ["heads/"], ["tags/"] etc. but the actual names are not restricted.} {-
-    They cannot have two consecutive dots [".."] anywhere.} {- They cannot have
-    ASCII control characters (i.e. bytes whose values are lower than [\040] or
-    [\177] DEL), space, tilde ['~'], caret ['^'], colon [':'], question-mark
-    ['?'], asterisk ['*'], or open bracket ['\['] anywhere.} {- They cannot end
-    with a slash ['/'] or a dot ['.'].} {- They cannot end with the sequence
-    [".lock"].} {- They cannot contain a sequence ["@{"].} {- They cannot
-    contain a ['\\'].}} *)
+    {ul
+
+    {- They can include slash ['/'] for hierarchical (directory) grouping, but
+   no slash-separated component can begin with a dot ['.'].} {- They must
+   contain at least one ['/']. This enforces the presence of a category like
+   ["heads/"], ["tags/"] etc. but the actual names are not restricted.}
+
+    {- They cannot have two consecutive dots [".."] anywhere.}
+
+    {- They cannot have ASCII control characters (i.e. bytes whose values are
+   lower than [\040] or [\177] DEL), space, tilde ['~'], caret ['^'], colon
+   [':'], question-mark ['?'], asterisk ['*'], or open bracket ['\['] anywhere.}
+
+    {- They cannot end with a slash ['/'] or a dot ['.'].}
+
+    {- They cannot end with the sequence [".lock"].}
+
+    {- They cannot contain a sequence ["@{"].}
+
+    {- They cannot contain a ['\\'].}} *)
 
 val to_string : t -> string
 (** [to_string t] returns the string value of the reference [t]. *)

--- a/src/git/smart.mli
+++ b/src/git/smart.mli
@@ -48,22 +48,41 @@ module type COMMON = sig
   type shallow_update = hash Sync.shallow_update
 
   (** In the negociation phase, the server will ACK obj-ids differently
-      depending on which ack mode is chosen by the client:
+     depending on which ack mode is chosen by the client:
 
-      {ul {- [`Multi_ack] mode: {ul {- the server will respond with [`Continue]
-      for any common commits.} {- once the server has found an acceptable
-      common base commit and is ready to make a packfile, it will blindly ACK
-      all ["have"] obj-ids back to the client.} {- the server will then send a
-      ["NAK"] and then wait for another response from the client - either a
-      ["done"] or another list of ["have"] lines.}}} {- [`Multi_ack_detailed]
-      mode: {ul {- the server will differentiate the ACKs where it is signaling
-      that it is ready to send data with [`Ready] lines, and signals the
-      identified common commits with [`Common] lines.}}} {- [None] mode: {ul {-
-      upload-pack sends [`ACK] on the first common object it finds. After that
-      it says nothing until the client gives it a ["done"].} {- upload-pack
-      sends ["NAK"] on a [`Flush] if no common object has been found yet. If
-      one has been found, and thus an ACK was already sent, it's silent on the
-      [`Flush].}}}}
+      {ul
+
+      {- [`Multi_ack] mode:
+
+      {ul
+
+      {- the server will respond with [`Continue] for any common commits.}
+
+      {- once the server has found an acceptable common base commit and is ready
+     to make a packfile, it will blindly ACK all ["have"] obj-ids back to the
+     client.}
+
+      {- the server will then send a ["NAK"] and then wait for another response
+     from the client - either a ["done"] or another list of ["have"] lines.}}}
+
+      {- [`Multi_ack_detailed] mode:
+
+      {ul
+
+      {- the server will differentiate the ACKs where it is signaling that it is
+     ready to send data with [`Ready] lines, and signals the identified common
+     commits with [`Common] lines.}}}
+
+      {- [None] mode:
+
+      {ul
+
+      {- upload-pack sends [`ACK] on the first common object it finds. After
+     that it says nothing until the client gives it a ["done"].}
+
+      {- upload-pack sends ["NAK"] on a [`Flush] if no common object has been
+     found yet. If one has been found, and thus an ACK was already sent, it's
+     silent on the [`Flush].}}}}
 
       This type represents this information. *)
   type acks = hash Sync.acks

--- a/src/git/store.mli
+++ b/src/git/store.mli
@@ -198,7 +198,7 @@ module type LOOSE = sig
   module E :
     S.ENCODER
     with type t = t
-     and type init = int * t * int * Cstruct.t
+     and type init = Cstruct.t * t * int * Cstruct.t
      and type error = [`Deflate of Deflate.error]
 end
 
@@ -449,6 +449,7 @@ module type S = sig
 
   val buffer :
        ?ztmp:Cstruct.t
+    -> ?etmp:Cstruct.t
     -> ?dtmp:Cstruct.t
     -> ?raw:Cstruct.t
     -> ?window:Inflate.window

--- a/src/git/store.mli
+++ b/src/git/store.mli
@@ -72,15 +72,19 @@ module type LOOSE = sig
 
   val read : state -> Hash.t -> (t, error) result Lwt.t
   (** [read state hash] is the git {i loose} object in [state] such that
-      [digest(result) = hash].
+     [digest(result) = hash].
 
       Can return an {!error}:
 
-      {ul {- {!FS.File.error} when we can not access to the git object in the
-      file-system (because it does not exist or the structure of the git
-      repository is wrong).} {- {!Value.D.error} when we can not de-serialize
-      xor inflate the requested git {i loose} object. That means, the git {i
-      loose} object does not respect the Git format.}} *)
+      {ul
+
+      {- {!FS.File.error} when we can not access to the git object in the
+     file-system (because it does not exist or the structure of the git
+     repository is wrong).}
+
+      {- {!Value.D.error} when we can not de-serialize xor inflate the requested
+     git {i loose} object. That means, the git {i loose} object does not respect
+     the Git format.}} *)
 
   val size : state -> Hash.t -> (int64, error) result Lwt.t
   (** [size t hash] is the size of the git {i loose} object which respects the
@@ -94,19 +98,21 @@ module type LOOSE = sig
   (** [write state v] writes [v] as a {i loose} git object in the file-system.
 
       This function does not allocate any buffer and uses only the specified
-      buffers in [state]'s buffer. Once the write is done, [v] becomes
-      available by [read state digest(v)].
+     buffers in [state]'s buffer. Once the write is done, [v] becomes available
+     by [read state digest(v)].
 
       Can return an {!error}:
 
-      {ul {- {!FS.File.error} when we can not create a new file in the
-      file-system.} {- {!Value.E.error} when we can not serialize xor deflate
-      the requested git {i loose} object. This kind of error should be never
-      happen.}}
+      {ul
+
+      {- {!FS.File.error} when we can not create a new file in the file-system.}
+
+      {- {!Value.E.error} when we can not serialize xor deflate the requested
+     git {i loose} object. This kind of error should be never happen.}}
 
       The current implementation does not limit the memory consumption of the
-      deflate computation (i.e. {i zlib} and the flush method). Depending of
-      the object [v], the process can consume a lot of memory. *)
+     deflate computation (i.e. {i zlib} and the flush method). Depending of the
+     object [v], the process can consume a lot of memory. *)
 
   val write_inflated : state -> kind:kind -> Cstruct.t -> Hash.t Lwt.t
   (** [write_inflated state kind raw] writes the git object in the git
@@ -121,49 +127,57 @@ module type LOOSE = sig
 
   val read_inflated : state -> Hash.t -> (kind * Cstruct.t, error) result Lwt.t
   (** [read_inflated state hash] can retrieve a git {i loose} object from the
-      file-system. However, this function {b does not} de-serialize the git
-      object and returns the kind of the object and the {i raw-data} inflated.
-      Precisely, it decodes only the header.
+     file-system. However, this function {b does not} de-serialize the git
+     object and returns the kind of the object and the {i raw-data} inflated.
+     Precisely, it decodes only the header.
 
-      This function allocate only one buffer in the major-heap and uses only
-      the specified buffers to compute the {i raw-data} in the allocated
-      {!Cstruct.t}. The {i raw-data} respects the predicate [digest(header +
-      raw-data) = hash].
+      This function allocate only one buffer in the major-heap and uses only the
+     specified buffers to compute the {i raw-data} in the allocated
+     {!Cstruct.t}. The {i raw-data} respects the predicate [digest(header +
+     raw-data) = hash].
 
       Can return an {!error}:
 
-      {ul {- {!FS.File.error} when we can not access to the git object in the
-      file-system (because it does not exist or the structure of the git
-      repository is wrong).} {- {!Value.D.error} when we can not de-serialize
-      xor inflate the requested git {i loose} object. That means, the git {i
-      loose} object has a wrong header or it is corrupted.}} *)
+      {ul
+
+      {- {!FS.File.error} when we can not access to the git object in the
+     file-system (because it does not exist or the structure of the git
+     repository is wrong).}
+
+      {- {!Value.D.error} when we can not de-serialize xor inflate the requested
+     git {i loose} object. That means, the git {i loose} object has a wrong
+     header or it is corrupted.}} *)
 
   val read_inflated_wa :
     Cstruct.t -> state -> Hash.t -> (kind * Cstruct.t, error) result Lwt.t
   (** [read_inflated_wa result state h] is the Git {i loose} object with the
-      hash [h]. However, this function {b does not} de-serialize the git object
-      and returns the kind of the object and the {i raw-data} inflated.
-      Precisely, it decodes only the header. This function needs some buffers,
-      provided by [decoder] as well as [result], a buffer to store the result.
+     hash [h]. However, this function {b does not} de-serialize the git object
+     and returns the kind of the object and the {i raw-data} inflated.
+     Precisely, it decodes only the header. This function needs some buffers,
+     provided by [decoder] as well as [result], a buffer to store the result.
 
       The suffix [wa] refers to: Without Allocation. Indeed, this function
-      allocates {b only} any data in the minor-heap. All other needed OCaml
-      objects must be noticed by the client. However, the client needs to
-      provide a well sized [result] (otherwise, the client can retrieve an
-      error). He can get this information by {!size}.
+     allocates {b only} any data in the minor-heap. All other needed OCaml
+     objects must be noticed by the client. However, the client needs to provide
+     a well sized [result] (otherwise, the client can retrieve an error). He can
+     get this information by {!size}.
 
       The {i raw-data} respects the predicate [digest(header + raw-data) = h].
 
       Can return an {!error}:
 
-      {ul {- {!FS.File.error} when we can not access to the git object in the
-      file-system (because it does not exist or the structure of the git
-      repository is wrong).} {- {!Value.D.error} when we can not de-serialize
-      xor inflate the requested git {i loose} object. That means, the git {i
-      loose} object has a wrong header or it is corrupted.}}
+      {ul
 
-      In a server context, this function should be used to limit the
-      allocation. *)
+      {- {!FS.File.error} when we can not access to the git object in the
+     file-system (because it does not exist or the structure of the git
+     repository is wrong).}
+
+      {- {!Value.D.error} when we can not de-serialize xor inflate the requested
+     git {i loose} object. That means, the git {i loose} object has a wrong
+     header or it is corrupted.}}
+
+      In a server context, this function should be used to limit the allocation.
+     *)
 
   (** The decoder of the Git object. We constraint the input to be an
       {!Inflate.window} and a {Cstruct.t} which used by the {Inflate} module
@@ -271,24 +285,30 @@ module type PACK = sig
 
   val read : state -> Hash.t -> (value, error) result Lwt.t
   (** [read state hash] can retrieve a git {i packed} object from any {i PACK}
-      files available in the current git repository [state]. It just inflates
-      the git object and informs some meta-data (like kind, CRC-32 check-sum,
-      length, etc.) about it. Then, the client can use the related decoder to
-      get the OCaml value.
+     files available in the current git repository [state]. It just inflates the
+     git object and informs some meta-data (like kind, CRC-32 check-sum, length,
+     etc.) about it. Then, the client can use the related decoder to get the
+     OCaml value.
 
       This function allocates 2 {Cstruct.t} needed to re-construct the git {i
-      packed} object in any case (if it is delta-ified or not) and a certain
-      amount of little buffer (sized by 0x7F bytes) to help the construction
-      only when the requested object is delta-ified.
+     packed} object in any case (if it is delta-ified or not) and a certain
+     amount of little buffer (sized by 0x7F bytes) to help the construction only
+     when the requested object is delta-ified.
 
       Can return an {!error}:
 
-      {ul {- {!FS.File.error} or {!FS.Dir.error} or {!FS.Mapper.error} when we
-      retrieve a file-system error} {- {!PACKDecoder.error} when we retrieve an
-      error about the decoding of the {i packed} git object in the founded {i
-      PACK}i file} {- {!IDXDecoder.error} when we retrieve an error about the
-      decoding of an {i IDX} file} {- [`Not_found] when the requested object is
-      not {i packed}}} *)
+      {ul
+
+      {- {!FS.File.error} or {!FS.Dir.error} or {!FS.Mapper.error} when we
+     retrieve a file-system error}
+
+      {- {!PACKDecoder.error} when we retrieve an error about the decoding of
+     the {i packed} git object in the founded {i PACK}i file}
+
+      {- {!IDXDecoder.error} when we retrieve an error about the decoding of an
+     {i IDX} file}
+
+      {- [`Not_found] when the requested object is not {i packed}}} *)
 
   val size : state -> Hash.t -> (int, error) result Lwt.t
   (** [size state hash] returns the size of the git {i packed} object which
@@ -457,17 +477,23 @@ module type S = sig
     -> buffer
   (** Build a buffer to read and write a Git object.
 
-      {ul {- [window] is a buffer used by the {!Inflate} module} {- [ztmp] is a
-      buffer used to store the inflated flow} {- [dtmp] is a buffer used by the
-      decoder to save the inflated flow (and keep it for an alteration)} {-
-      [raw] is a buffer used to store the input flow}}
+      {ul
+
+      {- [window] is a buffer used by the {!Inflate} module}
+
+      {- [ztmp] is a buffer used to store the inflated flow}
+
+      {- [dtmp] is a buffer used by the decoder to save the inflated flow (and
+     keep it for an alteration)}
+
+      {- [raw] is a buffer used to store the input flow}}
 
       If not specified the cstruct are created with a size of 4 MiB.
 
-      Store functions can be used in a concurrency context only if the
-      specified buffers are not used by another process. The deserialisation
-      functions does not allocate any buffer and uses only the specified
-      buffers to construct the OCaml value. *)
+      Store functions can be used in a concurrency context only if the specified
+     buffers are not used by another process. The deserialisation functions does
+     not allocate any buffer and uses only the specified buffers to construct
+     the OCaml value. *)
 
   val dotgit : t -> Fpath.t
   (** [dotgit state] is the current [".git"] path used. *)
@@ -504,18 +530,19 @@ module type S = sig
 
   val write : t -> Value.t -> (Hash.t * int, error) result Lwt.t
   (** [write state v] writes as a {b loose} git object [v] in the file-system.
-      It serializes and deflates the value to a new file. which respect the
-      internal structure of a git repository.
+     It serializes and deflates the value to a new file. which respect the
+     internal structure of a git repository.
 
       This function does not allocate any buffer and uses only the specified
-      buffers to store the OCaml value to the file-system. Then, the OCaml
-      value will be available by [read state digest(v)]. Otherwise, return an
-      {!error}:
+     buffers to store the OCaml value to the file-system. Then, the OCaml value
+     will be available by [read state digest(v)]. Otherwise, return an {!error}:
 
-      {ul {- {!FS.File.error} when we can not create a new file in the
-      file-system.} {- {!Value.E.error} when we can not serialize xor deflate
-      the requested git {i loose} object. This kind of error should be never
-      happen.}} *)
+      {ul
+
+      {- {!FS.File.error} when we can not create a new file in the file-system.}
+
+      {- {!Value.E.error} when we can not serialize xor deflate the requested
+     git {i loose} object. This kind of error should be never happen.}} *)
 
   val size : t -> Hash.t -> (int64, error) result Lwt.t
   (** [size state hash] is the size of the git object such that [digest(object)
@@ -559,28 +586,35 @@ module type S = sig
     -> Hash.t
     -> 'a Lwt.t
   (** [fold state f ~path acc hash] iters on any git objects reachable by the
-      git object [hash] which located in [path] (for example, if you iter on a
-      commit, [path] should be ["."] - however, if you iter on a tree, [path]
-      should be the directory path represented by your tree). For each git
-      objects, we notice the path [name] (derived from [path]) if the object is
-      a Blob or a Tree, the [length] or the git object (see {!size}), the
-      [hash] and the [value].
+     git object [hash] which located in [path] (for example, if you iter on a
+     commit, [path] should be ["."] - however, if you iter on a tree, [path]
+     should be the directory path represented by your tree). For each git
+     objects, we notice the path [name] (derived from [path]) if the object is a
+     Blob or a Tree, the [length] or the git object (see {!size}), the [hash]
+     and the [value].
 
       If the [hash] points to:
 
-      {ul {- {!Value.Blob.t}: [f] is called only one time with the OCaml value
-      of the {i blob}.} {- {!Value.Tree.t}: [f] is called firstly with the
-      Ocaml value of the pointed {i tree} by the hash [hash]. Then, we {i iter}
-      (and call [f] for each iteration) in the list of entries of the {i tree}.
-      Finally, we retrieve recursively all sub-tree objects and do an ascending
-      walk. [f] is never called more than one time for each hash.} {-
-      {!Value.Commit.t}: [f] is called firstly with the OCaml value of the
-      pointed {i commit} by the hash [hash]. Then, it follozs recursively all
-      parents of the current commit, Finallym it starts a [fold] inside the
-      pointed root {i tree} git object of each {i commit} previously retrieved.
-      [f] never called more than one time for each hash.} {- {!Value.Tag.t}:
-      [f] is called firstly with the OCaml value of the pointed {i tag} by the
-      hash [hash]. Then, it follows the git object pointed by the {i tag}.}}
+      {ul
+
+      {- {!Value.Blob.t}: [f] is called only one time with the OCaml value of
+     the {i blob}.}
+
+      {- {!Value.Tree.t}: [f] is called firstly with the Ocaml value of the
+     pointed {i tree} by the hash [hash]. Then, we {i iter} (and call [f] for
+     each iteration) in the list of entries of the {i tree}. Finally, we
+     retrieve recursively all sub-tree objects and do an ascending walk. [f] is
+     never called more than one time for each hash.}
+
+      {- {!Value.Commit.t}: [f] is called firstly with the OCaml value of the
+     pointed {i commit} by the hash [hash]. Then, it follozs recursively all
+     parents of the current commit, Finallym it starts a [fold] inside the
+     pointed root {i tree} git object of each {i commit} previously retrieved.
+     [f] never called more than one time for each hash.}
+
+      {- {!Value.Tag.t}: [f] is called firstly with the OCaml value of the
+     pointed {i tag} by the hash [hash]. Then, it follows the git object pointed
+     by the {i tag}.}}
 
       Any retrieved {!error} is skipped. *)
 
@@ -600,11 +634,13 @@ module type S = sig
       -> Reference.head_contents
       -> (Hash.t, error) result Lwt.t
     (** [normalize graph ref] is the final hash pointed by the reference [ref].
-        This function can return an error:
+       This function can return an error:
 
-        {ul {- [`Invalid_reference ref] if, from the graph [graph], we don't
-        find the final pointed hash. This case can appear if the graph is not
-        complete or if the link is broken.}} *)
+        {ul
+
+        {- [`Invalid_reference ref] if, from the graph [graph], we don't find
+       the final pointed hash. This case can appear if the graph is not complete
+       or if the link is broken.}} *)
 
     val list : t -> (Reference.t * Hash.t) list Lwt.t
     (** [list state] is the list of references and their associated hash. This

--- a/src/git/sync.mli
+++ b/src/git/sync.mli
@@ -97,43 +97,52 @@ module type S = sig
        result
        Lwt.t
   (** [fetch_some git ?capabilities ~references repository] will fetch some
-      remote references specified by [references].
+     remote references specified by [references].
 
-      [references] is a map which: {ul {- the key is the {b remote} reference.}
+      [references] is a map which:
+
+      {ul
+
+      {- the key is the {b remote} reference.}
+
       {- the value is a list of {b local} references - which may not exist
-      yet.}}
+     yet.}}
 
-      Then, the function will try to download all of these remote references
-      and returns 2 maps:
+      Then, the function will try to download all of these remote references and
+     returns 2 maps:
 
-      {ul {- the first map contains all local references updated by the new
-      hash. This new hash is come from the server as the downloaded remote
-      reference asked by the client by [references]. Then, from associated
-      local references with remote references, we updated them with the
-      associated hash.
+      {ul
+
+      {- the first map contains all local references updated by the new hash.
+     This new hash is come from the server as the downloaded remote reference
+     asked by the client by [references]. Then, from associated local references
+     with remote references, we updated them with the associated hash.
 
       For example, if [references] is: {[ { "refs/heads/master": [
-      "refs/remotes/origin/master" ; "refs/heads/master" ] } ]}
+     "refs/remotes/origin/master" ; "refs/heads/master" ] } ]}
 
       We will update (or create) "refs/remotes/origin/master" and
-      "refs/heads/master" with the new hash downloaded from the remote
-      reference "refs/heads/master" only if it's necessary (only if we did not
-      find the hash referenced by "refs/heads/master" in the local store).}
+     "refs/heads/master" with the new hash downloaded from the remote reference
+     "refs/heads/master" only if it's necessary (only if we did not find the
+     hash referenced by "refs/heads/master" in the local store).}
 
       {- the second map is a {b subset} of [references] which contains all
-      binder of:
+     binder of:
 
-      {ul {- remote references which does not exist on the server side.} {-
-      remote references which references to an already existing in the local
-      store hash.}}}}
+      {ul
+
+      {- remote references which does not exist on the server side.}
+
+      {- remote references which references to an already existing in the local
+     store hash.}}}}
 
       The client should not put the same local reference as a value of some
-      remote references. The client can define non-existing remote references
-      (then, they appear on the second map). The client can want to set
-      non-existing local references - we will create them.
+     remote references. The client can define non-existing remote references
+     (then, they appear on the second map). The client can want to set
+     non-existing local references - we will create them.
 
       If the processus encountered an error when it updates references, it
-      leaves but, it did partially some update on some local references. *)
+     leaves but, it did partially some update on some local references. *)
 
   val fetch_all :
        Store.t
@@ -170,11 +179,15 @@ module type S = sig
        result
        Lwt.t
   (** [fetch_one git ?capabilities ~reference repository] is a specific call of
-      {!fetch_some} with only one reference. Then, it retuns:
+     {!fetch_some} with only one reference. Then, it retuns:
 
-      {ul {- [`AlreadySync] if the hash of the requested reference already
-      exists on the local store} {- [`Sync updated] if we downloaded [new_hash]
-      and set [local_ref] with this new hash.}} *)
+      {ul
+
+      {- [`AlreadySync] if the hash of the requested reference already exists on
+     the local store}
+
+      {- [`Sync updated] if we downloaded [new_hash] and set [local_ref] with
+     this new hash.}} *)
 
   val clone :
        Store.t
@@ -192,32 +205,37 @@ module type S = sig
        , error )
        result
        Lwt.t
-  (** As {!fetch_some}, [update git ?capabilities ~references repository] is
-      the other side of the communication with a Git server and update and
-      create remote references when it uploads local hashes.
+       (** As {!fetch_some}, [update git ?capabilities ~references repository]
+          is the other side of the communication with a Git server and update
+          and create remote references when it uploads local hashes.
 
-      [reference] is a map which: {ul {- the key is the {b local} reference.}
-      {- the value is a list of {b remote} references - which may not exist
-      yet.}}
+           [reference] is a map which:
 
-      Then, the function will try to upload all of these local references to
-      the binded remote references. If binded remote reference does not exist
-      on the server, we ask to the server to create and set it to the local
-      hash.
+           {ul
+
+           {- the key is the {b local} reference.}
+
+           {- the value is a list of {b remote} references - which may not exist
+          yet.}}
+
+      Then, the function will try to upload all of these local references to the
+          binded remote references. If binded remote reference does not exist on
+          the server, we ask to the server to create and set it to the local
+          hash.
 
       For each update action, we check if the local store has the remote hash.
-      In other case, we miss this action - that means, the local store is not
-      synchronized with the server (and the client probably needs to
-      {!fetch_some} before).
+          In other case, we miss this action - that means, the local store is
+          not synchronized with the server (and the client probably needs to
+          {!fetch_some} before).
 
       Then, it returns a list of results. The [Ok] case with the remote
-      reference which the server updated correctly and the [Error] case with
-      the remote reference which the server encountered an error with a
-      description of this error.
+          reference which the server updated correctly and the [Error] case with
+          the remote reference which the server encountered an error with a
+          description of this error.
 
       At this final stage, the function does not encountered any error during
-      the commmunication - if it's the case, we did not do any modification on
-      the server and return an {!error}. *)
+          the commmunication - if it's the case, we did not do any modification
+          on the server and return an {!error}. *)
 end
 
 module Default : sig

--- a/src/git/tag.ml
+++ b/src/git/tag.ml
@@ -39,7 +39,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = t
-     and type init = int * t
+     and type init = Cstruct.t * t
      and type error = Error.never
 
   include S.DIGEST with type t := t and type hash := Hash.t
@@ -215,7 +215,8 @@ module Make (Hash : S.HASH) = struct
 
   let digest value =
     let tmp = Cstruct.create 0x100 in
-    Helper.fdigest (module Hash) (module E) ~tmp ~kind:"tag" ~length value
+    let etmp = Cstruct.create 0x100 in
+    Helper.digest (module Hash) (module E) ~tmp ~etmp ~kind:"tag" ~length value
 
   let equal = ( = )
   let compare = Pervasives.compare

--- a/src/git/tag.mli
+++ b/src/git/tag.mli
@@ -54,7 +54,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = t
-     and type init = int * t
+     and type init = Cstruct.t * t
      and type error = Error.never
 
   include S.DIGEST with type t := t and type hash := Hash.t

--- a/src/git/tree.ml
+++ b/src/git/tree.ml
@@ -48,7 +48,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = t
-     and type init = int * t
+     and type init = Cstruct.t * t
      and type error = Error.never
 
   include S.DIGEST with type t := t and type hash := Hash.t
@@ -273,7 +273,8 @@ module Make (Hash : S.HASH) = struct
 
   let digest value =
     let tmp = Cstruct.create 0x100 in
-    Helper.fdigest (module Hash) (module E) ~tmp ~kind:"tree" ~length value
+    let etmp = Cstruct.create 0x100 in
+    Helper.digest (module Hash) (module E) ~etmp ~tmp ~kind:"tree" ~length value
 
   let equal = ( = )
   let compare = Pervasives.compare

--- a/src/git/tree.mli
+++ b/src/git/tree.mli
@@ -72,7 +72,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = t
-     and type init = int * t
+     and type init = Cstruct.t * t
      and type error = Error.never
 
   include S.DIGEST with type t := t and type hash := Hash.t

--- a/src/git/unpack.mli
+++ b/src/git/unpack.mli
@@ -113,17 +113,23 @@ module type H = sig
        | `Ok of t * hunks ]
   (** [eval src t] is:
 
-      {ul {- [`Await t] iff [t] needs more input storage. The client must use
-      {!refill} to provide a new buffer and then call {!eval} with [`Await]
-      until other value returned.} {- [`Hunk t] when [t] can return a new
-      {!hunk}. The client can call {!continue} to move to the next step of the
-      process, otherwise the decode sticks on this situation. The value will be
-      consumed then. If the {!hunk} is [Insert], the internal [Cstruct.t] need
-      to be copied because {!eval} will erase the content then.} {- [`Ok (t,
-      hunks)] when [t] is done. We returns the complete value {!hunks}. Then,
-      [t] sticks on this situation, the client can remove it.} {- [`Error (t,
-      exn)] iff the decoder [t] meet an {!error} [exn]. The decoder can't
-      continue and sticks in this situation.}} *)
+      {ul
+
+      {- [`Await t] iff [t] needs more input storage. The client must use
+     {!refill} to provide a new buffer and then call {!eval} with [`Await] until
+     other value returned.}
+
+      {- [`Hunk t] when [t] can return a new {!hunk}. The client can call
+     {!continue} to move to the next step of the process, otherwise the decode
+     sticks on this situation. The value will be consumed then. If the {!hunk}
+     is [Insert], the internal [Cstruct.t] need to be copied because {!eval}
+     will erase the content then.}
+
+      {- [`Ok (t, hunks)] when [t] is done. We returns the complete value
+     {!hunks}. Then, [t] sticks on this situation, the client can remove it.}
+
+      {- [`Error (t, exn)] iff the decoder [t] meet an {!error} [exn]. The
+     decoder can't continue and sticks in this situation.}} *)
 
   val default : int -> reference -> t
   (** Make a new decoder state {!t} from a {!reference}. We need to notice the
@@ -207,13 +213,21 @@ module type P = sig
     | Blob
     | Tag
     | Hunk of Hunk.hunks
-        (** The kind of the PACK object. It can be:
+    (** The kind of the PACK object. It can be:
 
-            {ul {- A [Commit]} {- A [Tree]} {- A [Blob]} {- A [Tag]} {- A
-            [Hunk]: this is not a git object but a specific PCK object. The
-            {!H.hunks} refers to another PACK object by {!H.reference} and it's
-            just a result of a diff between the reference and the current
-            object.} } *)
+            {ul
+
+            {- A [Commit]}
+
+            {- A [Tree]}
+
+            {- A [Blob]}
+
+            {- A [Tag]}
+
+            {- A [Hunk]: this is not a git object but a specific PCK object. The
+       {!H.hunks} refers to another PACK object by {!H.reference} and it's just
+       a result of a diff between the reference and the current object.} } *)
 
   val default : Cstruct.t -> Inflate.window -> t
   (** [default tmp window] makes a new decoder of a PACK file.
@@ -339,24 +353,33 @@ module type P = sig
        | `Error of t * error ]
   (** [eval src t] is:
 
-      {ul {- [`Await t] iff [t] more input storage. The client muse use
-      {!refill} to provide a new buffer and then call {!eval} with [`Await]
-      until other value returned.} {- [`Object t] iff [t] finishes to compute
-      one object. The client is able to use the meta-data functions (like
-      {!kind} or {!crc}) and should use {!next_object} to move the decoder to
-      the next step. Otherwise, the decoder [t] sticks in this situation.} {-
-      [Hunk (t, hunk)] defers the value returned by the internal {!H.t}
-      decoder. The client should use {!continue} to move the decoder to the
-      next step. In this situation, we ensure than the future {!kind} of the
-      current/expected object is {!Hunk _}.} {- [`Flush t] iff [t] needs more
-      output storage. The client must use {!flush} to provide a new buffer and
-      then call {!eval} with [`Flush] until [`Object] is returned. In this
-      situation, we ensure than the future {!kind} of the current/expected
-      object is different than the {!Hunk _}.} {- [`End (t, hash)] when the
-      decoder is done. [t] sticks to this situation. The client can remove it.
-      We return the hash produced by the PACK stream.} {- [`Error (t, exn)] iff
-      the decoder meet an {!error} [exn]. The decoder can't continue and sticks
-      in this situation.}} *)
+      {ul
+
+      {- [`Await t] iff [t] more input storage. The client muse use {!refill} to
+     provide a new buffer and then call {!eval} with [`Await] until other value
+     returned.}
+
+      {- [`Object t] iff [t] finishes to compute one object. The client is able
+     to use the meta-data functions (like {!kind} or {!crc}) and should use
+     {!next_object} to move the decoder to the next step. Otherwise, the decoder
+     [t] sticks in this situation.}
+
+      {- [Hunk (t, hunk)] defers the value returned by the internal {!H.t}
+     decoder. The client should use {!continue} to move the decoder to the next
+     step. In this situation, we ensure than the future {!kind} of the
+     current/expected object is {!Hunk _}.}
+
+      {- [`Flush t] iff [t] needs more output storage. The client must use
+     {!flush} to provide a new buffer and then call {!eval} with [`Flush] until
+     [`Object] is returned. In this situation, we ensure than the future {!kind}
+     of the current/expected object is different than the {!Hunk _}.}
+
+      {- [`End (t, hash)] when the decoder is done. [t] sticks to this
+     situation. The client can remove it. We return the hash produced by the
+     PACK stream.}
+
+      {- [`Error (t, exn)] iff the decoder meet an {!error} [exn]. The decoder
+     can't continue and sticks in this situation.}} *)
 
   val eval_length :
        Cstruct.t
@@ -368,9 +391,11 @@ module type P = sig
        | `Error of t * error ]
   (** [eval_length src t] has the same purpose than {!eval} plus:
 
-      {ul {- [`Length t] iff [t] can return the real inflated length of the
-      current/expected object. The client should use {!length} to get this
-      information.}} *)
+      {ul
+
+      {- [`Length t] iff [t] can return the real inflated length of the
+     current/expected object. The client should use {!length} to get this
+     information.}} *)
 
   val eval_metadata :
        Cstruct.t
@@ -380,10 +405,12 @@ module type P = sig
        | `Flush of t
        | `End of t * Hash.t
        | `Error of t * error ]
-  (** [eval_length src t] has the same purpose than {!eval} plus:
+    (** [eval_length src t] has the same purpose than {!eval} plus:
 
-      {ul {- [`Metadata t] iff [t] can be used with meta-data functions (like
-      {!kind} or {!length}).}} *)
+      {ul
+
+      {- [`Metadata t] iff [t] can be used with meta-data functions (like
+       {!kind} or {!length}).}} *)
 end
 
 module Pack

--- a/src/git/value.mli
+++ b/src/git/value.mli
@@ -71,7 +71,7 @@ module type S = sig
   module E :
     S.ENCODER
     with type t = t
-     and type init = int * t * int * Cstruct.t
+     and type init = Cstruct.t * t * int * Cstruct.t
      and type error = [`Deflate of Deflate.error]
 
   include S.DIGEST with type t := t and type hash := Hash.t
@@ -98,7 +98,7 @@ module type RAW = sig
   module EncoderRaw :
     S.ENCODER
     with type t = t
-     and type init = int * t
+     and type init = Cstruct.t * t
      and type error = Error.never
 
   module DecoderRaw :
@@ -110,11 +110,12 @@ module type RAW = sig
   module EncoderWithoutHeader :
     S.ENCODER
     with type t = t
-     and type init = int * t
+     and type init = Cstruct.t * t
      and type error = Error.never
 
   val to_deflated_raw :
-       ?capacity:int
+       raw:Cstruct.t
+    -> etmp:Cstruct.t
     -> ?level:int
     -> ztmp:Cstruct.t
     -> t
@@ -128,14 +129,14 @@ module type RAW = sig
       All error from the {!Deflate} module is relayed to the [`Deflate] error
       value. *)
 
-  val to_raw : ?capacity:int -> t -> (string, EncoderRaw.error) result
+  val to_raw : raw:Cstruct.t -> etmp:Cstruct.t -> t -> (string, EncoderRaw.error) result
   (** [to_raw ?capacity value] serializes the value [value]. [capacity] is the
       memory consumption of the encoder in bytes (default to [0x100]).
 
       This function can not returns an {!EE.error} (see {!EE}). *)
 
   val to_raw_without_header :
-    ?capacity:int -> t -> (string, EncoderWithoutHeader.error) result
+    raw:Cstruct.t -> etmp:Cstruct.t -> t -> (string, EncoderWithoutHeader.error) result
 
   val of_raw :
        kind:[`Commit | `Blob | `Tree | `Tag]

--- a/test/common/test_store.ml
+++ b/test/common/test_store.ml
@@ -313,7 +313,9 @@ module Make (Store : S) = struct
       |> Store.Value.commit
     in
     let test () =
-      match ValueIO.to_raw c with
+      let raw = Cstruct.create 0x100 in
+      let etmp = Cstruct.create 0x100 in
+      match ValueIO.to_raw ~raw ~etmp c with
       | Error e -> Alcotest.failf "%a" ValueIO.EncoderRaw.pp_error e
       | Ok raw -> (
         match ValueIO.of_raw_with_header (Cstruct.of_string raw) with


### PR DESCRIPTION
Big pass to be able to use an already allocated buffer to encode Git object. This PR was thinked at the beginning of `ocaml-git.2.0.0` but it was never apply ... This is should optimize `ocaml-git` when I deleted most of systemic allocation - however, we still have some allocations in some place but I figure out currently on this issue.