### PR TITLE
Constraint to use, at least, fmt.0.8.7

### DIFF
--- a/carton-git.opam
+++ b/carton-git.opam
@@ -29,7 +29,7 @@ depends: [
   "fpath"
   "result"
   "mmap"
-  "fmt"
+  "fmt"        {>= "0.8.7"}
   "base-unix"
   "decompress" {>= "1.2.0"}
 ]

--- a/carton.opam
+++ b/carton.opam
@@ -33,7 +33,7 @@ depends: [
   "logs"
   "bigstringaf"
   "psq"          {>= "0.2.0"}
-  "fmt"
+  "fmt"          {>= "0.8.7"}
   "result"       {with-test}
   "rresult"      {with-test}
   "fpath"        {with-test}

--- a/git-nss.opam
+++ b/git-nss.opam
@@ -21,11 +21,10 @@ depends: [
   "stdlib-shims"
   "rresult"
   "result"
-  "fmt"
+  "fmt"               {>= "0.8.7"}
   "cstruct"           {>= "5.0.0"}
   "domain-name"
   "astring"
-  "fmt"
   "logs"
   "psq"               {>= "0.2.0"}
   "carton"

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -27,7 +27,7 @@ depends: [
   "result"
   "bigarray-compat"
   "bigstringaf"
-  "fmt"
+  "fmt"               {>= "0.8.7"}
   "git-nss"
   "bos"
   "fpath"

--- a/git.opam
+++ b/git.opam
@@ -43,7 +43,7 @@ depends: [
   "carton-lwt"
   "carton-git"
   "ke"                {>= "0.4"}
-  "fmt"
+  "fmt"               {>= "0.8.7"}
   "checkseum"         {>= "0.2.1"}
   "ocamlgraph"        {>= "1.8.8"}
   "astring"


### PR DESCRIPTION
Follow #421 and constraint packages to use, at least, `fmt.0.8.7` (which added the deprecation).