### PR TITLE
Preview of ocamlformat.0.16.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.15.0
+version=0.16.0
 module-item-spacing=compact
 break-struct=natural
 break-infix=fit-or-vertical

--- a/src/carton-git/carton_git.ml
+++ b/src/carton-git/carton_git.ml
@@ -95,7 +95,7 @@ struct
       | x :: r -> (
           f a x >>= function
           | Ok a -> go a r
-          | Error x -> err x >>= fun () -> go a r )
+          | Error x -> err x >>= fun () -> go a r)
     in
     go a l
 

--- a/src/carton-git/carton_git_unix.ml
+++ b/src/carton-git/carton_git_unix.ml
@@ -64,7 +64,7 @@ module Store = struct
           | entry -> (
               match Fpath.of_string entry with
               | Ok x -> if Fpath.has_ext "pack" x then go (x :: acc) else go acc
-              | Error (`Msg _) -> (* ignore *) go acc ))
+              | Error (`Msg _) -> (* ignore *) go acc))
         (function End_of_file -> Lwt.return acc | exn -> Lwt.fail exn)
     in
     go []

--- a/src/carton/dec.ml
+++ b/src/carton/dec.ml
@@ -121,7 +121,7 @@ module Fp (Uid : UID) = struct
           Bigstringaf.blit d.i ~src_off:d.i_pos d.i ~dst_off:0 ~len:rem;
           (* compress *)
           let res = input_bigstring ic d.i rem (Bigstringaf.length d.i - rem) in
