### PR TITLE
Small refactor decoder

### DIFF
--- a/src/git/sync.mli
+++ b/src/git/sync.mli
@@ -17,6 +17,8 @@
 
 (** The synchronization commands to a git repository. *)
 
+(** [Sync] interface used by backend-specific Git implementations
+    such as [Mem] and [Git_unix] *)
 module type S = sig
   type hash
   type store
@@ -49,6 +51,8 @@ module type S = sig
     (unit, error) result Lwt.t
 end
 
+(** Creates a lower-level [Sync] functions [fetch] and [push] that are then
+        overridden by backend-specific implementations such as [Mem] and [Git_unix] *)
 module Make
     (Digestif : Digestif.S)
     (Pack : Smart_git.APPEND with type +'a fiber = 'a Lwt.t)
@@ -90,10 +94,10 @@ module Make
     Index.t ->
     ((hash * (Reference.t * hash) list) option, [> error ]) result Lwt.t
   (** fetches remote references and saves them.
-      Behavior of fetch when [want] is 
-      [`All] - fetches all remote references and saves them in store 
-      [`Some src_dst_pairs] - fetch [src] and save in [dst] 
-      [`None] - doesn't save anything *)
+          Behavior of fetch when [want] is
+          [`All] - fetches all remote references and saves them in store
+          [`Some src_dst_pairs] - fetch [src] and save in [dst]
+          [`None] - doesn't save anything *)
 
   val push :
     resolvers:Conduit.resolvers ->

--- a/src/not-so-smart/decoder.ml
+++ b/src/not-so-smart/decoder.ml
@@ -132,11 +132,11 @@ let at_least_one_line decoder =
     bytes as hex and converts to int.
     Why unsafe:
     @raise Invalid_argument if there are no 4 bytes to read, i.e.,
-           [decoder.max - decoder.pos < 4]  *)
+                            [decoder.max - decoder.pos < 4]  *)
 let pkt_len_unsafe (decoder : decoder) =
   let hex = Bytes.of_string "0x0000" in
   Bytes.blit decoder.buffer decoder.pos hex 2 4;
-  Bytes.to_string hex |> int_of_string
+  int_of_string (Bytes.unsafe_to_string hex)
 
 (* no header *)
 

--- a/src/not-so-smart/decoder.mli
+++ b/src/not-so-smart/decoder.mli
@@ -40,7 +40,7 @@ type ('v, 'err) state =
 val safe :
   (decoder -> ('v, ([> error ] as 'err)) state) -> decoder -> ('v, 'err) state
 
