### PR TITLE
Fix Sync.fetch behavior to save not only local refs

### DIFF
--- a/src/not-so-smart/fetch.ml
+++ b/src/not-so-smart/fetch.ml
@@ -75,9 +75,8 @@ struct
     let capabilities =
       (* XXX(dinosaure): HTTP ([stateless]) enforces no-done capabilities. Otherwise, you never
          will receive the PACK file. *)
-      if
-        fetch_cfg.Neg.no_done && not (List.exists (( = ) `No_done) capabilities)
-      then `No_done :: capabilities
+      if fetch_cfg.Neg.no_done && not (no_done capabilities) then
+        `No_done :: capabilities
       else capabilities
     in
     let prelude ctx =

--- a/src/not-so-smart/protocol.mli
+++ b/src/not-so-smart/protocol.mli
@@ -4,7 +4,9 @@ module Advertised_refs : sig
   val pp : (string, string) t Fmt.t
   val head : ('a, string) t -> 'a option
   val capabilities : ('uid, 'reference) t -> Capability.t list
-  val refs : ('uid, 'reference) t -> ('uid * 'reference * bool) list
+
+  val refs :
+    ('uid, 'reference) t -> ('uid * 'reference * (* peeled *) bool) list
 
   val reference :
     equal:('ref -> 'ref -> bool) ->

--- a/src/not-so-smart/smart.mli
+++ b/src/not-so-smart/smart.mli
@@ -12,7 +12,9 @@ module Advertised_refs : sig
   val pp : (string, string) t Fmt.t
   val head : ('a, string) t -> 'a option
   val capabilities : ('uid, 'reference) t -> Capability.t list
-  val refs : ('uid, 'reference) t -> ('uid * 'reference * bool) list
+
+  val refs :
+    ('uid, 'reference) t -> ('uid * 'reference * (* peeled *) bool) list
 
   val reference :
     equal:('ref -> 'ref -> bool) ->

--- a/test/smart/dune
+++ b/test/smart/dune
@@ -1,9 +1,10 @@
 (executable
  (name test)
- (libraries result curl.lwt mirage-crypto-rng.unix digestif digestif.c
-   domain-name nss.git bos fpath bigarray-compat carton-lwt bigstringaf
-   nss.sigs fmt nss.pck carton rresult conduit alcotest conduit-lwt nss.smart
-   lwt.unix mmap astring lwt cstruct uri fmt.tty logs.fmt alcotest-lwt))
+ (libraries git git-unix result curl.lwt mirage-crypto-rng.unix digestif
+   digestif.c domain-name nss.git bos fpath bigarray-compat carton-lwt
+   bigstringaf nss.sigs fmt nss.pck carton rresult conduit alcotest
+   conduit-lwt nss.smart lwt.unix mmap astring lwt cstruct uri fmt.tty
+   logs.fmt alcotest-lwt cohttp-lwt-unix git-cohttp-unix))
 
 (rule
  (alias runtest)

--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -299,7 +299,7 @@ let test_sync_fetch () =
 
 (* XXX(dinosaure): [tmp] without systemic deletion of directories. *)
 
-module SGit =
+module Git =
   Smart_git.Make (Scheduler) (Append) (Append) (Conduit_lwt) (HTTP) (Uid) (Ref)
 
 (* TODO(dinosaure): we don't check what we sent, we should check that. *)
@@ -322,7 +322,7 @@ let test_empty_clone () =
     Bos.OS.File.tmp "pack-%s.idx" |> Lwt.return >>? fun tmp2 ->
     Smart_git.endpoint_of_string "git://localhost/not-found.git" |> Lwt.return
     >>? fun endpoint ->
-    SGit.fetch ~resolvers ~capabilities access store endpoint
+    Git.fetch ~resolvers ~capabilities access store endpoint
       (`Some [ Ref.v "HEAD" ])
       pack index ~src:tmp0 ~dst:tmp1 ~idx:tmp2
   in
@@ -351,7 +351,7 @@ let test_simple_clone () =
     Bos.OS.File.tmp "pack-%s.idx" |> Lwt.return >>? fun tmp2 ->
     Smart_git.endpoint_of_string "git://localhost/not-found.git" |> Lwt.return
     >>? fun endpoint ->
-    SGit.fetch ~resolvers ~capabilities access store endpoint `All pack index
+    Git.fetch ~resolvers ~capabilities access store endpoint `All pack index
       ~src:tmp0 ~dst:tmp1 ~idx:tmp2
   in
   run () >>= function
@@ -449,7 +449,7 @@ let test_simple_push () =
     let resolvers = resolvers_with_payloads payloads in
     Smart_git.endpoint_of_string "git://localhost/not-found.git" |> Lwt.return
     >>? fun endpoint ->
-    SGit.push ~resolvers ~capabilities access store endpoint
+    Git.push ~resolvers ~capabilities access store endpoint
       [ `Update (Ref.v "refs/head/master", Ref.v "refs/head/master") ]
   in
   run () >>= function
@@ -485,7 +485,7 @@ let test_push_error () =
     let resolvers = resolvers_with_payloads payloads in
     Smart_git.endpoint_of_string "git://localhost/not-found.git" |> Lwt.return
     >>? fun endpoint ->
-    SGit.push ~resolvers ~capabilities access store endpoint
+    Git.push ~resolvers ~capabilities access store endpoint
       [ `Update (Ref.v "refs/head/master", Ref.v "refs/head/master") ]
   in
   run () >>= function
@@ -515,7 +515,7 @@ let test_fetch_empty () =
     Bos.OS.File.tmp "pack-%s.idx" |> Lwt.return >>? fun tmp2 ->
     Smart_git.endpoint_of_string "git://localhost/not-found.git" |> Lwt.return
     >>? fun endpoint ->
-    SGit.fetch ~resolvers ~capabilities access store endpoint `All pack index
+    Git.fetch ~resolvers ~capabilities access store endpoint `All pack index
       ~src:tmp0 ~dst:tmp1 ~idx:tmp2
     >>? function
     | `Empty -> Alcotest.fail "Unexpected empty fetch"
@@ -609,8 +609,8 @@ let test_fetch_empty () =
         Smart_git.endpoint_of_string "git://localhost/not-found.git"
         |> Lwt.return
         >>? fun endpoint ->
-        SGit.fetch ~resolvers ~capabilities access store endpoint `All pack
-          index ~src:tmp0 ~dst:tmp1 ~idx:tmp2
+        Git.fetch ~resolvers ~capabilities access store endpoint `All pack index
+          ~src:tmp0 ~dst:tmp1 ~idx:tmp2
   in
   run () >>= function
   | Ok `Empty -> Lwt.return_unit
@@ -1051,7 +1051,7 @@ let test_negotiation () =
     Bos.OS.File.tmp "pack-%s.idx" |> Lwt.return >>? fun tmp2 ->
     Smart_git.endpoint_of_string "git://localhost/not-found.git" |> Lwt.return
     >>? fun endpoint ->
-    SGit.fetch ~resolvers ~capabilities access store endpoint `All pack index
+    Git.fetch ~resolvers ~capabilities access store endpoint `All pack index
       ~src:tmp0 ~dst:tmp1 ~idx:tmp2
   in
   run () >>= function
@@ -1177,7 +1177,7 @@ let test_ssh () =
     >>? fun endpoint ->
     Logs.app (fun m -> m "Waiting git-upload-pack.");
     Logs.app (fun m -> m "Start to fetch repository with SSH.");
-    SGit.fetch ~resolvers ~capabilities access store1 endpoint
+    Git.fetch ~resolvers ~capabilities access store1 endpoint
       (`Some [ Ref.v "HEAD" ])
       pack index ~src:tmp0 ~dst:tmp1 ~idx:tmp2
   in
@@ -1261,7 +1261,7 @@ let test_negotiation_ssh () =
     >>? fun endpoint ->
     Logs.app (fun m -> m "Waiting git-upload-pack.");
     Logs.app (fun m -> m "Start to fetch repository with SSH.");
-    SGit.fetch ~resolvers ~capabilities access store1 endpoint
+    Git.fetch ~resolvers ~capabilities access store1 endpoint
       (`Some [ Ref.v "HEAD" ])
       pack index ~src:tmp0 ~dst:tmp1 ~idx:tmp2
   in
@@ -1346,7 +1346,7 @@ let test_push_ssh () =
     let resolvers = resolvers_with_fifo ic_fifo oc_fifo in
     Smart_git.endpoint_of_string "git@localhost:not-found.git" |> Lwt.return
     >>? fun endpoint ->
-    SGit.push ~resolvers ~capabilities access store1 endpoint
+    Git.push ~resolvers ~capabilities access store1 endpoint
       [ `Update (Ref.v "refs/heads/master", Ref.v "refs/heads/master") ]
     >>? fun () ->
     let { path; _ } = store_prj store0 in
@@ -1421,7 +1421,7 @@ let test_negotiation_http () =
     Queue.push (load_file "GET") queue;
     Queue.push (load_file "POST") queue;
     let resolvers = http_resolver queue in
-    SGit.fetch ~resolvers ~capabilities access store endpoint `All pack index
+    Git.fetch ~resolvers ~capabilities access store endpoint `All pack index
       ~src:tmp0 ~dst:tmp1 ~idx:tmp2
   in
   run () >>= function
@@ -1474,8 +1474,7 @@ let test_partial_clone_ssh () =
     >>? fun endpoint ->
     Logs.app (fun m -> m "Waiting git-upload-pack.");
     Logs.app (fun m -> m "Start to fetch repository with SSH.");
-    SGit.fetch ~resolvers ~capabilities access store1 endpoint
-      ~deepen:(`Depth 1)
+    Git.fetch ~resolvers ~capabilities access store1 endpoint ~deepen:(`Depth 1)
       (`Some [ Ref.v "HEAD" ])
       pack index ~src:tmp0 ~dst:tmp1 ~idx:tmp2
     >>? function
@@ -1549,8 +1548,7 @@ let test_partial_fetch_ssh () =
     in
     Logs.app (fun m -> m "Waiting git-upload-pack.");
     Logs.app (fun m -> m "Start to fetch repository with SSH.");
-    SGit.fetch ~resolvers ~capabilities access store1 endpoint
-      ~deepen:(`Depth 1)
+    Git.fetch ~resolvers ~capabilities access store1 endpoint ~deepen:(`Depth 1)
       (`Some [ Ref.v "HEAD" ])
       pack index ~src:tmp0 ~dst:tmp1 ~idx:tmp2
     >>? function
@@ -1599,7 +1597,7 @@ let test_partial_fetch_ssh () =
         Bos.OS.File.tmp "pack-%s.idx" |> Lwt.return >>? fun tmp2 ->
         Logs.app (fun m -> m "Waiting git-upload-pack.");
         Logs.app (fun m -> m "Start to fetch repository with SSH.");
-        SGit.fetch ~resolvers ~capabilities access store1 endpoint
+        Git.fetch ~resolvers ~capabilities access store1 endpoint
           ~deepen:(`Depth 1)
           (`Some [ Ref.v "HEAD" ])
           pack index ~src:tmp0 ~dst:tmp1 ~idx:tmp2

--- a/test/smart/uid.mli
+++ b/test/smart/uid.mli
@@ -1,4 +1,6 @@
-include module type of Digestif.SHA1
+type t = Digestif.SHA1.t
+
+include module type of Digestif.SHA1 with type t := t
 
 val length : int
 val compare : t -> t -> int


### PR DESCRIPTION
- moves repetitive fetching from `Git_unix.fetch` and `Mem.fetch` to `Sync.fetch`
- changes `Sync.fetch` behavior to save fetched ref `src` either as `dst` ref if provided by the user or as `src`