-          peek k (src d d.i 0 (rem + res)) )
+          peek k (src d d.i 0 (rem + res)))
         else k d
     | `Manual ->
         let rem = i_rem d in
@@ -129,7 +129,7 @@ module Fp (Uid : UID) = struct
         if rem < d.t_peek then (
           Bigstringaf.blit d.i ~src_off:d.i_pos d.i ~dst_off:0 ~len:rem;
           (* compress *)
-          `Peek { d with k = peek k; i_pos = 0; i_len = rem - 1 } )
+          `Peek { d with k = peek k; i_pos = 0; i_len = rem - 1 })
         else k d
 
   let t_need d n = { d with t_need = n }
@@ -467,7 +467,7 @@ module Fp (Uid : UID) = struct
                 let _, dst_len = variable_length d.o x len in
                 source := src_len;
                 target := dst_len;
-                first := false );
+                first := false);
 
               go (Zl.Inf.flush z)
           | `Malformed err -> `Malformed (Fmt.strf "inflate: %s" err)
@@ -478,7 +478,7 @@ module Fp (Uid : UID) = struct
                 let _, dst_len = variable_length d.o x len in
                 source := src_len;
                 target := dst_len;
-                first := false );
+                first := false);
 
               let len = i_rem d - Zl.Inf.src_rem z in
               let crc = Checkseum.Crc32.digest_bigstring d.i d.i_pos len crc in
@@ -615,7 +615,7 @@ module W = struct
                  available according the given offset. *)
             then (
               slice := Some s;
-              raise_notrace Found )
+              raise_notrace Found)
         | None -> ()
       done;
       heavy_load s ~map t w
@@ -686,7 +686,7 @@ let weight_of_delta :
             let decoder = Zh.M.src decoder slice.W.payload off len in
             (go [@tailcall])
               Int64.(add slice.W.offset (of_int slice.W.length))
-              decoder )
+              decoder)
   in
   let off = Int64.(to_int (sub cursor slice.W.offset)) in
   let len = slice.W.length - off in
@@ -716,7 +716,7 @@ let header_of_ref_delta ({ bind; return } as s) ~map t cursor slice =
                      (sub
                         (add !slice.W.offset (of_int !slice.W.length))
                         next_slice.W.offset)));
-              slice := next_slice )
+              slice := next_slice)
           in
           return consume
   in
@@ -730,7 +730,7 @@ let header_of_ref_delta ({ bind; return } as s) ~map t cursor slice =
       for _ = 0 to t.uid_ln - 1 do
         consume ()
       done;
-      uid )
+      uid)
     else
       let uid = Bytes.create t.uid_ln in
       for i = 0 to t.uid_ln - 1 do
@@ -765,7 +765,7 @@ let header_of_ofs_delta ({ bind; return } as s) ~map t cursor slice =
                      (sub
                         (add !slice.W.offset (of_int !slice.W.length))
                         next_slice.W.offset)));
-              slice := next_slice )
+              slice := next_slice)
           in
           return consume
   in
@@ -806,7 +806,7 @@ let header_of_entry ({ bind; return } as s) ~map t cursor slice0 =
                      (sub
                         (add !slice.W.offset (of_int !slice.W.length))
                         next_slice.W.offset)));
-              slice := next_slice )
+              slice := next_slice)
           in
           return consume
   in
@@ -920,7 +920,7 @@ and weight_of_offset :
             ~visited
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
-      | _ -> assert false )
+      | _ -> assert false)
 
 type raw = { raw0 : Bigstringaf.t; raw1 : Bigstringaf.t; flip : bool }
 type v = { kind : kind; raw : raw; len : int; depth : int }
@@ -997,7 +997,7 @@ let uncompress :
               decoder
         | None ->
             let decoder = Zl.Inf.src decoder Bigstringaf.empty 0 0 in
-            (go [@tailcall]) l p cursor decoder )
+            (go [@tailcall]) l p cursor decoder)
   in
   let off = Int64.(to_int (sub cursor slice.W.offset)) in
   let len = slice.W.length - off in
@@ -1044,7 +1044,7 @@ let of_delta :
             let decoder = Zh.M.src decoder slice.W.payload off len in
             (go [@tailcall])
               Int64.(add slice.W.offset (of_int slice.W.length))
-              raw decoder )
+              raw decoder)
   in
   let off = Int64.(to_int (sub cursor slice.W.offset)) in
   let len = slice.W.length - off in
@@ -1137,7 +1137,7 @@ and of_offset :
           of_ref_delta s ~map t raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
-      | _ -> assert false )
+      | _ -> assert false)
 
 type path = { path : int64 array; depth : int; kind : [ `A | `B | `C | `D ] }
 
@@ -1227,7 +1227,7 @@ and fill_path_from_offset :
           (fill_path_from_ref_delta [@tailcall]) s ~map t ~depth path
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
-      | _ -> assert false )
+      | _ -> assert false)
 
 let path_of_offset :
     type fd uid s.
@@ -1300,7 +1300,7 @@ let of_offset_with_source :
           of_delta s ~map t kind raw ~depth
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
-      | _ -> assert false )
+      | _ -> assert false)
 
 let base_of_offset :
     type fd uid s.
@@ -1452,7 +1452,7 @@ let uid_of_offset_with_source :
             slice
           >>= fun ({ raw; _ } as v) ->
           return (digest ~kind ~len:v.len (get_payload raw))
-      | _ -> assert false )
+      | _ -> assert false)
 
 type 'uid node = Node of int64 * 'uid * 'uid node list | Leaf of int64 * 'uid
 
@@ -1557,7 +1557,7 @@ struct
         | cursors ->
             nodes_of_offsets ~map ~oracle t ~kind (flip raw) ~depth:(succ depth)
               ~cursors
-            >>= fun nodes -> IO.return [ Node (cursor, uid, nodes) ] )
+            >>= fun nodes -> IO.return [ Node (cursor, uid, nodes) ])
     | cursors ->
         let source = get_source raw in
         let source =
@@ -1627,7 +1627,7 @@ struct
             let raw' = make_raw ~weight:weight' in
             Bigstringaf.blit (get_payload raw) ~src_off:0 (get_payload raw')
               ~dst_off:0 ~len:weight;
-            raw' )
+            raw')
           else raw
         in
         nodes_of_offsets ~map ~oracle t ~kind (flip raw) ~depth:1 ~cursors
@@ -1687,7 +1687,7 @@ struct
       done;
       if mutex.v >= Array.length matrix then (
         IO.Mutex.unlock mutex.m;
-        IO.return () )
+        IO.return ())
       else
         let root = mutex.v in
         mutex.v <- mutex.v + 1;
@@ -1777,7 +1777,7 @@ struct
         finish := true;
         IO.Condition.broadcast signal;
         IO.Mutex.unlock mutex;
-        return () )
+        return ())
       else (
         incr p;
         let uid = Idx.get_uid idx v
@@ -1788,7 +1788,7 @@ struct
 
         IO.Condition.signal signal;
         IO.Mutex.unlock mutex;
-        go () )
+        go ())
     in
     go ()
 

--- a/src/carton/enc.ml
+++ b/src/carton/enc.ml
@@ -47,7 +47,8 @@ module Utils = struct
     length_of_variable_length source
     + length_of_variable_length target
     + List.fold_left
-        (fun acc -> function Duff.Insert (_, len) -> 1 + len + acc
+        (fun acc -> function
+          | Duff.Insert (_, len) -> 1 + len + acc
           | Duff.Copy (off, len) -> 1 + length_of_copy_code ~off ~len + acc)
         0 hunks
 end
@@ -143,7 +144,7 @@ let entry_to_target :
   let ( >>= ) = bind in
 
   load entry.uid >>= fun v ->
-  ( match entry.delta with
+  (match entry.delta with
   | From uid ->
       load uid >>= fun s ->
       let source = Bigstringaf.sub ~off:0 ~len:(Dec.len s) (Dec.raw s) in
@@ -160,7 +161,7 @@ let entry_to_target :
              source = uid;
              source_length = Dec.len s;
            })
-  | Zero -> return None )
+  | Zero -> return None)
   >>= fun patch -> return { patch; entry; v = W.create_with v }
 
 let length_of_delta ~source ~target hunks = Utils.length ~source ~target hunks
@@ -322,7 +323,7 @@ struct
           match window.(j) with
           | Some m -> (
               try try_delta j m >>= fun () -> (go [@tailcall]) (pred j)
-              with Break -> return () )
+              with Break -> return ())
           | None -> return ()
         (* TODO: check it! *)
       in
@@ -358,11 +359,11 @@ struct
             v := (!v + 1) mod weight
           done;
 
-          window.(!v) <- swap );
+          window.(!v) <- swap);
 
         if depth_of_target targets.(n) < _max_depth then
           (iter [@tailcall]) (succ n) (if idx + 1 >= weight then 0 else idx + 1)
-        else (iter [@tailcall]) (succ n) idx )
+        else (iter [@tailcall]) (succ n) idx)
       else return ()
     in
     iter 0 0
@@ -382,12 +383,12 @@ struct
       mutex.v <- mutex.v + 1;
       if v >= Array.length entries then (
         IO.Mutex.unlock mutex.m;
-        IO.return () )
+        IO.return ())
       else (
         IO.Mutex.unlock mutex.m;
         entry_to_target s ~load entries.(v) |> Scheduler.prj >>= fun target ->
         targets.(v) <- Some target;
-        go () )
+        go ())
     in
     go ()
 
@@ -441,11 +442,11 @@ end = struct
     | Z encoder -> (
         match encode_zlib ~o encoder with
         | `Flush (encoder, len) -> `Flush (Z encoder, len)
-        | `End -> `End )
+        | `End -> `End)
     | H encoder -> (
         match encode_hunk ~o encoder with
         | `Flush (encoder, len) -> `Flush (H encoder, len)
-        | `End -> `End )
+        | `End -> `End)
 
   let dst encoder s j l =
     match encoder with
@@ -586,4 +587,4 @@ let encode_target :
           >>= fun encoder ->
           let off = off + uid.uid_ln in
           let len = Bigstringaf.length b.o - off in
-          return (off, N.dst encoder b.o off len) )
+          return (off, N.dst encoder b.o off len))

--- a/src/carton/h.ml
+++ b/src/carton/h.ml
@@ -191,7 +191,7 @@ module M = struct
     else (
       d.i <- s;
       d.i_pos <- j;
-      d.i_len <- j + l - 1 )
+      d.i_len <- j + l - 1)
 
   let dst d s j l =
     match d.s with
@@ -201,7 +201,7 @@ module M = struct
         else (
           d.dst <- s;
           d.o_pos <- j;
-          if bigstring_length d.source >= d.src_len then d.s <- Cmd )
+          if bigstring_length d.source >= d.src_len then d.s <- Cmd)
     | _ -> Fmt.invalid_arg "Invalid call of dst"
 
   let pp_state ppf = function
@@ -245,10 +245,10 @@ module M = struct
       let need = d.t_need - d.t_len in
       if rem < need then (
         blit d rem;
-        refill (t_fill k) d )
+        refill (t_fill k) d)
       else (
         blit d need;
-        k d )
+        k d)
 
   let required =
     let a = [| 0; 1; 1; 2; 1; 2; 2; 3; 1; 2; 2; 3; 2; 3; 3; 4 |] in
@@ -281,31 +281,31 @@ module M = struct
     if command land 0x01 != 0 then (
       let v = unsafe_get_uint8 i !p in
       cp_off := v;
-      incr p );
+      incr p);
     if command land 0x02 != 0 then (
       let v = unsafe_get_uint8 i !p in
       cp_off := !cp_off lor (v lsl 8);
-      incr p );
+      incr p);
     if command land 0x04 != 0 then (
       let v = unsafe_get_uint8 i !p in
       cp_off := !cp_off lor (v lsl 16);
-      incr p );
+      incr p);
     if command land 0x08 != 0 then (
       let v = unsafe_get_uint8 i !p in
       cp_off := !cp_off lor (v lsl 24);
-      incr p );
+      incr p);
     if command land 0x10 != 0 then (
       let v = unsafe_get_uint8 i !p in
       cp_len := v;
-      incr p );
+      incr p);
     if command land 0x20 != 0 then (
       let v = unsafe_get_uint8 i !p in
       cp_len := !cp_len lor (v lsl 8);
-      incr p );
+      incr p);
     if command land 0x40 != 0 then (
       let v = unsafe_get_uint8 i !p in
       cp_len := !cp_len lor (v lsl 16);
-      incr p );
+      incr p);
     if !cp_len == 0 then cp_len := 0x10000;
 
     unsafe_blit d.source !cp_off d.dst d.o_pos !cp_len;
@@ -324,14 +324,14 @@ module M = struct
       d.o_pos <- d.o_pos + len;
       d.s <- Cmd;
       d.k <- decode_k;
-      decode_k d )
+      decode_k d)
     else (
       unsafe_blit d.i d.i_pos d.dst d.o_pos len;
       d.i_pos <- d.i_pos + len;
       d.o_pos <- d.o_pos + len;
       d.s <- Cmd;
       d.k <- decode_k;
-      decode_k d )
+      decode_k d)
 
   and cmd d =
     let c = unsafe_get_uint8 d.i d.i_pos in
@@ -344,7 +344,7 @@ module M = struct
       if enough d then if c land 0x80 != 0 then cp d else it d
       else (
         t_need d (need d);
-        t_fill (if c land 0x80 != 0 then cp else it) d ) )
+        t_fill (if c land 0x80 != 0 then cp else it) d))
 
   and decode_k d =
     let rem = i_rem d in
@@ -373,12 +373,12 @@ module M = struct
           if required (cmd land 0x7f) <= rem then cp d
           else (
             t_need d (need d);
-            t_fill cp d )
+            t_fill cp d)
       | It len ->
           if len <= rem then it d
           else (
             t_need d (need d);
-            t_fill it d )
+            t_fill it d)
 
   let decode d =
     match d.k d with
@@ -494,10 +494,10 @@ module N = struct
 
     if rem < len then (
       blit e rem;
-      flush (t_flush k) e )
+      flush (t_flush k) e)
     else (
       blit e len;
-      k e )
+      k e)
 
   let rec encode_contents e v =
     let k e =
@@ -514,7 +514,7 @@ module N = struct
         let s, j, k =
           if rem < required then (
             t_range e (required - 1);
-            e.t, 0, t_flush k )
+            e.t, 0, t_flush k)
           else
             let j = e.o_pos in
             e.o_pos <- e.o_pos + required;
@@ -527,14 +527,14 @@ module N = struct
         while !off <> 0 do
           if !off land 0xff != 0 then (
             unsafe_set_uint8 s !pos !off;
-            incr pos );
+            incr pos);
           off := !off asr 8
         done;
         let len = ref len in
         while !len <> 0 do
           if !len land 0xff != 0 then (
             unsafe_set_uint8 s !pos !len;
-            incr pos );
+            incr pos);
           len := !len asr 8
         done;
         k e
@@ -545,7 +545,7 @@ module N = struct
         let s, j, k =
           if rem < required then (
             t_range e (required - 1);
-            e.t, 0, t_flush k )
+            e.t, 0, t_flush k)
           else
             let j = e.o_pos in
             e.o_pos <- e.o_pos + required;
@@ -591,12 +591,12 @@ module N = struct
       store_variable_length e.o e.o_pos e.src_len;
       store_variable_length e.o (e.o_pos + needed e.src_len) e.dst_len;
       e.o_pos <- e.o_pos + ndd;
-      k e )
+      k e)
     else (
       t_range e ndd;
       store_variable_length e.t 0 e.src_len;
       store_variable_length e.t (needed e.src_len) e.dst_len;
-      t_flush k e )
+      t_flush k e)
 
   let encode e v = e.k e v
 

--- a/src/carton/idx.ml
+++ b/src/carton/idx.ml
@@ -317,10 +317,10 @@ end = struct
     let flush = if with_ctx then flush_with_ctx else flush_without_ctx in
     if rem < len then (
       blit e rem;
-      flush (t_flush k) e )
+      flush (t_flush k) e)
     else (
       blit e len;
-      k e )
+      k e)
 
   let ok e =
     e.k <- (fun _ `Await -> `Ok);
@@ -333,7 +333,7 @@ end = struct
       let s, j, k =
         if rem < Uid.length then (
           t_range e (Uid.length - 1);
-          e.t, 0, t_flush ~with_ctx:false k2 )
+          e.t, 0, t_flush ~with_ctx:false k2)
         else
           let j = e.o_pos in
           e.o_pos <- e.o_pos + Uid.length;
@@ -349,7 +349,7 @@ end = struct
     let s, j, k =
       if rem < Uid.length then (
         t_range e (Uid.length - 1);
-        e.t, 0, t_flush k0 )
+        e.t, 0, t_flush k0)
       else
         let j = e.o_pos in
         e.o_pos <- e.o_pos + Uid.length;
@@ -363,17 +363,17 @@ end = struct
     let k e =
       if e.n + 1 == Array.length e.index then (
         e.n <- 0;
-        encode_trail e `Await )
+        encode_trail e `Await)
       else (
         e.n <- succ e.n;
-        encode_offset e `Await )
+        encode_offset e `Await)
     in
     let rem = o_rem e in
 
     let s, j, k =
       if rem < 4 then (
         t_range e 3;
-        e.t, 0, t_flush k )
+        e.t, 0, t_flush k)
       else
         let j = e.o_pos in
         e.o_pos <- e.o_pos + 4;
@@ -387,17 +387,17 @@ end = struct
     let k e =
       if e.n + 1 == Array.length e.index then (
         e.n <- 0;
-        encode_offset e `Await )
+        encode_offset e `Await)
       else (
         e.n <- succ e.n;
-        encode_crc e `Await )
+        encode_crc e `Await)
     in
     let rem = o_rem e in
 
     let s, j, k =
       if rem < 4 then (
         t_range e 3;
-        e.t, 0, t_flush k )
+        e.t, 0, t_flush k)
       else
         let j = e.o_pos in
         e.o_pos <- e.o_pos + 4;
@@ -411,17 +411,17 @@ end = struct
     let k e =
       if e.n + 1 == Array.length e.index then (
         e.n <- 0;
-        encode_crc e `Await )
+        encode_crc e `Await)
       else (
         e.n <- succ e.n;
-        encode_hash e `Await )
+        encode_hash e `Await)
     in
     let rem = o_rem e in
 
     let s, j, k =
       if rem < Uid.length then (
         t_range e (Uid.length - 1);
-        e.t, 0, t_flush k )
+        e.t, 0, t_flush k)
       else
         let j = e.o_pos in
         e.o_pos <- e.o_pos + Uid.length;
@@ -438,17 +438,17 @@ end = struct
       if e.n + 1 == 256 then (
         e.n <- 0;
         if Array.length e.index > 0 then encode_hash e `Await
-        else encode_trail e `Await )
+        else encode_trail e `Await)
       else (
         e.n <- succ e.n;
-        encode_fanout e `Await )
+        encode_fanout e `Await)
     in
     let rem = o_rem e in
 
     let s, j, k =
       if rem < 4 then (
         t_range e 3;
-        e.t, 0, t_flush k )
+        e.t, 0, t_flush k)
       else
         let j = e.o_pos in
         e.o_pos <- e.o_pos + 4;
@@ -473,7 +473,7 @@ end = struct
     let s, j, k =
       if rem < 8 then (
         t_range e 8;
-        e.t, 0, t_flush k )
+        e.t, 0, t_flush k)
       else
         let j = e.o_pos in
         e.o_pos <- e.o_pos + 8;