-val leave_with : decoder -> error -> 'a
+val leave_with : decoder -> error -> 'never
 val fail : decoder -> ([> error ] as 'err) -> ('v, 'err) state
 val return : 'v -> decoder -> ('v, 'err) state
 val peek_char : decoder -> char option

--- a/src/not-so-smart/decoder.mli
+++ b/src/not-so-smart/decoder.mli
@@ -54,4 +54,9 @@ val prompt :
 val peek_while_eol : decoder -> bytes * int * int
 val peek_while_eol_or_space : decoder -> bytes * int * int
 val peek_pkt : decoder -> bytes * int * int
+
 val junk_pkt : decoder -> unit
+(** skip [max(4, pkt_len)], where [pkt_len] is the length of the pkt line starting at
+    [decoder.pos] encoded according to pkt line encoding (as hex in the first 4 bytes);
+
+    @raise Invalid_argument if there aren't 4 bytes representing the length *)

--- a/src/not-so-smart/decoder.mli
+++ b/src/not-so-smart/decoder.mli
@@ -26,6 +26,8 @@ val pp_error : error Fmt.t
 
 type 'err info = { error : 'err; buffer : bytes; committed : int }
 
+exception Leave of error info
+
 type ('v, 'err) state =
   | Done of 'v
   | Read of {
@@ -41,6 +43,10 @@ val safe :
   (decoder -> ('v, ([> error ] as 'err)) state) -> decoder -> ('v, 'err) state
 
 val leave_with : decoder -> error -> 'never
+(** [leave_with d error] raises [Leave { error; buffer = d.buffer; committed = d.pos }]
+
+    @raise Leave *)
+
 val fail : decoder -> ([> error ] as 'err) -> ('v, 'err) state
 val return : 'v -> decoder -> ('v, 'err) state
 val peek_char : decoder -> char option

--- a/src/not-so-smart/decoder.mli
+++ b/src/not-so-smart/decoder.mli
@@ -39,13 +39,15 @@ type ('v, 'err) state =
     }
   | Error of 'err info
 
-val safe :
-  (decoder -> ('v, ([> error ] as 'err)) state) -> decoder -> ('v, 'err) state
-
 val leave_with : decoder -> error -> 'never
 (** [leave_with d error] raises [Leave { error; buffer = d.buffer; committed = d.pos }]
 
-    @raise Leave *)
+  @raise Leave *)
+
+val safe :
+  (decoder -> ('v, ([> error ] as 'err)) state) -> decoder -> ('v, 'err) state
+(** [safe k decoder] wraps a call [k decoder] in a try-with block;
+    if exception [Leave err] is raised, the function returns [Error of err] *)
 
 val fail : decoder -> ([> error ] as 'err) -> ('v, 'err) state
 val return : 'v -> decoder -> ('v, 'err) state

--- a/src/not-so-smart/dune
+++ b/src/not-so-smart/dune
@@ -1,8 +1,15 @@
 (library
+ (name pkt_line)
+ (public_name git-nss.pkt-line)
+ (modules decoder encoder)
+ (libraries astring fmt))
+
+(library
  (name smart)
  (public_name git-nss.smart)
- (modules smart filter capability state protocol encoder decoder)
- (libraries conduit stdlib-shims result rresult domain-name astring fmt))
+ (modules smart filter capability state protocol)
+ (libraries git-nss.pkt-line conduit stdlib-shims result rresult domain-name
+   astring fmt))
 
 (library
  (name sigs)

--- a/src/not-so-smart/fetch.ml
+++ b/src/not-so-smart/fetch.ml
@@ -37,21 +37,23 @@ struct
   let return x = IO.return x
 
   let sched =
-    {
-      Sigs.bind = (fun x f -> inj (prj x >>= fun x -> prj (f x)));
-      Sigs.return = (fun x -> inj (return x));
-    }
+    Sigs.
+      {
+        bind = (fun x f -> inj (prj x >>= fun x -> prj (f x)));
+        return = (fun x -> inj (return x));
+      }
 
   let fail exn =
     let fail = IO.fail exn in
     inj fail
 
   let io =
-    {
-      Sigs.recv = (fun flow raw -> inj (Flow.recv flow raw));
-      Sigs.send = (fun flow raw -> inj (Flow.send flow raw));
-      Sigs.pp_error = Flow.pp_error;
-    }
+    Sigs.
+      {
+        recv = (fun flow raw -> inj (Flow.recv flow raw));
+        send = (fun flow raw -> inj (Flow.send flow raw));
+        pp_error = Flow.pp_error;
+      }
 
   let references want have =
     match want with

--- a/src/not-so-smart/protocol.mli
+++ b/src/not-so-smart/protocol.mli
@@ -141,10 +141,10 @@ module Status : sig
 end
 
 module Decoder : sig
-  open Decoder
+  open Pkt_line.Decoder
 
-  type error =
-    [ Decoder.error
+  type nonrec error =
+    [ error
     | `Invalid_advertised_ref of string
     | `Invalid_shallow of string
     | `Invalid_negotiation_result of string
@@ -177,9 +177,9 @@ module Decoder : sig
 end
 
 module Encoder : sig
-  open Encoder
+  open Pkt_line.Encoder
 
-  type error = Encoder.error
+  type nonrec error = error
 
   val pp_error : error Fmt.t
   val encode_proto_request : encoder -> Proto_request.t -> error state

--- a/src/not-so-smart/smart.ml
+++ b/src/not-so-smart/smart.ml
@@ -37,6 +37,8 @@ module Witness = struct
 end
 
 module Value = struct
+  open Pkt_line
+
   type encoder = Encoder.encoder
   type decoder = Decoder.decoder
 

--- a/src/not-so-smart/state.ml
+++ b/src/not-so-smart/state.ml
@@ -35,6 +35,8 @@ module type S = sig
 end
 
 module Context = struct
+  open Pkt_line
+
   type t = {
     encoder : Encoder.encoder;
     decoder : Decoder.decoder;

--- a/src/not-so-smart/state.mli
+++ b/src/not-so-smart/state.mli
@@ -33,6 +33,8 @@ module type S = sig
 end
 
 module Context : sig
+  open Pkt_line
+
   include
     CONTEXT
       with type encoder = Encoder.encoder


### PR DESCRIPTION
- added some docs
- moved `nss/decoder.ml/i` and `nss/encoder.ml/i` to `git-nss.pkt-line` lib to be able to re-use it in wire protocol v2
- made some refactorings (would appreciate your comment if I'm using `Bytes.unsafe_of_string` correctly)

- there are a couple of functions that are defined but not used, which I could remove, but that's up to you

- I can also revert some commits if you don't like them