### PR TITLE
Delete the useless verify function and start an SSH connection with a pre-condition over the given Smart_git.Endpoint.t

### DIFF
--- a/src/git-mirage/git_mirage.mli
+++ b/src/git-mirage/git_mirage.mli
@@ -7,9 +7,14 @@ module Make
     end) : sig
   val git_path : string Mimic.value
   val git_capabilities : [ `Rd | `Wr ] Mimic.value
+  val git_scheme : [ `Git | `SSH | `HTTP | `HTTPS ] Mimic.value
   val with_git_path : string -> Mimic.ctx -> Mimic.ctx
   val fetch : Mimic.ctx -> Mimic.ctx
   val push : Mimic.ctx -> Mimic.ctx
+  val gri : Mimic.ctx -> Mimic.ctx
+  val ssh : Mimic.ctx -> Mimic.ctx
+  val http : Mimic.ctx -> Mimic.ctx
+  val https : Mimic.ctx -> Mimic.ctx
   val with_resolv : Mimic.ctx -> Mimic.ctx
   val ctx : Mimic.ctx
   val with_smart_git_endpoint : string -> Mimic.ctx -> Mimic.ctx

--- a/src/git-mirage/git_mirage_ssh.mli
+++ b/src/git-mirage/git_mirage_ssh.mli
@@ -18,6 +18,7 @@ module Make
     end) (Git : sig
       val git_path : string Mimic.value
       val git_capabilities : [ `Rd | `Wr ] Mimic.value
+      val git_scheme : [ `Git | `SSH | `HTTP | `HTTPS ] Mimic.value
     end)
     (Mclock : Mirage_clock.MCLOCK) : sig
   type nonrec endpoint = Stack.t endpoint

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -717,8 +717,8 @@ module Sync (Git_store : Git.S) (HTTP : Smart_git.HTTP) = struct
     Lwt.async fill;
     fun () -> Lwt_stream.get stream
 
-  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ~ctx ?verify edn
-      store ?version ?capabilities ?deepen want =
+  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ~ctx edn store
+      ?version ?capabilities ?deepen want =
     let dotgit = Git_store.dotgit store in
     let temp = Fpath.(dotgit / "tmp") in
     tmp temp "pack-%s.pack" >>= fun src ->
@@ -726,7 +726,7 @@ module Sync (Git_store : Git.S) (HTTP : Smart_git.HTTP) = struct
     tmp temp "pack-%s.idx" >>= fun idx ->
     let create_idx_stream () = stream_of_file idx in
     let create_pack_stream () = stream_of_file dst in
-    fetch ~push_stdout ~push_stderr ~ctx ?verify edn store ?version
-      ?capabilities ?deepen want ~src ~dst ~idx ~create_idx_stream
-      ~create_pack_stream temp temp
+    fetch ~push_stdout ~push_stderr ~ctx edn store ?version ?capabilities
+      ?deepen want ~src ~dst ~idx ~create_idx_stream ~create_pack_stream temp
+      temp
 end

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -473,8 +473,8 @@ module Sync (Git_store : Minimal.S) (HTTP : Smart_git.HTTP) = struct
     Lwt.async fill;
     fun () -> Lwt_stream.get stream
 
-  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ~ctx ?verify edn
-      store ?version ?capabilities ?deepen want =
+  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ~ctx edn store
+      ?version ?capabilities ?deepen want =
     let t_idx = Carton.Dec.Idx.Device.device () in
     let t_pck = Cstruct_append.device () in
     let index = Carton.Dec.Idx.Device.create t_idx in
@@ -489,7 +489,7 @@ module Sync (Git_store : Minimal.S) (HTTP : Smart_git.HTTP) = struct
       let pack = Cstruct_append.project t_pck dst in
       stream_of_cstruct pack
     in