@@ -609,8 +609,8 @@ struct
 
   let close tbl fd =
     let result = Bigstringaf.sub fd.buffer ~off:0 ~len:fd.length in
-    ( match Ephemeron.K1.get_data tbl with
+    (match Ephemeron.K1.get_data tbl with
     | Some value -> value := result
-    | None -> assert false );
+    | None -> assert false);
     IO.return (Ok ())
 end

--- a/src/carton/thin.ml
+++ b/src/carton/thin.ml
@@ -42,7 +42,7 @@ struct
               Ke.Rke.N.push ke ~blit:blit_from_string ~length:String.length ~off
                 ~len src;
               go filled inputs
-          | None -> return filled )
+          | None -> return filled)
       | src :: _ ->
           let src = Cstruct.of_bigarray src in
           let len = min (Cstruct.len inputs) (Cstruct.len src) in
@@ -68,7 +68,7 @@ struct
       let rec go rest raw =
         if rest <= 0 then (
           Cstruct.blit_to_bytes fl_buffer 0 buf off len;
-          return (abs rest + len) )
+          return (abs rest + len))
         else
           read_cstruct 0 raw >>= function
           | 0 ->
@@ -130,17 +130,17 @@ struct
           Hashtbl.add where offset n;
           Hashtbl.add checks offset crc;
 
-          ( try
-              let vs =
-                Hashtbl.find children (`Ofs Int64.(sub offset (of_int s)))
-              in
-              Hashtbl.replace children
-                (`Ofs Int64.(sub offset (of_int s)))
-                (offset :: vs)
-            with Not_found ->
-              Hashtbl.add children
-                (`Ofs Int64.(sub offset (of_int s)))
-                [ offset ] );
+          (try
+             let vs =
+               Hashtbl.find children (`Ofs Int64.(sub offset (of_int s)))
+             in
+             Hashtbl.replace children
+               (`Ofs Int64.(sub offset (of_int s)))
+               (offset :: vs)
+           with Not_found ->
+             Hashtbl.add children
+               (`Ofs Int64.(sub offset (of_int s)))
+               [ offset ]);
           go decoder
       | `Entry
           ({ Fp.kind = Ref { ptr; target; source }; offset; crc; _ }, decoder)
@@ -153,10 +153,10 @@ struct
           Hashtbl.add where offset n;
           Hashtbl.add checks offset crc;
 
-          ( try
-              let vs = Hashtbl.find children (`Ref ptr) in
-              Hashtbl.replace children (`Ref ptr) (offset :: vs)
-            with Not_found -> Hashtbl.add children (`Ref ptr) [ offset ] );
+          (try
+             let vs = Hashtbl.find children (`Ref ptr) in
+             Hashtbl.replace children (`Ref ptr) (offset :: vs)
+           with Not_found -> Hashtbl.add children (`Ref ptr) [ offset ]);
           go decoder
       | `End uid -> return (Ok uid)
       | `Malformed err ->

--- a/src/carton/zh.ml
+++ b/src/carton/zh.ml
@@ -72,7 +72,7 @@ end = struct
             encode_z { e with z }
         | d ->
             H.N.dst e.h e.t 0 (De.bigstring_length e.t);
-            encode_h e d )
+            encode_h e d)
 
   and encode_h e d =
     let v, d = match d with v :: d -> v, d | [] -> `End, [] in

--- a/src/git-index/git_index.ml
+++ b/src/git-index/git_index.ml
@@ -182,11 +182,11 @@ module Entry = struct
       let mtime_sec = Float.to_int mtime_sec in
       let mtime_nsec = Float.to_int (mtime_nsec *. 1_000_000_000.) in
       let open Rresult in
-      ( match stat.Unix.st_kind with
+      (match stat.Unix.st_kind with
       | Unix.S_DIR -> Fmt.invalid_arg "Git sub-module are not implemented"
       | Unix.S_REG -> oid_of_blob ~hash path
       | Unix.S_LNK -> oid_of_link ~hash path
-      | _kind -> Fmt.invalid_arg "Invalid kind" )
+      | _kind -> Fmt.invalid_arg "Invalid kind")
       >>| fun oid ->
       {
         ce_stat =
@@ -392,7 +392,7 @@ module Entry = struct
         Bigstringaf.set_int16_be ce_payload
           (40 + Hash.digest_size + 2)
           (flags asr 16);
-        ce_payload )
+        ce_payload)
       else Bigstringaf.sub ce_payload ~off:0 ~len:(40 + Hash.digest_size + 2)
     in
 
@@ -543,7 +543,7 @@ let rem : Fpath.t -> 'oid t -> unit =
           (fun i -> if i < pos then t.entries.(i) else t.entries.(i + 1))
       in
       t.entries <- res;
-      go pos )
+      go pos)
   in
   go pos
 
