### PR TITLE
use mirage-crypto instead of nocrypto

### DIFF
--- a/git-http.opam
+++ b/git-http.opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"        {>= "4.03.0"}
+  "ocaml"        {>= "4.07.0"}
   "dune"
   "git"          {= version}
   "cohttp"       {>= "1.0.0"}

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -16,22 +16,21 @@ build: [
 ]
 
 depends: [
-  "ocaml"            {>= "4.03.0"}
+  "ocaml"             {>= "4.07.0"}
   "dune"
-  "cohttp-mirage"    {>= "1.0.0"}
-  "mirage-flow"      {>= "2.0.0"}
-  "mirage-channel"   {>= "4.0.0"}
+  "cohttp-mirage"     {>= "1.0.0"}
+  "mirage-flow"       {>= "2.0.0"}
+  "mirage-channel"    {>= "4.0.0"}
   "conduit-mirage"
-  "git-http"         {= version}
-  "git"              {= version}
-  "alcotest"         {with-test & >= "0.8.1"}
-  "mtime"            {with-test & >= "1.0.0"}
-  "nocrypto"         {with-test & >= "0.5.4"}
-  "tls"              {with-test}
-  "io-page"          {with-test & >= "1.6.1"}
-  "tcpip"            {with-test & >= "3.3.0"}
-  "io-page-unix"     {with-test}
-  "mirage-stack" {with-test & >= "2.0.0"}
-  "mirage-random-test" {with-test}
+  "git-http"          {= version}
+  "git"               {= version}
+  "alcotest"          {with-test & >= "0.8.1"}
+  "mtime"             {with-test & >= "1.0.0"}
+  "mirage-crypto-rng" {with-test & >= "0.5.4"}
+  "tls"               {with-test}
+  "io-page"           {with-test & >= "1.6.1"}
+  "tcpip"             {with-test & >= "3.3.0"}
+  "io-page-unix"      {with-test}
+  "mirage-stack"      {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -16,17 +16,17 @@ build: [
 ]
 
 depends: [
-  "ocaml"           {>= "4.03.0"}
+  "ocaml"             {>= "4.07.0"}
   "dune"
-  "mmap"            {>= "1.1.0"}
+  "mmap"              {>= "1.1.0"}
   "cmdliner"
-  "git-http"        {= version}
-  "cohttp"          {>= "1.0.0"}
-  "cohttp-lwt-unix" {>= "1.0.0"}
-  "mtime"           {>= "1.0.0"}
+  "git-http"          {= version}
+  "cohttp"            {>= "1.0.0"}
+  "cohttp-lwt-unix"   {>= "1.0.0"}
+  "mtime"             {>= "1.0.0"}
   "base-unix"
-  "alcotest"        {with-test & >= "0.8.1"}
-  "nocrypto"        {with-test & >= "0.5.4"}
-  "tls"             {with-test}
-  "io-page"         {with-test & >= "1.6.1"}
+  "alcotest"          {with-test & >= "0.8.1"}
+  "mirage-crypto-rng" {with-test}
+  "tls"               {with-test}
+  "io-page"           {with-test & >= "1.6.1"}
 ]

--- a/git.opam
+++ b/git.opam
@@ -24,7 +24,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.03.0"}
+  "ocaml"      {>= "4.07.0"}
   "dune"       {>= "1.1"}
   "uri"        {>= "1.9.0"}
   "lwt"        {>= "2.4.7"}
@@ -46,8 +46,8 @@ depends: [
   "astring"
   "cstruct"
   "ocamlgraph"
-  "alcotest" {with-test & >= "0.8.1"}
-  "nocrypto" {with-test & >= "0.5.4"}
-  "tls"      {with-test}
-  "mtime"    {with-test & >= "1.0.0"}
+  "alcotest"          {with-test & >= "0.8.1"}
+  "mirage-crypto-rng" {with-test & >= "0.5.4"}
+  "tls"               {with-test}
+  "mtime"             {with-test & >= "1.0.0"}
 ]

--- a/test/common/dune
+++ b/test/common/dune
@@ -1,4 +1,4 @@
 (library
   (name      test_git)
   (wrapped   false)
-  (libraries git mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))
+  (libraries git mtime mtime.clock.os alcotest mirage-crypto-rng lwt.unix logs.fmt))

--- a/test/common/test_store.ml
+++ b/test/common/test_store.ml
@@ -23,11 +23,7 @@ open Lwt.Infix
 open Git
 
 let random_cstruct len =
-  let t = Unix.gettimeofday () in
-  let cs = Cstruct.create 8 in
-  Cstruct.BE.set_uint64 cs 0 Int64.(of_float (t *. 1000.)) ;
-  Nocrypto.Rng.reseed cs ;
-  Nocrypto.Rng.generate len
+  Mirage_crypto_rng.generate len
 
 let long_random_cstruct () =
   random_cstruct 1024

--- a/test/git-mirage/dune
+++ b/test/git-mirage/dune
@@ -3,7 +3,7 @@
  (libraries checkseum.ocaml digestif.ocaml
             test_git test_smart
             git-mirage io-page.unix conduit-mirage
-	    mirage-random-test
+	    mirage-crypto-rng mirage-crypto-rng.unix
             tcpip.udpv4-socket tcpip.tcpv4-socket tcpip.unix
             tcpip.stack-socket mirage-clock-unix))
 

