### PR TITLE
Support for authentication via Uri

### DIFF
--- a/src/git-mirage/dune
+++ b/src/git-mirage/dune
@@ -1,4 +1,4 @@
 (library
  (name        git_mirage)
  (public_name git-mirage)
- (libraries   git mirage-flow-lwt mirage-channel-lwt mirage-conduit cohttp-mirage git-http decompress))
+ (libraries   digestif.ocaml checkseum.ocaml git mirage-flow-lwt mirage-channel-lwt mirage-conduit cohttp-mirage git-http decompress))


### PR DESCRIPTION
Hello friends! 
We tested the new KV interface with github as a storage backend for caldav. To make it work, we had to add HTTP Basic Auth. With this change, we can authenticate to github and read and write (pull and push). See it working at https://github.com/roburio/testcalendar 
Also, we reverted your change regarding `checkseum.ocaml` and `digestif.ocaml` to make it compile. We tried to add the above libraries as sublibraries in a mirage unikernel's config.ml file, but that did not seem to work yet. 
Enjoy! 🌴 