@@ -770,8 +770,7 @@ let store :
 
       if t.entries.(i).ce_flags land Entry._ce_extended_flags <> 0 then (
         v := true;
-        t.entries.(i).ce_flags <- t.entries.(i).ce_flags lor Entry._ce_extended
-        )
+        t.entries.(i).ce_flags <- t.entries.(i).ce_flags lor Entry._ce_extended)
     done;
     !v
   in

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -50,7 +50,7 @@ module Fold = struct
       | Some f when dotfiles || not (f.[0] = '.') -> (
           match Fpath.of_string f with
           | Ok f -> readdir dh ((if rel then f else Fpath.(dir // f)) :: acc)
-          | Error (`Msg _) -> (* ignore *) readdir dh acc )
+          | Error (`Msg _) -> (* ignore *) readdir dh acc)
       | Some _ -> readdir dh acc
     in
     Lwt.catch
@@ -302,7 +302,7 @@ module Minor_heap (Digestif : Digestif.S) = struct
       | tl :: hd :: _ -> (
           match Digestif.of_hex (hd ^ tl) with
           | _ -> Fold.file_exists path
-          | exception _ -> Lwt.return false )
+          | exception _ -> Lwt.return false)
       | _ -> Lwt.return false
     in
     Fold.fold ~dotfiles:false ~elements:(`Sat elements) f [] root
@@ -491,7 +491,7 @@ module Unix = struct
               | [] -> Lwt.return_ok ()
             in
             dirs_to_create dir [] >>? fun dirs ->
-            create_them dirs () >>? fun () -> Lwt.return_ok true )
+            create_them dirs () >>? fun () -> Lwt.return_ok true)
 end
 
 module Reference_heap = struct
@@ -530,8 +530,8 @@ module Reference_heap = struct
     let open Rresult in
     Bos.OS.Dir.create ~path:true base >>= fun _ ->
     Bos.OS.Dir.exists path >>= fun res ->
-    ( if res then Bos.OS.Dir.delete ~must_exist:false ~recurse:true path
-    else R.ok () )
+    (if res then Bos.OS.Dir.delete ~must_exist:false ~recurse:true path
+    else R.ok ())
     >>= fun () ->
     Bos.OS.File.tmp "git-reference-%s" >>= fun src ->
     Bos.OS.File.write src str >>= fun () ->
@@ -570,7 +570,7 @@ module Reference_heap = struct
           Log.debug (fun l -> l "%a exists into the store." Fpath.pp x);
           match Git.Reference.of_string (Fpath.to_string x) with
           | Ok x -> x :: r
-          | Error _ -> r )
+          | Error _ -> r)
       | None -> assert false
       (* XXX(dinosaure): see [elements]. *)
     in
@@ -655,9 +655,10 @@ module Sync (Git_store : Git.S) (HTTP : Smart_git.HTTP) = struct
 
   module Log = (val Logs.src_log src : Logs.LOG)
 
-  include Git.Sync.Make (Git_store.Hash) (Major_heap) (Major_heap) (Conduit_lwt)
-            (Git_store)
-            (HTTP)
+  include
+    Git.Sync.Make (Git_store.Hash) (Major_heap) (Major_heap) (Conduit_lwt)
+      (Git_store)
+      (HTTP)
 
   let random_gen = lazy (Random.State.make_self_init ())
 

--- a/src/git-unix/ogit-fetch/main.ml
+++ b/src/git-unix/ogit-fetch/main.ml
@@ -189,13 +189,13 @@ let command =
   let exits = Term.default_exits in
   ( Term.(
       ret
-        ( const main
+        (const main
         $ Flag.progress
         $ Flag.ssh_seed
         $ Flag.references
         $ Flag.directory
         $ Flag.repository
-        $ setup_log )),
+        $ setup_log)),
     Term.info "ogit-fetch" ~version:"v0.1" ~doc ~exits )
 
 let () = Term.(exit @@ eval command)

--- a/src/git/cstruct_append.ml
+++ b/src/git/cstruct_append.ml
@@ -45,12 +45,12 @@ let key tbl =
     Ephemeron.K1.set_key tbl.o0 value;
     Ephemeron.K1.set_data tbl.o0 (ref empty);
     tbl.which <- not tbl.which;
-    value )
+    value)
   else (
     Ephemeron.K1.set_key tbl.o1 value;
     Ephemeron.K1.set_data tbl.o1 (ref empty);
     tbl.which <- not tbl.which;
-    value )
+    value)
   [@@inline never]
 
 type uid = key ref
@@ -117,7 +117,7 @@ let create ~mode:_ { o0; o1; _ } key =
     if Cstruct.len !value < 1 then (
       let v = Cstruct.create 1 in
       value := v;
-      v )
+      v)
     else !value
   in
 
@@ -155,14 +155,14 @@ let close tbl fd =
   Log.debug (fun m ->
       m "Close the object into the cstruct-append heap (save %d bytes)."
         fd.length);
-  ( if fd.which then
-    match Ephemeron.K1.get_data tbl.o0 with
-    | Some value -> value := result
-    | None -> assert false
+  (if fd.which then
+   match Ephemeron.K1.get_data tbl.o0 with
+   | Some value -> value := result
+   | None -> assert false
   else
     match Ephemeron.K1.get_data tbl.o1 with
     | Some value -> value := result
-    | None -> assert false );
+    | None -> assert false);
   Lwt.return_ok ()
 
 let move tbl ~src ~dst =
@@ -177,7 +177,7 @@ let move tbl ~src ~dst =
         else if src == k1 && dst == k0 then v0 := !v1
         else (
           Log.err (fun m -> m "Given keys are wrong!");
-          assert false );
+          assert false);
         Lwt.return_ok ()
     | _ ->
         Log.err (fun m -> m "One object was deleted by the garbage collector.");

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -127,7 +127,7 @@ module Make (Digestif : Digestif.S) = struct
     include (
       Reference :
         module type of Reference
-          with type 'uid contents := 'uid Reference.contents )
+          with type 'uid contents := 'uid Reference.contents)
 
     type contents = hash Reference.contents
   end
@@ -179,18 +179,18 @@ module Make (Digestif : Digestif.S) = struct
     if Hashtbl.mem t.values hash then Lwt.return (Ok (hash, 0))
     else (
       Hashtbl.add t.values hash (lazy value);
-      Lwt.return_ok (hash, Int64.to_int (Value.length value)) )
+      Lwt.return_ok (hash, Int64.to_int (Value.length value)))
 
   let digest kind raw =
     let len = Cstruct.len raw in
     let ctx = Hash.init () in
     let hdr =
       Fmt.strf "%s %d\000%!"
-        ( match kind with
+        (match kind with
         | `Commit -> "commit"
         | `Blob -> "blob"
         | `Tree -> "tree"
-        | `Tag -> "tag" )
+        | `Tag -> "tag")
         len
     in
     let ctx = Hash.feed_string ctx hdr in
@@ -204,11 +204,11 @@ module Make (Digestif : Digestif.S) = struct
     else
       let value =
         lazy
-          ( match Value.of_raw ~kind inflated with
+          (match Value.of_raw ~kind inflated with
           | Error (`Msg err) ->
               let str = Fmt.strf "Value.of_raw(%a): %s" Hash.pp hash err in
               raise (Failure str)
-          | Ok value -> value )
+          | Ok value -> value)
       in
       Hashtbl.add t.inflated hash (kind, inflated);
       Hashtbl.add t.values hash value;
@@ -230,7 +230,7 @@ module Make (Digestif : Digestif.S) = struct
       try
         let kind, raw = Hashtbl.find t.inflated h in
         Lwt.return_some (kind, raw)
-      with Not_found -> Lwt.return_none )
+      with Not_found -> Lwt.return_none)
 
   let read t h =
     try Ok (Lazy.force (Hashtbl.find t.values h))
@@ -244,7 +244,7 @@ module Make (Digestif : Digestif.S) = struct
         | Error (`Msg err) ->
             let str = Fmt.strf "Value.of_raw(%a): %s" Hash.pp h err in
             raise (Failure str)
-      with Not_found -> Error (`Not_found h) )
+      with Not_found -> Error (`Not_found h))
 
   let keys t = Hashtbl.fold (fun k _ l -> k :: l) t []
 
@@ -346,7 +346,8 @@ module Make (Digestif : Digestif.S) = struct
       Log.debug (fun l -> l "Ref.list.");
       let graph, rest =
         Hashtbl.fold
-          (fun k -> function `R ptr -> fun (a, r) -> a, (k, ptr) :: r
+          (fun k -> function
+            | `R ptr -> fun (a, r) -> a, (k, ptr) :: r
             | `H hash -> fun (a, r) -> Graph.add k hash a, r)
           t.refs (Graph.empty, [])
       in
@@ -458,9 +459,9 @@ struct
     let map _ _ ~pos:_ _ = assert false
   end
 
-  include Sync.Make (Git_store.Hash) (Cstruct_append) (Index) (Conduit)
-            (Git_store)
-            (HTTP)
+  include
+    Sync.Make (Git_store.Hash) (Cstruct_append) (Index) (Conduit) (Git_store)
+      (HTTP)
 
   let stream_of_cstruct ?(chunk = 0x1000) payload =
     let stream, emitter = Lwt_stream.create () in
@@ -468,7 +469,7 @@ struct
       let rec go pos =
         if pos = Cstruct.len payload then (
           emitter None;
-          Lwt.return_unit )
+          Lwt.return_unit)
         else
           let len = min chunk (Cstruct.len payload - pos) in
           let tmp = Bytes.create len in

--- a/src/git/object_graph.ml
+++ b/src/git/object_graph.ml
@@ -205,7 +205,7 @@ struct
             Search.pred ~full t key >>= fun preds ->
             let keys = List.map (fun x -> snd (label x)) preds in
             List.iter (fun k -> K.add_edge g k key) keys;
-            Lwt_list.iter_p add keys )
+            Lwt_list.iter_p add keys)
     in
     let max = S.fold (fun x a -> x :: a) max [] in
     Lwt_list.iter_p add max >>= fun () -> Lwt.return g

--- a/src/git/reference.ml
+++ b/src/git/reference.ml
@@ -21,10 +21,10 @@ let validate_and_collapse_seps p =
       if c = '\x00' then error_msgf "Malformed reference: %S" p
       else if c <> dir_sep_char then (
         Bytes.set b k c;
-        with_buf b false (k + 1) (i + 1) )
+        with_buf b false (k + 1) (i + 1))
       else if not last_sep then (
         Bytes.set b k c;
-        with_buf b true (k + 1) (i + 1) )
+        with_buf b true (k + 1) (i + 1))
       else with_buf b true k (i + 1)
   in
   let rec try_no_alloc last_sep i =
@@ -139,7 +139,7 @@ module Packed = struct
                   let reference = v reference in
                   let uid = of_hex uid in
                   go (Ref (reference, uid) :: acc)
-              | None -> go acc ) )
+              | None -> go acc))
       | None -> return (List.rev acc)
     in
     go []
@@ -152,7 +152,7 @@ module Packed = struct
       | Ref (reference', _) ->
           if equal reference reference' then (
             res := true;
-            raise Found )
+            raise Found)
       | _ -> ()
     in
     (try List.iter f packed with Found -> ());
@@ -164,7 +164,7 @@ module Packed = struct
       | Ref (reference', uid) ->
           if equal reference reference' then (
             res := Some uid;
-            raise Found )
+            raise Found)
       | _ -> ()
     in
     (try List.iter f packed with Found -> ());
@@ -197,7 +197,7 @@ let contents store str =
       let is_sep chr = Astring.Char.Ascii.is_white chr || chr = ':' in
       match Astring.String.fields ~empty:false ~is_sep str with
       | [ _ref; value ] -> Ref (v value)
-      | _ -> Fmt.invalid_arg "Invalid reference contents: %S" str )
+      | _ -> Fmt.invalid_arg "Invalid reference contents: %S" str)
 
 let resolve { Carton.bind; Carton.return } t store reference =
   let ( >>= ) = bind in
@@ -207,13 +207,13 @@ let resolve { Carton.bind; Carton.return } t store reference =
     | Error _ -> (
         match Packed.get reference store.packed with
         | Some uid -> return (Ok uid)
-        | None -> return (Error (`Not_found reference)) )
+        | None -> return (Error (`Not_found reference)))
     | Ok str -> (
         match contents store str with
         | Uid uid -> return (Ok uid)
         | Ref reference ->
             if List.exists (equal reference) visited then return (Error `Cycle)
-            else go (reference :: visited) reference )
+            else go (reference :: visited) reference)
   in
   go [ reference ] reference
 
@@ -224,7 +224,7 @@ let read { Carton.bind; Carton.return } t store reference =
   | Error _ -> (
       match Packed.get reference store.packed with
       | Some uid -> return (Ok (Uid uid))
-      | None -> return (Error (`Not_found reference)) )
+      | None -> return (Error (`Not_found reference)))
   | Ok str -> return (Ok (contents store str))
 
 let write { Carton.bind; Carton.return } t store reference contents =

--- a/src/git/search.ml
+++ b/src/git/search.ml
@@ -47,7 +47,7 @@ struct
             if full then [ `Tree_root (Store.Value.Commit.tree c) ] else []
         | false ->
             (if full then [ `Tree_root (Store.Value.Commit.tree c) ] else [])
-            @ List.map (fun x -> `Commit x) (Store.Value.Commit.parents c) )
+            @ List.map (fun x -> `Commit x) (Store.Value.Commit.parents c))
     | Value.Tag t -> if full then Lwt.return [ tag t ] else Lwt.return []
     | Value.Tree t ->
         if full then
@@ -86,17 +86,17 @@ struct
         pred t hash >>= fun preds ->
         match find_tag l preds with
         | None -> Lwt.return_none
-        | Some s -> (find [@tailcall]) t s p )
+        | Some s -> (find [@tailcall]) t s p)
     | `Commit p -> (
         pred t hash >>= fun preds ->
         match find_tree_root preds with
         | None -> Lwt.return_none
-        | Some s -> (find [@tailcall]) t s p )
+        | Some s -> (find [@tailcall]) t s p)
     | `Path (h :: p) -> (
         pred t hash >>= fun preds ->
         match find_tree h preds with
         | None -> Lwt.return_none
-        | Some s -> (find [@tailcall]) t s (`Path p) )
+        | Some s -> (find [@tailcall]) t s (`Path p))
 
   (* XXX: can do one less look-up *)
   let mem t h path =

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -84,7 +84,7 @@ struct
     include (
       Reference :
         module type of Reference
-          with type 'uid contents := 'uid Reference.contents )
+          with type 'uid contents := 'uid Reference.contents)
 
     type contents = hash Reference.contents
   end
@@ -103,8 +103,8 @@ struct
     major_uid : (hash, Mj.uid, Mj.t) major;
     packs : (Mj.uid, < rd : unit > Mj.fd, Hash.t) Carton_git.t;
     pools :
-      ( (< rd : unit > Mj.fd * int64)
-      * (< rd : unit > Mj.fd * int64) Carton_git.buffers Lwt_pool.t )
+      ((< rd : unit > Mj.fd * int64)
+      * (< rd : unit > Mj.fd * int64) Carton_git.buffers Lwt_pool.t)
       list;
     buffs : buffers Lwt_pool.t;
     rs : Rs.t;
@@ -213,7 +213,7 @@ struct
         | Error `Non_atomic -> (
             Loose.get t.minor buffers hash >>= function
             | Ok v -> Lwt.return_some v
-            | Error _ -> Lwt.return_none ) )
+            | Error _ -> Lwt.return_none))
 
   let read t hash =
     read_inflated t hash >>= function
@@ -279,7 +279,7 @@ struct
         let stream = stream_of_raw raw in
         Loose.add t.minor buffers (kind, length) stream >>= function
         | Ok _ as v -> Lwt.return v
-        | Error (`Store err) -> Lwt.return_error (`Minor err) )
+        | Error (`Store err) -> Lwt.return_error (`Minor err))
 
   let read_inflated t hash =
     read_inflated t hash >>= function
@@ -315,12 +315,12 @@ struct
           if !consumed then Lwt.return_none
           else (
             consumed := true;
-            Lwt.return_some (Bigstringaf.to_string raw) )
+            Lwt.return_some (Bigstringaf.to_string raw))
         in
         Loose.add t.minor buffers (kind, Int64.of_int len) stream >>= function
         | Ok (hash, _) -> Lwt.return hash
         | Error (`Store err) ->