--- a/test/git-mirage/test.ml
+++ b/test/git-mirage/test.ml
@@ -18,7 +18,7 @@
 open Lwt.Infix
 
 module C = Conduit_mirage.With_tcp (Tcpip_stack_socket)
-module R = Resolver_mirage.Make_with_stack (Mirage_random_test) (Mclock) (Tcpip_stack_socket)
+module R = Resolver_mirage.Make_with_stack (Mirage_crypto_rng) (Mclock) (Tcpip_stack_socket)
 
 let run f =
   Lwt_main.run
@@ -70,6 +70,7 @@ module TCP = Test_sync.Make (struct
 end)
 
 let () =
+  Mirage_crypto_rng_unix.initialize () ;
   Test_common.verbose () ;
   Alcotest.run "git-mirage"
     [ Test_store.suite "mirage" (module Store)

--- a/test/git-unix/dune
+++ b/test/git-unix/dune
@@ -1,6 +1,6 @@
 (executable
  (name      test)
- (libraries checkseum.c digestif.c test_git test_smart test_smart_regression git-unix))
+ (libraries checkseum.c digestif.c test_git test_smart test_smart_regression git-unix mirage-crypto-rng.unix))
 
 (alias
  (name runtest)

--- a/test/git-unix/test.ml
+++ b/test/git-unix/test.ml
@@ -182,6 +182,7 @@ module Http2 = Https (Fs_store)
 module Index = Test_index
 
 let () =
+  Mirage_crypto_rng_unix.initialize () ;
   verbose () ;
   Alcotest.run "git-unix"
     [ Test_store.suite "mem" (module Mem_store)

--- a/test/git/dune
+++ b/test/git/dune
@@ -1,7 +1,7 @@
 (executable
  (name      test)
  (libraries checkseum.ocaml digestif.ocaml test_git test_smart decompress
-            fpath lwt))
+            fpath lwt mirage-crypto-rng.unix))
 
 (alias
  (name runtest)

--- a/test/git/test.ml
+++ b/test/git/test.ml
@@ -21,6 +21,7 @@ module Store = struct include Git.Mem.Store
                       let v root = v root end
 
 let () =
+  Mirage_crypto_rng_unix.initialize () ;
   verbose () ;
   Alcotest.run "git"
     [ Test_store.suite "mem" (module Store)

--- a/test/smart/dune
+++ b/test/smart/dune
@@ -2,10 +2,10 @@
   (name      test_smart)
   (modules   test_smart)
   (wrapped   false)
-  (libraries git mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))
+  (libraries git mtime mtime.clock.os alcotest mirage-crypto-rng lwt.unix logs.fmt))
 
 (library
   (name      test_smart_regression)
   (modules   test_smart_regression)
   (wrapped   false)
-  (libraries git mtime mtime.clock.os alcotest nocrypto lwt.unix logs.fmt))
+  (libraries git mtime mtime.clock.os alcotest mirage-crypto-rng lwt.unix logs.fmt))

--- a/test/smart/test_smart.ml
+++ b/test/smart/test_smart.ml
@@ -12,11 +12,7 @@ module Make (S : Git.S) = struct
   end
 
   let generate_hash () =
-    let t = Unix.gettimeofday () in
-    let cs = Cstruct.create 8 in
-    Cstruct.BE.set_uint64 cs 0 Int64.(of_float (t *. 1000.)) ;
-    Nocrypto.Rng.reseed cs ;
-    Nocrypto.Rng.generate S.Hash.digest_size
+    Mirage_crypto_rng.generate S.Hash.digest_size
     |> Cstruct.to_string
     |> S.Hash.of_raw_string
 


### PR DESCRIPTION
since mirage-crypto requires OCaml 4.07.0, raise these here as well. also, get rid of custom reseeding code and Mirage_random_test.