### PR TITLE
Replace 'prelude' with 'uses_git_transport'

### DIFF
--- a/src/not-so-smart/default.ml
+++ b/src/not-so-smart/default.ml
@@ -1,3 +1,8 @@
+(** default[1] negotiator implementation
+
+   [1] "default" as defined in the canonical git implementation in C,
+       see https://github.com/git/git/tree/master/negotiator *)
+
 open Sigs
 
 type ('k, 'p, 't) psq =

--- a/src/not-so-smart/fetch.ml
+++ b/src/not-so-smart/fetch.ml
@@ -69,9 +69,9 @@ struct
         in
         List.fold_left fold [] have |> List.split
 
-  let fetch_v1 ?(prelude = true) ?(push_stdout = ignore) ?(push_stderr = ignore)
-      ~capabilities ?deepen ?want:(refs = `None) ~host path flow store access
-      fetch_cfg pack =
+  let fetch_v1 ?(uses_git_transport = true) ?(push_stdout = ignore)
+      ?(push_stderr = ignore) ~capabilities ?deepen ?want:(refs = `None) ~host
+      path flow store access fetch_cfg pack =
     let capabilities =
       (* XXX(dinosaure): HTTP ([stateless]) enforces no-done capabilities. Otherwise, you never
          will receive the PACK file. *)
@@ -82,7 +82,7 @@ struct
     let prelude ctx =
       let open Smart in
       let* () =
-        if prelude then
+        if uses_git_transport then
           send ctx proto_request
             (Proto_request.upload_pack ~host ~version:1 path)
         else return ()

--- a/src/not-so-smart/fetch.ml
+++ b/src/not-so-smart/fetch.ml
@@ -69,7 +69,7 @@ struct
         in
         List.fold_left fold [] have |> List.split
 
-  let fetch_v1 ?(uses_git_transport = true) ?(push_stdout = ignore)
+  let fetch_v1 ?(uses_git_transport = false) ?(push_stdout = ignore)
       ?(push_stderr = ignore) ~capabilities ?deepen ?want:(refs = `None) ~host
       path flow store access fetch_cfg pack =
     let capabilities =

--- a/src/not-so-smart/fetch.mli
+++ b/src/not-so-smart/fetch.mli
@@ -11,7 +11,7 @@ module Make
     (Uid : UID)
     (Ref : REF) : sig
   val fetch_v1 :
-    ?prelude:bool ->
+    ?uses_git_transport:bool ->
     ?push_stdout:(string -> unit) ->
     ?push_stderr:(string -> unit) ->
     capabilities:Smart.Capability.t list ->

--- a/src/not-so-smart/smart_git.ml
+++ b/src/not-so-smart/smart_git.ml
@@ -411,9 +411,9 @@ struct
         headers;
       }
     in
-    Fetch_http.fetch_v1 ~uses_git_transport:false ~push_stdout ~push_stderr
-      ~capabilities ?deepen ?want ~host:endpoint path flow store access
-      fetch_cfg (fun (payload, off, len) ->
+    Fetch_http.fetch_v1 ~push_stdout ~push_stderr ~capabilities ?deepen ?want
+      ~host:endpoint path flow store access fetch_cfg
+      (fun (payload, off, len) ->
         let v = String.sub payload off len in
         pack (Some (v, 0, len)))
     >>= fun refs ->


### PR DESCRIPTION
Previously, we called a prelude the message sent from the client to server requesting a service. Such a request message is necessary only for `git://` transport, so the code should be more understandable if we give it a more explicit name. 

A note: 

@dinosaure 's comment in the code

```ocaml
(* XXX(dinosaure): [prelude] is the only tweak needed between git:// and SSH. *)
```

in reality means that `prelude` is the only tweak needed between `git://` and (SSH and `file://`), but since we don't support `file://`, the comment is true. Also note that `http://` is quite different from all other transports and is not considered in this context of initial request of service from server.