-            Lwt.fail (Failure (Fmt.strf "%a" pp_error (`Minor err))) )
+            Lwt.fail (Failure (Fmt.strf "%a" pp_error (`Minor err))))
 
   let mem t hash =
     if not (Pack.exists t.major t.packs hash) then Loose.exists t.minor hash
@@ -453,7 +453,7 @@ struct
       let res = Rresult.R.reword_error (fun err -> `Ref err) res in
       if Packed.exists refname t.refs.packed then (
         t.refs <- { t.refs with packed = Packed.remove refname t.refs.packed };
-        Lwt.return res )
+        Lwt.return res)
       else Lwt.return res
   end
 

--- a/src/git/sync.ml
+++ b/src/git/sync.ml
@@ -103,7 +103,7 @@ struct
             let v = hash, ref 0, ts in
             Hashtbl.add hashtbl hash v;
             Lwt.return_some v
-        | Ok _ | Error _ -> Lwt.return_none )
+        | Ok _ | Error _ -> Lwt.return_none)
 
   let parents_of_commit t hash =
     Log.debug (fun m -> m "Get parents of %a." Hash.pp hash);
@@ -111,7 +111,7 @@ struct
     | Value.Commit commit -> (
         Store.is_shallowed t hash >>= function
         | false -> Lwt.return (Store.Value.Commit.parents commit)
-        | true -> Lwt.return [] )
+        | true -> Lwt.return [])
     | _ -> Lwt.return []
 
   let parents ((t, _hashtbl) as store) hash =
@@ -188,8 +188,9 @@ struct
         Lwt.return (Carton.Dec.v ~kind raw)
     | None -> Lwt.fail Not_found
 
-  include Smart_git.Make (Scheduler) (Pack) (Index) (Conduit) (HTTP) (Hash)
-            (Reference)
+  include
+    Smart_git.Make (Scheduler) (Pack) (Index) (Conduit) (HTTP) (Hash)
+      (Reference)
 
   let ( >>? ) x f =
     x >>= function Ok x -> f x | Error err -> Lwt.return_error err
@@ -278,7 +279,7 @@ struct
         | Some o as v ->
             Hashtbl.replace hashtbl hash o;
             Lwt.return v
-        | None -> Lwt.return_none )
+        | None -> Lwt.return_none)
 
   let access =
     {

--- a/src/git/traverse_bfs.ml
+++ b/src/git/traverse_bfs.ml
@@ -49,7 +49,7 @@ module Make (Store : STORE) = struct
       | [] -> (
           match Queue.pop queue with
           | rest -> walk close [ rest ] queue acc
-          | exception Queue.Empty -> Lwt.return acc )
+          | exception Queue.Empty -> Lwt.return acc)
       | hash :: rest -> (
           if Store.Hash.Set.mem hash close then walk close rest queue acc
           else
@@ -66,7 +66,7 @@ module Make (Store : STORE) = struct
                       (fun x -> Queue.add x queue)
                       (Store.Value.Commit.parents commit);
                     f acc ~length:(Store.Value.Commit.length commit) hash value
-                    >>= fun acc' -> walk close' rest' queue acc' )
+                    >>= fun acc' -> walk close' rest' queue acc')
             | Value.Tree tree as value ->
                 let path =
                   try Hashtbl.find names hash with Not_found -> path
@@ -98,7 +98,7 @@ module Make (Store : STORE) = struct
             | Value.Tag tag as value ->
                 Queue.add (Store.Value.Tag.obj tag) queue;
                 f acc ~length:(Store.Value.Tag.length tag) hash value
-                >>= fun acc' -> walk close' rest queue acc' )
+                >>= fun acc' -> walk close' rest queue acc')
     in
     walk Store.Hash.Set.empty [ hash ] (Queue.create ()) acc
 

--- a/src/git/tree.ml
+++ b/src/git/tree.ml
@@ -56,13 +56,13 @@ type 'hash entry = { perm : perm; name : string; node : 'hash }
 
 let pp_entry ~pp ppf { perm; name; node } =
   Fmt.pf ppf "{ @[<hov>perm = %s;@ name = %S;@ node = %a;@] }"
-    ( match perm with
+    (match perm with
     | `Normal -> "normal"
     | `Everybody -> "everybody"
     | `Exec -> "exec"
     | `Link -> "link"
     | `Dir -> "dir"
-    | `Commit -> "commit" )
+    | `Commit -> "commit")
     name (Fmt.hvbox pp) node
 
 let equal_entry ~equal a b =
@@ -109,8 +109,8 @@ let compare x y =
         !p < len_a
         && !p < len_b
         &&
-        ( c := Char.compare a.[!p] b.[!p];
-          !c = 0 )
+        (c := Char.compare a.[!p] b.[!p];
+         !c = 0)
       do
         incr p
       done;
@@ -235,12 +235,12 @@ module Make (Hash : S.HASH) : S with type hash = Hash.t = struct
       let hash = hash <$> fixed Hash.digest_size in
       let name = while1 is_not_nl in
       entry
-      <$> ( perm
+      <$> (perm
           <* (Encore.Bij.char ' ' <$> any)
           <* commit
           <*> (name <* (Encore.Bij.char '\x00' <$> any) <* commit)
           <*> (hash <* commit)
-          <* commit )
+          <* commit)
 
     let format = Encore.Syntax.rep0 entry
   end

--- a/src/git/user.ml
+++ b/src/git/user.ml
@@ -83,11 +83,11 @@ let int64 =
 let format =
   let open Encore.Syntax in
   Encore.Bij.(compose obj4) user
-  <$> ( chop
+  <$> (chop
       <$> (while1 is_not_lt <* (Encore.Bij.char '<' <$> any))
       <*> (while1 is_not_gt <* (Encore.Bij.string "> " <$> const "> "))
       <*> (int64 <$> while1 is_digit <* (Encore.Bij.char ' ' <$> any))
-      <*> date )
+      <*> date)
 
 let length t =
   let string x = Int64.of_int (String.length x) in

--- a/src/git/value.ml
+++ b/src/git/value.ml
@@ -173,10 +173,10 @@ module Make (Hash : S.HASH) : S with type hash = Hash.t = struct
         <*> t
       in
       Encore.Bij.(compose obj3) iso
-      <$> ( value "commit" commit'
+      <$> (value "commit" commit'
           <|> value "tree" tree
           <|> value "blob" blob
-          <|> value "tag" tag )
+          <|> value "tag" tag)
   end
 
   let format = Syntax.format
@@ -241,12 +241,12 @@ module Make (Hash : S.HASH) : S with type hash = Hash.t = struct
         | Error _ ->
             Log.err (fun m ->
                 m "Object %s is bad: @[<hov>%S@]"
-                  ( match kind with
+                  (match kind with
                   | `Tree -> "tree"
                   | `Commit -> "commit"
-                  | `Tag -> "tag" )
+                  | `Tag -> "tag")
                   (Cstruct.to_string raw));
-            Error (`Msg "Invalid Git object") )
+            Error (`Msg "Invalid Git object"))
 
   let to_raw_without_header = function
     | Blob v -> Cstruct.to_string (Blob.to_cstruct v)
@@ -304,7 +304,7 @@ module Make (Hash : S.HASH) : S with type hash = Hash.t = struct
           if !consumed then Lwt.return_none
           else (
             consumed := true;
-            Lwt.return_some (Cstruct.to_string (Blob.to_cstruct v)) )
+            Lwt.return_some (Cstruct.to_string (Blob.to_cstruct v)))
         in
         stream
     | v ->

--- a/src/loose/loose.ml
+++ b/src/loose/loose.ml
@@ -112,13 +112,13 @@ module Make (Uid : UID) = struct
               ~len:max;
             let ctx = Uid.feed ctx buffers.i ~off:0 ~len:max in
             let encoder = Zl.Def.src encoder buffers.i 0 max in
-            go ctx (src, off + max, len - max) dsts encoder )
+            go ctx (src, off + max, len - max) dsts encoder)
           else
             stream () >>= function
             | Some src -> go ctx (src, 0, String.length src) dsts encoder
             | None ->
                 let encoder = Zl.Def.src encoder Bigstringaf.empty 0 0 in
-                go ctx payload dsts encoder )
+                go ctx payload dsts encoder)
       | `Flush encoder ->
           let len = Bigstringaf.length buffers.o - Zl.Def.dst_rem encoder in
           let raw = Bigstringaf.copy buffers.o ~off:0 ~len in

--- a/src/loose/loose_git.ml
+++ b/src/loose/loose_git.ml
@@ -105,7 +105,7 @@ struct
               | v -> Fmt.failwith "Invalid type of Git object: %s" v
             in
             contents, kind, length
-        | None -> failwith "Invalid Git header" )
+        | None -> failwith "Invalid Git header")
 
   let hdr_set ~buffer (kind, length) =
     let kind =

--- a/src/loose/loose_git_unix.ml
+++ b/src/loose/loose_git_unix.ml
@@ -111,7 +111,7 @@ module Make (Uid : UID) = struct
           | Error (`Msg _) ->
               failwithf
                 "Directory contents %a: cannot parse element to a path (%S)"
-                Fpath.pp dir f )
+                Fpath.pp dir f)
       | Some _ -> readdir dh acc
     in
     Lwt.catch
@@ -212,7 +212,7 @@ module Make (Uid : UID) = struct
     | tl :: hd :: _ -> (
         match Uid.of_hex (hd ^ tl) with
         | _ -> file_exists path
-        | exception _ -> Lwt.return_false )
+        | exception _ -> Lwt.return_false)
     | _ -> Lwt.return_false
 
   (* fold *)
@@ -274,7 +274,7 @@ module Make (Uid : UID) = struct
               | v -> Fmt.failwith "Invalid type of Git object: %s" v
             in
             contents, kind, length
-        | None -> failwith "Invalid Git header" )
+        | None -> failwith "Invalid Git header")
 
   let hdr_set ~buffer (kind, length) =
     let kind =

