### PR TITLE
initial ssh (client) support using awa-ssh

### DIFF
--- a/git.opam
+++ b/git.opam
@@ -36,8 +36,8 @@ depends: [
   "checkseum"  {>= "0.0.9"}
   "stdlib-shims"
   "ke"
-  "encore"     {>= "0.5"}
-  "duff"
+  "encore"     {>= "0.5" & < "0.6"}
+  "duff"       {< "0.3"}
   "hex"
   "ocplib-endian"
   "rresult"

--- a/src/git-mirage/git_mirage.mli
+++ b/src/git-mirage/git_mirage.mli
@@ -16,6 +16,8 @@ val endpoint :
 module Sync (G : Git.S) : sig
   module Tcp : Git.Sync.S with module Store := G and type Endpoint.t = endpoint
 
+  module Ssh : Git.Sync.S with module Store := G and type Endpoint.t = endpoint
+
   module Http :
     Git_http.Sync.S with module Store := G and type Client.endpoint = endpoint
 

--- a/src/git-unix/net.ml
+++ b/src/git-unix/net.ml
@@ -33,7 +33,7 @@ let host uri =
   | None ->
       Fmt.kstrf failwith "Expected a git url with host: %a." Uri.pp_hum uri
 
-let socket (e : endpoint) =
+let socket ?cmd:_ (e : endpoint) =
   let open Lwt.Infix in
   let uri = e.uri in
   Log.debug (fun l ->

--- a/src/git/git.ml
+++ b/src/git/git.ml
@@ -37,4 +37,5 @@ module Buffer = Cstruct_buffer
 module Hash = Hash
 module Gri = Gri
 module Tcp = Tcp
+module Ssh = Ssh
 module Path = Path

--- a/src/git/git.mli
+++ b/src/git/git.mli
@@ -33,6 +33,7 @@ module Buffer = Cstruct_buffer
 module Hash = Hash
 module Gri = Gri
 module Tcp = Tcp
+module Ssh = Ssh
 module Path = Path
 
 module type FILE = S.FILE

--- a/src/git/smart.mli
+++ b/src/git/smart.mli
@@ -494,7 +494,7 @@ module type CLIENT = sig
   (** [run ctx action] sends an action to the server and schedule a specific
       {!Decoder.transaction} then. *)
 
-  val context : Common.git_proto_request -> context * process
+  val context : Common.git_proto_request option -> context * process
   (** [context request] makes a new context and the continuation of the
       transport. *)
 end

--- a/src/git/ssh.ml
+++ b/src/git/ssh.ml
@@ -224,10 +224,10 @@ struct
               Log.debug (fun l ->
                   l "Retrieve `Done ACK from negotiation engine." ) ;
               Client.run t.ctx `Done |> process t >>?= aux t asked state
-          | `Again have, state ->
+          | `Again _have, state ->
               Log.debug (fun l ->
                   l "Retrieve `Again ACK from negotiation engine." ) ;
-              Client.run t.ctx (`Has have) |> process t >>?= aux t asked state
+              Client.run t.ctx `Done |> process t >>?= aux t asked state
           )
       | `NegociationResult _ ->
           Log.debug (fun l -> l "Retrieve a negotiation result.") ;

--- a/src/git/ssh.ml
+++ b/src/git/ssh.ml
@@ -46,6 +46,8 @@ struct
   type command = Common.command
 
   let pp_command = Common.pp_command
+  let pp_fetch_one = Common.pp_fetch_one
+  let pp_update_and_create = Common.pp_update_and_create
 
   type t =
     { socket: Net.socket

--- a/src/git/ssh.mli
+++ b/src/git/ssh.mli
@@ -1,0 +1,5 @@
+(** This interface describes the minimal I/O operations to a git repository. *)
+module Make
+    (N : Tcp.NET)
+    (E : Sync.ENDPOINT with type t = N.endpoint)
+    (G : Minimal.S) : Sync.S with module Store = G and module Endpoint = E

--- a/src/git/tcp.ml
+++ b/src/git/tcp.ml
@@ -238,10 +238,10 @@ struct
               Log.debug (fun l ->
                   l "Retrieve `Done ACK from negotiation engine." ) ;
               Client.run t.ctx `Done |> process t >>?= aux t asked state
-          | `Again have, state ->
+          | `Again _have, state ->
               Log.debug (fun l ->
                   l "Retrieve `Again ACK from negotiation engine." ) ;
-              Client.run t.ctx (`Has have) |> process t >>?= aux t asked state
+              Client.run t.ctx `Done |> process t >>?= aux t asked state
           )
       | `NegociationResult _ ->
           Log.debug (fun l -> l "Retrieve a negotiation result.") ;

--- a/src/git/tcp.mli
+++ b/src/git/tcp.mli
@@ -7,7 +7,7 @@ module type NET = sig
   val pp_error : Format.formatter -> error -> unit
   val read : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
   val write : socket -> Bytes.t -> int -> int -> (int, error) result Lwt.t
-  val socket : endpoint -> socket Lwt.t
+  val socket : ?cmd:string -> endpoint -> socket Lwt.t
   val close : socket -> unit Lwt.t
 end
 


### PR DESCRIPTION
ssh.ml is mainly a copy of tcp.ml, some adjustment were needed since in the tcp protocol the client first sends a request, while in ssh a command (git-receive-pack or git-upload-pack) is executed (with the path to the repository as argument) which starts by emitting data.

this means that git-receive/upload-pack needs to be passed while the connection is established (as done with `?cmd` here), i.e. before there's a FLOW (or NET as it is called here).