### PR TITLE
Enlarge internal buffers to be able to parse large tree objects

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -4,3 +4,4 @@ break-infix=fit-or-vertical
 parens-tuple=multi-line-only
 wrap-comments=false
 break-collection-expressions=wrap
+version=0.14.2

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -21,7 +21,7 @@ depends: [
   "cohttp-mirage"     {>= "1.0.0"}
   "mirage-flow"       {>= "2.0.0"}
   "mirage-channel"    {>= "4.0.0"}
-  "conduit-mirage"
+  "conduit-mirage"    {>= "2.2.0"}
   "git-http"          {= version}
   "git"               {= version}
   "alcotest"          {with-test & >= "0.8.1"}
@@ -33,4 +33,5 @@ depends: [
   "io-page-unix"      {with-test}
   "mirage-stack"      {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-time-unix"  {with-test & >= "2.0.1"}
 ]

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -1132,10 +1132,6 @@ struct
   let io_buffer_size = 65536
 
   let default_buffer () =
-    let raw = Cstruct.create (0x8000 * 2) in
-    let buf =
-      Bigarray.Array1.create Bigarray.Char Bigarray.c_layout (2 * 0x8000)
-    in
     { window= Inflate.window ()
     ; ztmp= Cstruct.create io_buffer_size
     ; etmp= Cstruct.create io_buffer_size

--- a/test/git-mirage/dune
+++ b/test/git-mirage/dune
@@ -5,7 +5,7 @@
             git-mirage io-page.unix conduit-mirage
 	    mirage-crypto-rng mirage-crypto-rng.unix
             tcpip.udpv4-socket tcpip.tcpv4-socket tcpip.unix
-            tcpip.stack-socket mirage-clock-unix))
+            tcpip.stack-socket mirage-clock-unix mirage-time-unix))
 
 (alias
  (name runtest)

--- a/test/git-mirage/test.ml
+++ b/test/git-mirage/test.ml
@@ -18,7 +18,7 @@
 open Lwt.Infix
 
 module C = Conduit_mirage.With_tcp (Tcpip_stack_socket)
-module R = Resolver_mirage.Make_with_stack (Mirage_crypto_rng) (Mclock) (Tcpip_stack_socket)
+module R = Resolver_mirage.Make_with_stack (Mirage_crypto_rng) (Time) (Mclock) (Tcpip_stack_socket)
 
 let run f =
   Lwt_main.run


### PR DESCRIPTION
This PR wants to enlarge internal buffers to be able to decode large tree object as noticed here: mirage/irmin#1001. The PR deletes an old french comment about a possible bug because we used `set_len`/`add_len` (see mirage/ocaml-git#345).

It's a small fix (and highlight a larger problem) but something better will appear soon (so much teasing).