--- a/src/not-so-smart/capability.ml
+++ b/src/not-so-smart/capability.ml
@@ -77,19 +77,19 @@ let of_string ?value = function
   | "push-cert" -> (
       match value with
       | Some value -> `Push_cert value
-      | None -> raise (Capability_expect_value "push-cert") )
+      | None -> raise (Capability_expect_value "push-cert"))
   | "agent" -> (
       match value with
       | Some value -> `Agent value
-      | None -> raise (Capability_expect_value "agent") )
+      | None -> raise (Capability_expect_value "agent"))
   | "symref" -> (
       match Option.bind value (Astring.String.cut ~sep:":") with
       | Some (ref0, ref1) -> `Symref (ref0, ref1)
-      | None -> raise (Capability_expect_value "symref") )
+      | None -> raise (Capability_expect_value "symref"))
   | capability -> (
       match value with
       | Some value -> `Parameter (capability, value)
-      | None -> `Other capability )
+      | None -> `Other capability)
 
 let pp ppf = function
   | `Multi_ack -> Fmt.pf ppf "Multi-ACK"

--- a/src/not-so-smart/decoder.ml
+++ b/src/not-so-smart/decoder.ml
@@ -116,8 +116,8 @@ let at_least_one_line decoder =
   while
     !pos < decoder.max
     &&
-    ( chr := Bytes.unsafe_get decoder.buffer !pos;
-      not (!chr = '\n' && !has_cr) )
+    (chr := Bytes.unsafe_get decoder.buffer !pos;
+     not (!chr = '\n' && !has_cr))
   do
     has_cr := !chr = '\r';
     incr pos
@@ -212,7 +212,7 @@ let prompt :
     let rest = decoder.max - decoder.pos in
     Bytes.unsafe_blit decoder.buffer decoder.pos decoder.buffer 0 rest;
     decoder.max <- rest;
-    decoder.pos <- 0 );
+    decoder.pos <- 0);
   let rec go off =
     try
       if
@@ -238,14 +238,14 @@ let prompt :
             len = Bytes.length decoder.buffer - off;
             continue = (fun len -> go (off + len));
             eof =
-              ( if strict then error_end_of_input decoder (* fail *)
+              (if strict then error_end_of_input decoder (* fail *)
               else (
                 decoder.max <- off;
-                reliable_pkt k decoder ) );
+                reliable_pkt k decoder));
           }
       else (
         decoder.max <- off;
-        safe k decoder )
+        safe k decoder)
     with
     | _exn (* XXX(dinosaure): [at_least_one_pkt] can raise an exception. *) ->
       Error
@@ -275,8 +275,8 @@ let peek_while_eol decoder =
   while
     !idx < end_of_input decoder
     &&
-    ( chr := Bytes.unsafe_get decoder.buffer !idx;
-      not (!chr == '\n' && !has_cr) )
+    (chr := Bytes.unsafe_get decoder.buffer !idx;
+     not (!chr == '\n' && !has_cr))
   do
     has_cr := !chr == '\r';
     incr idx
@@ -284,7 +284,7 @@ let peek_while_eol decoder =
 
   if !idx < end_of_input decoder && !chr == '\n' && !has_cr then (
     assert (!idx + 1 - decoder.pos > 1);
-    decoder.buffer, decoder.pos, !idx + 1 - decoder.pos )
+    decoder.buffer, decoder.pos, !idx + 1 - decoder.pos)
   else leave_with decoder `Expected_eol
 
 let peek_while_eol_or_space decoder =
@@ -295,8 +295,8 @@ let peek_while_eol_or_space decoder =
   while
     !idx < end_of_input decoder
     &&
-    ( chr := Bytes.unsafe_get decoder.buffer !idx;
-      (not (!chr = '\n' && !has_cr)) && !chr <> ' ' )
+    (chr := Bytes.unsafe_get decoder.buffer !idx;
+     (not (!chr = '\n' && !has_cr)) && !chr <> ' ')
   do
     has_cr := !chr = '\r';
     incr idx

--- a/src/not-so-smart/default.ml
+++ b/src/not-so-smart/default.ml
@@ -61,7 +61,7 @@ let rec mark_common :
   if only_ancestors then p := !p lor _common;
   if !p land _seen = 0 then (
     rev_list_push t (uid, p, ts) _seen;
-    return () )
+    return ())
   else (
     if (not only_ancestors) && !p land _popped = 0 then
       state.non_common_revs <- non_common_revs - 1;
@@ -73,7 +73,7 @@ let rec mark_common :
           mark_common scheduler ~parents store t (uid, p, ts) false
           >>= fun () -> go rest
     in
-    go )
+    go)
 
 let known_common :
     type g s uid.
@@ -86,7 +86,7 @@ let known_common :
  fun ({ return; _ } as scheduler) ~parents store t (uid, p, ts) ->
   if !p land _seen = 0 then (
     rev_list_push t (uid, p, ts) (_common_ref lor _seen);
-    mark_common scheduler ~parents store t (uid, p, ts) true )
+    mark_common scheduler ~parents store t (uid, p, ts) true)
   else return ()
 
 let tip t obj = rev_list_push t obj _seen
@@ -134,13 +134,12 @@ let get_rev :
 
           if !p land _common <> 0 then (
             mark := _common lor _seen;
-            res := None )
+            res := None)
           else if !p land _common_ref <> 0 then mark := _common lor _seen
           else mark := _seen;
 
           let rec loop = function
-            | [] -> (
-                match !res with None -> go () | Some _ as v -> return v )
+            | [] -> ( match !res with None -> go () | Some _ as v -> return v)
             | (uid, p, ts) :: rest ->
                 if !p land _seen = 0 then rev_list_push t (uid, p, ts) !mark;
 

--- a/src/not-so-smart/encoder.ml
+++ b/src/not-so-smart/encoder.ml
@@ -37,7 +37,7 @@ let flush k0 encoder =
           }
       else (
         encoder.pos <- 0;
-        k0 encoder )
+        k0 encoder)
     in
     k1 0
   else k0 encoder

--- a/src/not-so-smart/fetch.ml
+++ b/src/not-so-smart/fetch.ml
@@ -58,7 +58,9 @@ struct
     | `None -> [], []
     | `All ->
         List.fold_left
-          (fun acc -> function uid, ref, false -> (uid, ref) :: acc | _ -> acc)
+          (fun acc -> function
+            | uid, ref, false -> (uid, ref) :: acc
+            | _ -> acc)
           [] have
         |> List.split
     | `Some refs ->

--- a/src/not-so-smart/find_common.ml
+++ b/src/not-so-smart/find_common.ml
@@ -41,7 +41,7 @@ let run :
             go (k len)
         | Error err ->
             Log.err (fun m -> m "Got an error: %a." pp_error err);
-            failwithf "%a" pp_error err )
+            failwithf "%a" pp_error err)
     | Smart.Write { k; buffer; off; len } ->
         let rec loop tmp =
           if Cstruct.len tmp = 0 then go (k len)
@@ -158,16 +158,15 @@ let find_common ({ bind; return } as scheduler) io flow
           let others = List.map (to_hex <.> fst) others in
           let capabilities, _ = Smart.capabilities ctx in
           let deepen =
-            ( deepen
-              :> [ `Depth of int | `Not of string | `Timestamp of int64 ] option
-              )
+            (deepen
+              :> [ `Depth of int | `Not of string | `Timestamp of int64 ] option)
           in
           send ctx want
             (Want.want ~capabilities ~shallows:shallowed ?deepen uid ~others))
       >>= fun () ->
-      ( match deepen with
+      (match deepen with
       | None -> return ()
-      | Some _ -> handle_shallow scheduler io flow hex access store ctx )
+      | Some _ -> handle_shallow scheduler io flow hex access store ctx)
       >>= fun () ->
       let in_vain = ref 0 in
       let count = ref 0 in
@@ -239,7 +238,7 @@ let find_common ({ bind; return } as scheduler) io flow
                             in_vain := 0;
                             retval := 0;
                             got_continue := true;
-                            loop () )
+                            loop ())
                           else if
                             (not stateless)
                             || not (Smart.Negotiation.is_common ack)
@@ -249,13 +248,13 @@ let find_common ({ bind; return } as scheduler) io flow
                             got_continue := true;
                             if Smart.Negotiation.is_ready ack then
                               got_ready := true;
-                            loop () )
+                            loop ())
                           else (
                             retval := 0;
                             got_continue := true;
                             if Smart.Negotiation.is_ready ack then
                               got_ready := true;
-                            loop () ) )
+                            loop ()))
                 in
                 loop () >>= function
                 | `Done -> return ()
@@ -263,24 +262,24 @@ let find_common ({ bind; return } as scheduler) io flow
                     decr flushes;
                     if !got_continue && _max_in_vain < !in_vain then return ()
                     else if !got_ready then return ()
-                    else go negotiator )
+                    else go negotiator)
             else go negotiator
       in
       go negotiator >>= fun () ->
       Log.debug (fun m ->
           m "Negotiation (got ready: %b, no-done: %b)." !got_ready no_done);