-    fetch ~push_stdout ~push_stderr ~ctx ?verify edn store ?version
-      ?capabilities ?deepen want ~src ~dst ~idx:index ~create_idx_stream
-      ~create_pack_stream t_pck t_idx
+    fetch ~push_stdout ~push_stderr ~ctx edn store ?version ?capabilities
+      ?deepen want ~src ~dst ~idx:index ~create_idx_stream ~create_pack_stream
+      t_pck t_idx
 end

--- a/src/git/sync.mli
+++ b/src/git/sync.mli
@@ -30,7 +30,6 @@ module type S = sig
     ?push_stdout:(string -> unit) ->
     ?push_stderr:(string -> unit) ->
     ctx:Mimic.ctx ->
-    ?verify:(Smart_git.Endpoint.t -> Mimic.flow -> (unit, error) result Lwt.t) ->
     Smart_git.Endpoint.t ->
     store ->
     ?version:[> `V1 ] ->
@@ -41,7 +40,6 @@ module type S = sig
 
   val push :
     ctx:Mimic.ctx ->
-    ?verify:(Smart_git.Endpoint.t -> Mimic.flow -> (unit, error) result Lwt.t) ->
     Smart_git.Endpoint.t ->
     store ->
     ?version:[> `V1 ] ->
@@ -71,7 +69,6 @@ module Make
     ?push_stdout:(string -> unit) ->
     ?push_stderr:(string -> unit) ->
     ctx:Mimic.ctx ->
-    ?verify:(Smart_git.Endpoint.t -> Mimic.flow -> (unit, 'err) result Lwt.t) ->
     Smart_git.Endpoint.t ->
     store ->
     ?version:[> `V1 ] ->
@@ -99,7 +96,6 @@ module Make
 
   val push :
     ctx:Mimic.ctx ->
-    ?verify:(Smart_git.Endpoint.t -> Mimic.flow -> (unit, 'err) result Lwt.t) ->
     Smart_git.Endpoint.t ->
     store ->
     ?version:[> `V1 ] ->

--- a/src/not-so-smart/smart_git.mli
+++ b/src/not-so-smart/smart_git.mli
@@ -77,7 +77,6 @@ module Make
     ?push_stdout:(string -> unit) ->
     ?push_stderr:(string -> unit) ->
     ctx:Mimic.ctx ->
-    ?verify:(Endpoint.t -> Mimic.flow -> (unit, 'err) result Lwt.t) ->
     (Uid.t, _, Uid.t * int ref * int64, 'g, Scheduler.t) Sigs.access
     * Uid.t Carton_lwt.Thin.light_load
     * Uid.t Carton_lwt.Thin.heavy_load ->
@@ -99,7 +98,6 @@ module Make
 
   val push :
     ctx:Mimic.ctx ->
-    ?verify:(Endpoint.t -> Mimic.flow -> (unit, 'err) result Lwt.t) ->
     (Uid.t, Ref.t, Uid.t Pck.t, 'g, Scheduler.t) Sigs.access
     * Uid.t Carton_lwt.Thin.light_load
     * Uid.t Carton_lwt.Thin.heavy_load ->

--- a/unikernel/unikernel.ml
+++ b/unikernel/unikernel.ml
@@ -25,7 +25,7 @@ struct
       | Smart_git.Endpoint.{ scheme= `SSH _; _ } ->
         if is_ssh flow then Lwt.return_ok () else Lwt.return_error (`Exn Invalid_flow)
       | _ -> if not (is_ssh flow) then Lwt.return_ok () else Lwt.return_error (`Exn Invalid_flow) in
-    Sync.fetch ~ctx ~verify edn git ~deepen:(`Depth 1) `All >>= function
+    Sync.fetch ~ctx edn git ~deepen:(`Depth 1) `All >>= function
     | Ok (Some (hash, references)) -> Lwt.return_unit
     | Ok None -> Lwt.return_unit
     | Error err -> Fmt.failwith "%a" Sync.pp_error err


### PR DESCRIPTION
No regression here, I tested the unikernel locally and even if the user gives to use an SSH key with a GRI remote, we start a GRI (with the prelude) connection. /cc @ulugbekna 