### PR TITLE
Remove digestif.{c,ocaml}, checkseum.{c,ocaml} dependencies on git-unix and git-mirage libraries

### DIFF
--- a/src/git-mirage/dune
+++ b/src/git-mirage/dune
@@ -1,6 +1,4 @@
 (library
  (name        git_mirage)
  (public_name git-mirage)
- (libraries   digestif.ocaml checkseum.ocaml
-              git mirage-flow-lwt mirage-channel-lwt
-              mirage-conduit cohttp-mirage git-http decompress))
+ (libraries   git mirage-flow-lwt mirage-channel-lwt mirage-conduit cohttp-mirage git-http decompress))

--- a/src/git-unix/dune
+++ b/src/git-unix/dune
@@ -1,5 +1,4 @@
 (library
  (name        git_unix)
  (public_name git-unix)
- (libraries   checkseum.c digestif.c
-              git logs.fmt lwt.unix git-http cohttp-lwt-unix))
+ (libraries   git logs.fmt lwt.unix git-http cohttp-lwt-unix))

--- a/src/git-unix/ogit-cat-file/dune
+++ b/src/git-unix/ogit-cat-file/dune
@@ -2,7 +2,8 @@
   (name        main)
   (public_name ogit-cat-file)
   (package     git-unix)
-  (libraries   git-unix
+  (libraries   digestif.c checkseum.c
+               git-unix
                cmdliner
                mtime mtime.clock.os
                fmt.cli fmt.tty

--- a/src/git-unix/ogit-dot/dune
+++ b/src/git-unix/ogit-dot/dune
@@ -2,4 +2,4 @@
  (name        main)
  (package     git-unix)
  (public_name ogit-dot)
- (libraries   git-unix))
+ (libraries   digestif.c checkseum.c git-unix))

--- a/src/git-unix/ogit-http-clone/dune
+++ b/src/git-unix/ogit-http-clone/dune
@@ -2,7 +2,8 @@
   (name        main)
   (package     git-unix)
   (public_name ogit-http-clone)
-  (libraries   git-unix
+  (libraries   digestif.c checkseum.c
+               git-unix
                cohttp-lwt-unix
                cmdliner
                mtime mtime.clock.os

--- a/src/git-unix/ogit-http-fetch-all/dune
+++ b/src/git-unix/ogit-http-fetch-all/dune
@@ -2,7 +2,8 @@
   (name        main)
   (package     git-unix)
   (public_name ogit-http-fetch-all)
-  (libraries   git-unix
+  (libraries   digestif.c checkseum.c
+               git-unix
                cohttp-lwt-unix
                cmdliner
                mtime mtime.clock.os

--- a/src/git-unix/ogit-http-fetch/dune
+++ b/src/git-unix/ogit-http-fetch/dune
@@ -2,7 +2,8 @@
   (name        main)
   (package     git-unix)
   (public_name ogit-http-fetch)
-  (libraries   git-unix
+  (libraries   digestif.c checkseum.c
+               git-unix
                cohttp-lwt-unix
                cmdliner
                mtime mtime.clock.os

--- a/src/git-unix/ogit-http-ls/dune
+++ b/src/git-unix/ogit-http-ls/dune
@@ -2,7 +2,8 @@
   (name        main)
   (package     git-unix)
   (public_name ogit-http-ls)
-  (libraries   git-unix
+  (libraries   digestif.c checkseum.c
+               git-unix
                cohttp-lwt-unix
                cmdliner
                mtime mtime.clock.os

--- a/src/git-unix/ogit-write-tree/dune
+++ b/src/git-unix/ogit-write-tree/dune
@@ -2,7 +2,8 @@
   (name        main)
   (package     git-unix)
   (public_name ogit-write-tree)
-  (libraries   git-unix
+  (libraries   digestif.c checkseum.c
+               git-unix
                cmdliner
                mtime mtime.clock.os
                fmt.cli fmt.tty


### PR DESCRIPTION
This PR is like a PR out of box but from an other project which want to link with `irmin-unix` and `irmin-mirage`, it wants to link with `git-unix` and `git-mirage` by transitivity. However, both compiles with `digestif.c` & `digestif.ocaml` (`git-unix`) and `checkseum.c` & `checkseum.ocaml` (`git-mirage`). By this way, we link both implementations.

At the end, we did not retrieve any compiler errors (which is an issue?) but get a _segfault_. This PR should fix this problem.