-      ( if (not !got_ready) || not no_done then
-        run scheduler raise io flow Smart.(send ctx negotiation_done ())
-      else return () )
+      (if (not !got_ready) || not no_done then
+       run scheduler raise io flow Smart.(send ctx negotiation_done ())
+      else return ())
       >>= fun () ->
       if !retval <> 0 then (
         cfg.multi_ack <- `None;
-        incr flushes );
-      ( if (not !got_ready) || not no_done then (
-        Log.debug (fun m -> m "Negotiation is done!");
-        run scheduler raise io flow Smart.(recv ctx shallows)
-        >>= fun _shallows -> return () )
-      else return () )
+        incr flushes);
+      (if (not !got_ready) || not no_done then (
+       Log.debug (fun m -> m "Negotiation is done!");
+       run scheduler raise io flow Smart.(recv ctx shallows)
+       >>= fun _shallows -> return ())
+      else return ())
       >>= fun () ->
       let rec go () =
         if !flushes > 0 || cfg.multi_ack = `Some || cfg.multi_ack = `Detailed
@@ -296,7 +295,7 @@ let find_common ({ bind; return } as scheduler) io flow
               go ()
           | Smart.Negotiation.NAK ->
               decr flushes;
-              go () )
+              go ())
         else if !count > 0 then return (`Continue !retval)
         else return (`Continue 0)
       in

--- a/src/not-so-smart/pck.ml
+++ b/src/not-so-smart/pck.ml
@@ -67,7 +67,7 @@ let commands { bind; return } ~capabilities ~equal:equal_reference ~deref store
     | `Create reference -> (
         deref store reference >>= function
         | Some uid -> return (Smart.Commands.create uid reference :: acc)
-        | None -> return acc )
+        | None -> return acc)
     | `Delete reference ->
         let uid, _, _ =
           List.find
@@ -86,7 +86,7 @@ let commands { bind; return } ~capabilities ~equal:equal_reference ~deref store
                   equal_reference remote reference' && peeled = false)
                 have
             in
-            return (Smart.Commands.update uid_old uid_new remote :: acc) )
+            return (Smart.Commands.update uid_old uid_new remote :: acc))
   in
   let rec go a = function
     | [] -> return a
@@ -189,7 +189,7 @@ let get_uncommon_objects :
               value.color <- color;
               List.iter (fun uid -> Queue.push uid q) (preds node);
               go ()
-          | None | (exception Not_found) -> go () )
+          | None | (exception Not_found) -> go ())
       | exception Queue.Empty -> ()
     in
     List.iter (fun uid -> Queue.push uid q) (preds node);

--- a/src/not-so-smart/protocol.ml
+++ b/src/not-so-smart/protocol.ml
@@ -325,7 +325,7 @@ module Decoder = struct
         let v = peek_pkt decoder in
         if String.Sub.is_empty v then (
           junk_pkt decoder;
-          return { advertised_refs with Advertised_refs.shallows } decoder )
+          return { advertised_refs with Advertised_refs.shallows } decoder)
         else
           match String.Sub.cut ~sep:v_space v with
           | Some (_, uid) ->
@@ -350,7 +350,7 @@ module Decoder = struct
               version;
               shallows = [];
             }
-            decoder )
+            decoder)
         else if String.Sub.is_prefix ~affix:v_shallow v then
           decode_shallows
             {
@@ -482,7 +482,7 @@ module Decoder = struct
       let v = peek_pkt decoder in
       if String.Sub.equal_bytes v v_nak then (
         junk_pkt decoder;
-        return Result.NAK decoder )
+        return Result.NAK decoder)
       else
         match String.Sub.cut ~sep:v_space v with
         | Some (_, common) ->
@@ -508,7 +508,7 @@ module Decoder = struct
       let rest = decoder.max - decoder.pos in
       Bytes.unsafe_blit decoder.buffer decoder.pos decoder.buffer 0 rest;
       decoder.max <- rest;
-      decoder.pos <- 0 );
+      decoder.pos <- 0);
     let rec go off =
       if off = Bytes.length decoder.buffer && decoder.pos > 0 then
         Error
@@ -519,7 +519,7 @@ module Decoder = struct
           }
       else if off - decoder.pos > 0 then (
         decoder.max <- off;
-        safe kcontinue decoder )
+        safe kcontinue decoder)
       else
         Read
           {
@@ -581,7 +581,7 @@ module Decoder = struct
       let v = peek_pkt decoder in
       if String.Sub.length v = 0 then (
         junk_pkt decoder;
-        return (List.rev acc) decoder )
+        return (List.rev acc) decoder)
       else if
         String.Sub.is_prefix ~affix:v_shallow v
         || String.Sub.is_prefix ~affix:v_unshallow v
@@ -591,10 +591,10 @@ module Decoder = struct
             let uid = String.Sub.to_string uid in
             if String.Sub.equal_bytes v v_shallow then (
               junk_pkt decoder;
-              prompt_pkt (go (Shallow.Shallow uid :: acc)) decoder )
+              prompt_pkt (go (Shallow.Shallow uid :: acc)) decoder)
             else (
               junk_pkt decoder;
-              prompt_pkt (go (Shallow.Unshallow uid :: acc)) decoder )
+              prompt_pkt (go (Shallow.Unshallow uid :: acc)) decoder)
         | _ -> return (List.rev acc) decoder
       else return (List.rev acc) decoder
     in
@@ -605,7 +605,7 @@ module Decoder = struct
       let pkt = peek_pkt decoder in
       if String.Sub.equal_bytes pkt v_nak then (
         junk_pkt decoder;
-        return Negotiation.NAK decoder )
+        return Negotiation.NAK decoder)
       else if String.Sub.is_prefix ~affix:v_ack pkt then
         match String.Sub.cuts ~sep:v_space pkt with
         | [ _; uid ] ->
@@ -622,7 +622,7 @@ module Decoder = struct
             | "continue" -> return (Negotiation.ACK_continue uid) decoder
             | "ready" -> return (Negotiation.ACK_ready uid) decoder
             | "common" -> return (Negotiation.ACK_common uid) decoder
-            | _ -> fail decoder (`Invalid_ack (String.Sub.to_string pkt)) )
+            | _ -> fail decoder (`Invalid_ack (String.Sub.to_string pkt)))
         | _ -> fail decoder (`Invalid_ack (String.Sub.to_string pkt))
       else assert false
     in
@@ -650,8 +650,7 @@ module Decoder = struct
               let reference = String.Sub.to_string reference in
               Stdlib.Ok (Stdlib.Error (reference, err))
           | _ ->
-              Stdlib.Error (`Invalid_command_result (String.Sub.to_string pkt))
-          )
+              Stdlib.Error (`Invalid_command_result (String.Sub.to_string pkt)))
       | _ -> Stdlib.Error (`Invalid_command_result (String.Sub.to_string pkt))
     in
 
@@ -684,7 +683,7 @@ module Decoder = struct
               return (Stdlib.Ok ()) decoder
           | err ->
               junk_pkt decoder;
-              return (Stdlib.Error err) decoder )
+              return (Stdlib.Error err) decoder)
     in
     prompt_pkt result decoder >>= fun result ->
     prompt_pkt commands decoder >>= fun commands ->
@@ -764,7 +763,7 @@ module Encoder = struct
       if version > 1 then (
         write_zero encoder;
         write_version encoder version;
-        write_zero encoder )
+        write_zero encoder)
     in
     delayed_write_pkt k kdone encoder
 
@@ -842,7 +841,7 @@ module Encoder = struct
       in
       if List.length capabilities > 0 then (
         write_space encoder;
-        go capabilities );
+        go capabilities);
       write_new_line encoder
     in
 

--- a/src/not-so-smart/push.ml
+++ b/src/not-so-smart/push.ml
@@ -111,5 +111,5 @@ struct
             return ()
         | Error err ->
             Log.err (fun m -> m "Push got an error: %s" err);
-            return () )
+            return ())
 end

--- a/src/not-so-smart/smart_git.ml
+++ b/src/not-so-smart/smart_git.ml
@@ -94,7 +94,7 @@ let endpoint_of_string str =
                (function `Atom x -> x | `String x -> Fmt.strf "%S" x)
                m.Emile.local)
         in
-        ( match fst m.Emile.domain with
+        (match fst m.Emile.domain with
         | `Domain vs ->
             Domain_name.of_strings vs
             >>= Domain_name.host
@@ -106,7 +106,7 @@ let endpoint_of_string str =
         | `Addr (Emile.IPv4 ipv4) -> R.ok (Conduit.Endpoint.ip (Ipaddr.V4 ipv4))
         | `Addr (Emile.IPv6 ipv6) -> R.ok (Conduit.Endpoint.ip (Ipaddr.V6 ipv6))
         | `Addr (Emile.Ext (ext, _)) ->
-            R.error_msgf "Git does not handle domain extension %s." ext )
+            R.error_msgf "Git does not handle domain extension %s." ext)
         >>= fun endpoint -> R.ok { scheme = `SSH user; path; endpoint }
     | _ -> R.error_msg "invalid pattern"
   in
@@ -376,11 +376,11 @@ struct
     let rec recv t raw =
       if t.pos = String.length t.ic then (
         let open Lwt.Infix in
-        ( HTTP.post ~resolvers:t.resolvers ~headers:t.headers t.uri t.oc
-        >|= Rresult.(R.reword_error (R.msgf "%a" HTTP.pp_error)) )
+        (HTTP.post ~resolvers:t.resolvers ~headers:t.headers t.uri t.oc
+        >|= Rresult.(R.reword_error (R.msgf "%a" HTTP.pp_error)))
         >>? fun (_resp, contents) ->
         t.ic <- t.ic ^ contents;
-        recv t raw )
+        recv t raw)
       else
         let len = min (String.length t.ic - t.pos) (Cstruct.len raw) in
         Cstruct.blit_from_string t.ic t.pos raw 0 len;
@@ -453,8 +453,7 @@ struct
           let run () =
             Lwt.both
               (fetch_v1 ~push_stdout ~push_stderr ~prelude ~capabilities path
-                 ~resolvers ?deepen ~want endpoint store access fetch_cfg
-                 pusher)
+                 ~resolvers ?deepen ~want endpoint store access fetch_cfg pusher)
               (run ~light_load ~heavy_load stream t_pck t_idx ~src ~dst ~idx)
             >>= fun (refs, idx) ->
             match refs, idx with

--- a/test/carton/test.ml
+++ b/test/carton/test.ml
@@ -377,7 +377,7 @@ let file =
     if ln_a <> ln_b then (
       close_in ic_a;
       close_in ic_b;
-      false )
+      false)
     else
       let bf_a = Bytes.create 0x1000 and bf_b = Bytes.create 0x1000 in
       let rec go () =
@@ -477,10 +477,10 @@ let verify_bomb_pack () =
         Hashtbl.add weight offset target;
         Hashtbl.add where offset n;
 
-        ( try
-            let v = Hashtbl.find children (`Ofs base) in
-            Hashtbl.add children (`Ofs base) (offset :: v)
-          with Not_found -> Hashtbl.add children (`Ofs base) [ offset ] );
+        (try
+           let v = Hashtbl.find children (`Ofs base) in
+           Hashtbl.add children (`Ofs base) (offset :: v)
+         with Not_found -> Hashtbl.add children (`Ofs base) [ offset ]);
         go decoder
     | `Entry _ -> (* OBJ_REF *) Alcotest.fail "Unexpected OBJ_REF"
     | `Malformed err -> Alcotest.fail err
@@ -631,17 +631,17 @@ let unpack_bomb_pack () =
           Hashtbl.add weight Int64.(sub offset (Int64.of_int s)) source;
           Hashtbl.add weight offset target;
           Hashtbl.add where offset n;
-          ( try
-              let v =
-                Hashtbl.find children (`Ofs Int64.(sub offset (of_int s)))
-              in
-              Hashtbl.add children
-                (`Ofs Int64.(sub offset (of_int s)))
-                (offset :: v)
-            with _exn ->
-              Hashtbl.add children
-                (`Ofs Int64.(sub offset (of_int s)))
-                [ offset ] );
+          (try
+             let v =
+               Hashtbl.find children (`Ofs Int64.(sub offset (of_int s)))
+             in
+             Hashtbl.add children
+               (`Ofs Int64.(sub offset (of_int s)))
+               (offset :: v)
+           with _exn ->
+             Hashtbl.add children
+               (`Ofs Int64.(sub offset (of_int s)))
+               [ offset ]);
           go decoder
       | `Entry _ -> assert false
       | `End _ ->
