### PR TITLE
add progress reporting capability to fetch

### DIFF
--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -718,14 +718,15 @@ module Sync (Git_store : Git.S) (HTTP : Smart_git.HTTP) = struct
     Lwt.async fill;
     fun () -> Lwt_stream.get stream
 
-  let fetch ~resolvers edn store ?version ?capabilities want =
+  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ~resolvers edn store
+      ?version ?capabilities want =
     let dotgit = Git_store.dotgit store in
     let temp = Fpath.(dotgit / "tmp") in
     tmp temp "pack-%s.pack" >>= fun src ->
     tmp temp "pack-%s.pack" >>= fun dst ->
     tmp temp "pack-%s.idx" >>= fun idx ->
-    fetch ~resolvers edn store ?version ?capabilities want ~src ~dst ~idx temp
-      temp
+    fetch ~push_stdout ~push_stderr ~resolvers edn store ?version ?capabilities
+      want ~src ~dst ~idx temp temp
     >>? function
     | `Empty -> Lwt.return_ok None
     | `Pack (hash, refs) ->

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -473,14 +473,15 @@ struct
     Lwt.async fill;
     fun () -> Lwt_stream.get stream
 
-  let fetch ~resolvers edn store ?version ?capabilities want =
+  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ~resolvers edn store
+      ?version ?capabilities want =
     let t_idx = Carton.Dec.Idx.Device.device () in
     let t_pck = Cstruct_append.device () in
     let index = Carton.Dec.Idx.Device.create t_idx in
     let src = Cstruct_append.key t_pck in
     let dst = Cstruct_append.key t_pck in
-    fetch ~resolvers edn store ?version ?capabilities want ~src ~dst ~idx:index
-      t_pck t_idx
+    fetch ~push_stdout ~push_stderr ~resolvers edn store ?version ?capabilities
+      want ~src ~dst ~idx:index t_pck t_idx
     >>? function
     | `Empty -> Lwt.return_ok None
     | `Pack (hash, refs) ->

--- a/src/git/sync.ml
+++ b/src/git/sync.ml
@@ -28,6 +28,8 @@ module type S = sig
   val pp_error : error Fmt.t
 
   val fetch :
+    ?push_stdout:(string -> unit) ->
+    ?push_stderr:(string -> unit) ->
     resolvers:Conduit.resolvers ->
     Smart_git.endpoint ->
     store ->
@@ -170,10 +172,10 @@ struct
   include Smart_git.Make (Scheduler) (Pack) (Index) (Conduit) (HTTP) (Hash)
             (Reference)
 
-  let fetch ~resolvers endpoint t ?version ?capabilities want ~src ~dst ~idx
-      t_pck t_idx =
+  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ~resolvers endpoint
+      t ?version ?capabilities want ~src ~dst ~idx t_pck t_idx =
     let ministore = Ministore.inj (t, Hashtbl.create 0x100) in
-    fetch ~resolvers
+    fetch ~push_stdout ~push_stderr ~resolvers
       (access, lightly_load t, heavily_load t)
       ministore endpoint ?version ?capabilities want t_pck t_idx ~src ~dst ~idx
 

--- a/src/git/sync.mli
+++ b/src/git/sync.mli
@@ -25,6 +25,8 @@ module type S = sig
   val pp_error : error Fmt.t
 
   val fetch :
+    ?push_stdout:(string -> unit) ->
+    ?push_stderr:(string -> unit) ->
     resolvers:Conduit.resolvers ->
     Smart_git.endpoint ->
     store ->
@@ -65,6 +67,8 @@ module Make
   val pp_error : error Fmt.t
 
   val fetch :
+    ?push_stdout:(string -> unit) ->
+    ?push_stderr:(string -> unit) ->
     resolvers:Conduit.resolvers ->
     Smart_git.endpoint ->
     store ->

--- a/src/not-so-smart/fetch.ml
+++ b/src/not-so-smart/fetch.ml
@@ -69,8 +69,9 @@ struct
         in
         List.fold_left fold [] have |> List.split
 
-  let fetch_v1 ?(prelude = true) ~capabilities ?want:(refs = `None) ~host path
-      flow store access fetch_cfg pack =
+  let fetch_v1 ?(prelude = true) ?(push_stdout = ignore) ?(push_stderr = ignore)
+      ~capabilities ?want:(refs = `None) ~host path flow store access fetch_cfg
+      pack =
     let capabilities =
       (* XXX(dinosaure): HTTP ([stateless]) enforces no-done capabilities. Otherwise, you never
          will receive the PACK file. *)
@@ -115,8 +116,7 @@ struct
             Smart.shared `Side_band ctx || Smart.shared `Side_band_64k ctx
           in
           recv ctx
-            (recv_pack ~side_band ~push_stdout:ignore ~push_stderr:ignore
-               ~push_pack:pack)
+            (recv_pack ~side_band ~push_stdout ~push_stderr ~push_pack:pack)
         in
         if res < 0 then Log.warn (fun m -> m "No common commits");
         let rec go () =

--- a/src/not-so-smart/fetch.mli
+++ b/src/not-so-smart/fetch.mli
@@ -12,6 +12,8 @@ module Make
     (Ref : REF) : sig
   val fetch_v1 :
     ?prelude:bool ->
+    ?push_stdout:(string -> unit) ->
+    ?push_stderr:(string -> unit) ->
     capabilities:Smart.Capability.t list ->
     ?want:[ `All | `Some of Ref.t list | `None ] ->
     host:[ `host ] Domain_name.t ->

--- a/src/not-so-smart/smart_git.mli
+++ b/src/not-so-smart/smart_git.mli
@@ -73,6 +73,8 @@ module Make
     (Uid : UID)
     (Ref : Sigs.REF) : sig
   val fetch :
+    ?push_stdout:(string -> unit) ->
+    ?push_stderr:(string -> unit) ->
     resolvers:Conduit.resolvers ->
     (Uid.t, _, Uid.t * int ref * int64, 'g, Scheduler.t) Sigs.access
     * Uid.t Carton_lwt.Thin.light_load


### PR DESCRIPTION
Adds progress reporting capability (as arguments) to fetch through all fetch "levels":

`Nss.Fetch.fetch_v1 <- Smart_git.fetch <- Sync.fetch <- Git_unix/Mem.fetch`