### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/git-http.opam
+++ b/git-http.opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml"        {>= "4.03.0"}
-  "dune"         {build}
+  "dune"
   "git"          {= version}
   "cohttp"       {>= "1.0.0"}
   "cohttp-lwt"   {>= "1.0.0"}

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml"            {>= "4.03.0"}
-  "dune"             {build}
+  "dune"
   "cohttp-mirage"    {>= "1.0.0"}
   "mirage-flow-lwt"
   "mirage-channel-lwt"

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml"           {>= "4.03.0"}
-  "dune"            {build}
+  "dune"
   "mmap"            {>= "1.1.0"}
   "cmdliner"
   "git-http"        {= version}

--- a/git.opam
+++ b/git.opam
@@ -25,7 +25,7 @@ build: [
 
 depends: [
   "ocaml"      {>= "4.03.0"}
-  "dune"       {build}
+  "dune"
   "uri"        {>= "1.9.0"}
   "lwt"        {>= "2.4.7"}
   "angstrom"   {>= "0.9.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.