@@ -952,10 +952,10 @@ let decode_index_stream () =
            TODO(dinosaure): we should add test to ensure that [device] did not
            keep our value if we don't keep [uid]. *);
         close_in ic;
-        Index_stream_decoder.close device fd )
+        Index_stream_decoder.close device fd)
       else (
         Index_stream_decoder.append device fd (Bytes.sub_string tp 0 len);
-        go () )
+        go ())
     in
     Gc.minor ();
     Gc.full_major ();

--- a/test/index/test.ml
+++ b/test/index/test.ml
@@ -57,8 +57,7 @@ let add_should_be_empty =
             Alcotest.(check string) "add" "A" status;
             R.ok ()
         | _ ->
-            Alcotest.failf "git-status: impossible to parse %S" should_be_empty
-        )
+            Alcotest.failf "git-status: impossible to parse %S" should_be_empty)
     | res, _ ->
         Alcotest.failf "git-status: @[<hov>%a@]" Fmt.(Dump.list string) res
   in
@@ -115,7 +114,7 @@ let tree_of_children tbl children =
         | Some hash ->
             let name = Fpath.basename path in
             Lwt.return_ok (Git.Tree.entry ~name `Dir hash)
-        | None -> Alcotest.failf "%a does not exist" Fpath.pp path )
+        | None -> Alcotest.failf "%a does not exist" Fpath.pp path)
   in
   Lwt_list.map_p entry children
   >>= Lwt_list.map_s (Lwt.return <.> Rresult.R.get_ok)
@@ -147,7 +146,7 @@ let write_tree expect =
                 Alcotest.(check sha1) "blob" hash (Entry.oid entry);
                 Lwt.return_ok hash
             | Error err ->
-                Alcotest.failf "store: %a" Git_unix.Store.pp_error err )
+                Alcotest.failf "store: %a" Git_unix.Store.pp_error err)
         | `Tree path -> (
             tree_of_children tbl children >>= fun tree ->
             Git_unix.Store.write store (Git_unix.Store.Value.tree tree)
@@ -156,14 +155,14 @@ let write_tree expect =
                 Hashtbl.add tbl path hash;
                 Lwt.return_ok hash
             | Error err ->
-                Alcotest.failf "store: %a" Git_unix.Store.pp_error err )
+                Alcotest.failf "store: %a" Git_unix.Store.pp_error err)
         | `Root -> (
             tree_of_children tbl children >>= fun tree ->
             Git_unix.Store.write store (Git_unix.Store.Value.tree tree)
             >>= function
             | Ok (hash, _) -> Lwt.return_ok hash
             | Error err ->
-                Alcotest.failf "store: %a" Git_unix.Store.pp_error err )
+                Alcotest.failf "store: %a" Git_unix.Store.pp_error err)
       in
       fold ~f (Digestif.SHA1.digest_string "") t
     in
@@ -200,8 +199,7 @@ let delete_should_be_empty =
             Alcotest.(check string) "delete" status "D";
             Bos.OS.Cmd.run Bos.Cmd.(v "git" % "commit" % "-m" % ".")
         | _ ->
-            Alcotest.failf "git-status: impossible to parse %S" should_be_empty
-        )
+            Alcotest.failf "git-status: impossible to parse %S" should_be_empty)
     | res, _ ->
         Alcotest.failf "git-status: @[<hov>%a@]" Fmt.(Dump.list string) res
   in

--- a/test/smart/fifo.ml
+++ b/test/smart/fifo.ml
@@ -52,7 +52,7 @@ let recv { ic; linger; closed; _ } raw =
               (if filled + len = 0 then `End_of_flow else `Input (filled + len))
         else
           Lwt.return_ok
-            (if filled + len = 0 then `End_of_flow else `Input (filled + len)) )
+            (if filled + len = 0 then `End_of_flow else `Input (filled + len)))
     in
     Lwt.catch (fun () -> process 0 raw) @@ function
     | Unix.Unix_error (err, _, _) -> Lwt.return_error (`Unix_error err)
@@ -77,7 +77,7 @@ let rec send ({ oc; closed; linger; _ } as t) raw =
     in
     Lwt.catch process @@ function
     | Unix.Unix_error (err, _, _) -> Lwt.return_error (`Unix_error err)
-    | exn -> Lwt.fail exn )
+    | exn -> Lwt.fail exn)
 
 let close t =
   let process () =
@@ -86,7 +86,7 @@ let close t =
       Lwt_unix.close t.ic >>= fun () ->
       Lwt_unix.close t.oc >>= fun () ->
       t.closed <- true;
-      Lwt.return_ok () )
+      Lwt.return_ok ())
     else Lwt.return_ok ()
   in
   Lwt.catch process @@ function

--- a/test/smart/loopback.ml
+++ b/test/smart/loopback.ml
@@ -16,7 +16,7 @@ let connect i =
 let recv flow buf =
   if Cstruct.len flow.i = 0 then (
     flow.c <- true;
-    Lwt.return_ok `End_of_flow )
+    Lwt.return_ok `End_of_flow)
   else
     let len = min (Cstruct.len buf) (Cstruct.len flow.i) in
     Cstruct.blit flow.i 0 buf 0 len;
@@ -29,7 +29,7 @@ let send flow str =
   if flow.c then Lwt.return_error `Closed
   else (
     flow.o <- Cstruct.append flow.o str;
-    Lwt.return_ok (Cstruct.len str) )
+    Lwt.return_ok (Cstruct.len str))
 
 let close flow =
   flow.c <- true;

--- a/test/smart/store_backend.ml
+++ b/test/smart/store_backend.ml
@@ -182,7 +182,7 @@ let preds_of_tree path uid =
         let uid_and_name = String.concat " " uid_and_name in
         match Astring.String.cut ~sep:"\t" uid_and_name with
         | Some (uid, _) -> R.ok uid
-        | None -> R.error_msgf "Invalid line: %S" line )
+        | None -> R.error_msgf "Invalid line: %S" line)
     | _ -> R.error_msgf "Invalid line: %S" line
   in
   let open Bos in
@@ -263,7 +263,7 @@ let get_object_for_packer { return; _ } uid store =
       | Error err ->
           Log.warn (fun m ->
               m "Got an error [get_object_for_packer]: %a" R.pp_msg err);
-          return None )
+          return None)
 
 let get_commit_for_negotiation path (uid : Uid.t) =
   let open Bos in
@@ -304,12 +304,12 @@ let parents :
             | Ok None ->
                 assert false
                 (* XXX(dinosaure): impossible, [git] can not give to us unknown object. *)
-            | Error err -> Stdlib.raise (Failure (Fmt.strf "%a" R.pp_msg err)) )
+            | Error err -> Stdlib.raise (Failure (Fmt.strf "%a" R.pp_msg err)))
       in
       try
         let objs = List.map map uids in
         return objs
-      with Failure err -> failwithf "%s" err )
+      with Failure err -> failwithf "%s" err)
   | Error err ->
       Log.err (fun m -> m "Got an error [parents]: %a" R.pp_msg err);
       failwithf "%a" R.pp_msg err
@@ -379,7 +379,7 @@ let get_commit_for_negotiation { Sigs.return; _ } uid store =
       | Error err ->
           Log.warn (fun m ->
               m "Got an error [get_commit_for_negotiation]: %a" R.pp_msg err);
-          return None )
+          return None)
 
 let safely_rd ~f path =
   Bos.OS.File.with_ic path @@ fun ic a ->

--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -95,8 +95,8 @@ let create_tmp_dir ?(mode = 0o700) ?prefix_path pat =
       in
       try
         Ok
-          ( Unix.mkdir (Fpath.to_string dir) mode;
-            dir )
+          (Unix.mkdir (Fpath.to_string dir) mode;
+           dir)
       with
       | Unix.Unix_error (Unix.EEXIST, _, _) -> loop (count - 1)
       | Unix.Unix_error (Unix.EINTR, _, _) -> loop count
@@ -1124,7 +1124,7 @@ let run_git_upload_pack ?(tmps_exit = true) store ic oc =
             Tmp_dirs.are_valid := tmps_exit;
             Logs.debug (fun m -> m "git-upload-pack terminated properly.");
             exit 1
-        | Error (`Msg err) -> Alcotest.failf "git-upload-pack: %s" err )
+        | Error (`Msg err) -> Alcotest.failf "git-upload-pack: %s" err)
     | _ ->
         Logs.app (fun m -> m "git-upload-pack launched!");
         Lwt.return_unit
@@ -1296,7 +1296,7 @@ let run_git_receive_pack store ic oc =
             Tmp_dirs.are_valid := false;
             Logs.debug (fun m -> m "git-receive-pack terminated properly.");
             exit 1
-        | Error (`Msg err) -> Alcotest.failf "git-upload-pack: %s" err )
+        | Error (`Msg err) -> Alcotest.failf "git-upload-pack: %s" err)
     | _ ->
         Logs.app (fun m -> m "git-receive-pack launched!");
         Lwt.return_unit
@@ -1370,7 +1370,7 @@ let test_push_ssh () =
           Alcotest.failf "refs/heads/master has multiple hashes: %a"
             Fmt.(Dump.list string)
             hashes
-      | Error (`Msg err) -> Alcotest.failf "git-show-ref: %s" err )
+      | Error (`Msg err) -> Alcotest.failf "git-show-ref: %s" err)
   | Error (`Exn exn) -> Alcotest.failf "%s" (Printexc.to_string exn)
   | Error (#Conduit_lwt.error as err) ->
       Alcotest.failf "%a" Conduit_lwt.pp_error err
@@ -1606,7 +1606,7 @@ let test_partial_fetch_ssh () =
             Store_backend.shallowed lwt store1 |> Scheduler.prj
             >>= fun shallowed ->
             Alcotest.(check int) "2 shallowed commits" (List.length shallowed) 2;
-            Lwt.return_ok () )
+            Lwt.return_ok ())
   in
   run () >>= function
   | Ok v -> Lwt.return v

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -16,7 +16,7 @@ let random_reference () =
     let chr = Char.chr (Random.int 256) in
     if not (is_not_refname chr) then (
       Bytes.set res !idx chr;
-      incr idx )
+      incr idx)
   done;
   Git.Reference.v (Bytes.unsafe_to_string res)
 


### PR DESCRIPTION
Hi, this pull-request is a preview of the soon to be released ocamlformat.0.16.0. The main change in the diff is that `indicate-multiline-delimiters` option has now be switched to `no` on the conventional profile to improve consistency and minimize the diffs in the future.
Let me now if you notice any regressions.