### PR TITLE
Delete useless constraint on Hash.kind type

### DIFF
--- a/src/git/hash.ml
+++ b/src/git/hash.ml
@@ -16,10 +16,7 @@
  *)
 
 module Make (Digestif : Digestif.S) :
-  S.HASH
-    with type t = Digestif.t
-     and type ctx = Digestif.ctx
-     and type kind = Digestif.kind = struct
+  S.HASH with type t = Digestif.t and type ctx = Digestif.ctx = struct
   include Digestif
 
   module Ordered = struct

--- a/src/git/hash.mli
+++ b/src/git/hash.mli
@@ -16,7 +16,4 @@
  *)
 
 module Make (Digestif : Digestif.S) :
-  S.HASH
-    with type t = Digestif.t
-     and type ctx = Digestif.ctx
-     and type kind = Digestif.kind
+  S.HASH with type t = Digestif.t and type ctx = Digestif.ctx


### PR DESCRIPTION
This type does not need to be constraint where nobody really use it. In other side, mirage/digestif#103 was merge and we will have an incompatibility.