### PR TITLE
replace '==' with '=' in 'nss/decoder' and 'ogit-fetch'

### DIFF
--- a/src/git-unix/ogit-fetch/main.ml
+++ b/src/git-unix/ogit-fetch/main.ml
@@ -119,7 +119,7 @@ module Flag = struct
         | s -> Error (`Msg (Fmt.strf "%s is not an output." s))
       in
       let print ppf v =
-        Fmt.pf ppf "%s" (if v == Fmt.stdout then "stdout" else "stderr")
+        Fmt.pf ppf "%s" (if v = Fmt.stdout then "stdout" else "stderr")
       in
       Arg.conv ~docv:"<output>" (parse, print)
     in

--- a/src/not-so-smart/decoder.ml
+++ b/src/not-so-smart/decoder.ml
@@ -276,13 +276,13 @@ let peek_while_eol decoder =
     !idx < end_of_input decoder
     &&
     ( chr := Bytes.unsafe_get decoder.buffer !idx;
-      not (!chr == '\n' && !has_cr) )
+      not (!chr = '\n' && !has_cr) )
   do
-    has_cr := !chr == '\r';
+    has_cr := !chr = '\r';
     incr idx
   done;
 
-  if !idx < end_of_input decoder && !chr == '\n' && !has_cr then (
+  if !idx < end_of_input decoder && !chr = '\n' && !has_cr then (
     assert (!idx + 1 - decoder.pos > 1);
     decoder.buffer, decoder.pos, !idx + 1 - decoder.pos )
   else leave_with decoder `Expected_eol


### PR DESCRIPTION
Changes are in modules that I am working on now. Left `==` uses in `carton` et al. unchanged.