### PR TITLE
Fix #342 (WIP)

### DIFF
--- a/src/git/smart.mli
+++ b/src/git/smart.mli
@@ -299,7 +299,9 @@ module type DECODER = sig
     | Negociation : Hash.Set.t * ack_mode -> Common.acks transaction
     | NegociationResult : Common.negociation_result transaction
     | PACK : side_band -> flow transaction
-    | ReportStatus : side_band -> Common.report_status transaction
+    | ReportStatus :
+        string list * side_band
+        -> Common.report_status transaction
     | HttpReportStatus :
         string list * side_band
         -> Common.report_status transaction
@@ -483,7 +485,7 @@ module type CLIENT = sig
     | `Flush
     | `ReceivePACK
     | `SendPACK of int
-    | `FinishPACK ]
+    | `FinishPACK of Reference.Set.t ]
 
   val run : context -> action -> process
   (** [run ctx action] sends an action to the server and schedule a specific


### PR DESCRIPTION
This PR come from a reverse engineering about Smart protocol where technical documentation does not notice me about a `PKT-line` inside a `PKT-line` when we compute a TCP flow. In some way, this PR should be more close to `git` where we merge `p_http_report_status` (a special case on the HTTP flow) and `p_report_status` (the initial case explained by technical documentation) - indeed, this is what Git does about HTTP overlay, it wraps TCP flow with an internal state to be stateless over HTTP (yes, it's ****).

I tried this with `git.2.7.4` only on TCP. @hannesm could you try to test this PR with `caldav` over HTTP ? In my mind, it should not work ...

If it's work, I will rewrite this PR to be more clean (and remove the special case about HTTP).