### PR TITLE
Handle IPv4 when the user gives git@[IPv4]:path as the remote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="mimic.dev:. carton.dev:. carton-lwt.dev:. carton-git.dev:. git-nss.dev:. git.dev:. git-unix.dev:. git-cohttp.dev:. git-cohttp-unix.dev:. git-mirage.dev:. git-cohttp-mirage.dev:."
+    - PINS="mimic.dev:. carton.dev:. carton-lwt.dev:. carton-git.dev:. git.dev:. git-unix.dev:. git-cohttp.dev:. git-cohttp-unix.dev:. git-mirage.dev:. git-cohttp-mirage.dev:."
   matrix:
     - OCAML_VERSION=4.08 PACKAGE="git.dev"
     - OCAML_VERSION=4.09 PACKAGE="git.dev"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     FORK_BRANCH: master
     CYG_ROOT: C:\cygwin64
     OPAM_SWITCH: 4.08.1+mingw64c
-    PINS: "mimic.dev:. carton.dev:. carton-lwt.dev:. carton-git.dev:. git-nss.dev:. git.dev:. git-cohttp.dev:. git-cohttp-unix.dev:. git-unix.dev:."
+    PINS: "mimic.dev:. carton.dev:. carton-lwt.dev:. carton-git.dev:. git.dev:. git-cohttp.dev:. git-cohttp-unix.dev:. git-unix.dev:."
   matrix:
   - PACKAGE: "git.dev"
   - PACKAGE: "git-unix.dev"

--- a/src/git-mirage/git_mirage_dns.ml
+++ b/src/git-mirage/git_mirage_dns.ml
@@ -27,6 +27,11 @@ struct
 
   let with_smart_git_endpoint edn ctx =
     match Smart_git.Endpoint.of_string edn with
-    | Ok { Smart_git.Endpoint.host; _ } -> with_domain_name host ctx
+    | Ok { Smart_git.Endpoint.host = `Domain host; _ } ->
+        with_domain_name host ctx
+    | Ok { Smart_git.Endpoint.host = `Addr (Ipaddr.V4 v); _ } ->
+        Mimic.add TCP.tcp_ipaddr v ctx
+    | Ok { Smart_git.Endpoint.host = `Addr (Ipaddr.V6 _); _ } ->
+        assert false (* TODO *)
     | _ -> ctx
 end

--- a/src/not-so-smart/dune
+++ b/src/not-so-smart/dune
@@ -8,8 +8,8 @@
  (name smart)
  (public_name git.nss.smart)
  (modules smart filter capability state protocol)
- (libraries git.nss.pkt-line stdlib-shims result rresult domain-name astring
-   fmt))
+ (libraries git.nss.pkt-line stdlib-shims result rresult ipaddr domain-name
+   astring fmt))
 
 (library
  (name sigs)
@@ -39,7 +39,7 @@
  (name nss)
  (public_name git.nss)
  (modules nss fetch push)
- (libraries fmt result rresult logs domain-name smart sigs neg pck))
+ (libraries fmt result rresult logs ipaddr domain-name smart sigs neg pck))
 
 (library
  (name unixiz)

--- a/src/not-so-smart/fetch.mli
+++ b/src/not-so-smart/fetch.mli
@@ -17,7 +17,7 @@ module Make
     capabilities:Smart.Capability.t list ->
     ?deepen:[ `Depth of int | `Timestamp of int64 ] ->
     ?want:[ `All | `Some of Ref.t list | `None ] ->
-    host:[ `host ] Domain_name.t ->
+    host:[ `Addr of Ipaddr.t | `Domain of [ `host ] Domain_name.t ] ->
     string ->
     Flow.t ->
     (Uid.t, Uid.t * int ref * int64, 'g) store ->

--- a/src/not-so-smart/protocol.mli
+++ b/src/not-so-smart/protocol.mli
@@ -48,10 +48,18 @@ module Proto_request : sig
   val pp : t Fmt.t
 
   val upload_pack :
-    host:[ `host ] Domain_name.t -> ?port:int -> ?version:int -> string -> t
+    host:[ `Addr of Ipaddr.t | `Domain of [ `host ] Domain_name.t ] ->
+    ?port:int ->
+    ?version:int ->
+    string ->
+    t
 
   val receive_pack :
-    host:[ `host ] Domain_name.t -> ?port:int -> ?version:int -> string -> t
+    host:[ `Addr of Ipaddr.t | `Domain of [ `host ] Domain_name.t ] ->
+    ?port:int ->
+    ?version:int ->
+    string ->
+    t
 end
 
 module Want : sig

--- a/src/not-so-smart/push.mli
+++ b/src/not-so-smart/push.mli
@@ -14,7 +14,7 @@ module Make
     ?prelude:bool ->
     capabilities:Smart.Capability.t list ->
     [ `Create of Ref.t | `Delete of Ref.t | `Update of Ref.t * Ref.t ] list ->
-    host:[ `host ] Domain_name.t ->
+    host:[ `Addr of Ipaddr.t | `Domain of [ `host ] Domain_name.t ] ->
     string ->
     Flow.t ->
     (Uid.t, Uid.t Pck.t, 'git) store ->

--- a/src/not-so-smart/smart.mli
+++ b/src/not-so-smart/smart.mli
@@ -56,10 +56,18 @@ module Proto_request : sig
   val pp : t Fmt.t
 
   val upload_pack :
-    host:[ `host ] Domain_name.t -> ?port:int -> ?version:int -> string -> t
+    host:[ `Addr of Ipaddr.t | `Domain of [ `host ] Domain_name.t ] ->
+    ?port:int ->
+    ?version:int ->
+    string ->
+    t
 
   val receive_pack :
-    host:[ `host ] Domain_name.t -> ?port:int -> ?version:int -> string -> t
+    host:[ `Addr of Ipaddr.t | `Domain of [ `host ] Domain_name.t ] ->
+    ?port:int ->
+    ?version:int ->
+    string ->
+    t
 end
 
 module Want : sig

--- a/src/not-so-smart/smart_git.ml
+++ b/src/not-so-smart/smart_git.ml
@@ -64,19 +64,29 @@ module Endpoint = struct
       | `HTTP of (string * string) list
       | `HTTPS of (string * string) list ];
     path : string;
-    host : [ `host ] Domain_name.t;
+    host : [ `Addr of Ipaddr.t | `Domain of [ `host ] Domain_name.t ];
   }
 
   let pp ppf edn =
+    let pp_host ppf = function
+      | `Addr v -> Ipaddr.pp ppf v
+      | `Domain v -> Domain_name.pp ppf v
+    in
     match edn with
     | { scheme = `SSH user; path; host } ->
-        Fmt.pf ppf "%s@%a:%s" user Domain_name.pp host path
+        Fmt.pf ppf "%s@%a:%s" user pp_host host path
     | { scheme = `Git; path; host } ->
-        Fmt.pf ppf "git://%a/%s" Domain_name.pp host path
+        Fmt.pf ppf "git://%a/%s" pp_host host path
     | { scheme = `HTTP _; path; host } ->
-        Fmt.pf ppf "http://%a/%s" Domain_name.pp host path
+        Fmt.pf ppf "http://%a/%s" pp_host host path
     | { scheme = `HTTPS _; path; host } ->
-        Fmt.pf ppf "https://%a/%s" Domain_name.pp host path
+        Fmt.pf ppf "https://%a/%s" pp_host host path
+
+  let ( <|> ) a b =
+    match a, b with
+    | Ok a, _ -> Ok a
+    | Error _, Ok b -> Ok b
+    | Error err, _ -> Error err
 
   let of_string str =
     let open Rresult in
@@ -96,24 +106,33 @@ module Endpoint = struct
                  m.Emile.local)
           in
           (match fst m.Emile.domain with
-          | `Domain vs -> Domain_name.of_strings vs >>= Domain_name.host
-          | `Literal v -> Domain_name.of_string v >>= Domain_name.host
+          | `Domain vs ->
+              Domain_name.of_strings vs >>= Domain_name.host >>| fun v ->
+              `Domain v
+          | `Literal v ->
+              Domain_name.of_string v >>= Domain_name.host >>| fun v ->
+              `Domain v
+          | `Addr (Emile.IPv4 v) -> R.ok (`Addr (Ipaddr.V4 v))
+          | `Addr (Emile.IPv6 v) -> R.ok (`Addr (Ipaddr.V6 v))
           | v -> R.error_msgf "Invalid hostname: %a" Emile.pp_domain v)
           >>= fun host -> R.ok { scheme = `SSH user; path; host }
       | _ -> R.error_msg "invalid pattern"
     in
     let parse_uri x =
       let uri = Uri.of_string x in
+      let host str =
+        Domain_name.of_string str
+        >>= Domain_name.host
+        >>| (fun x -> `Domain x)
+        <|> (Ipaddr.of_string str >>| fun x -> `Addr x)
+      in
       match Uri.scheme uri, Uri.host uri, Uri.path uri with
-      | Some "git", Some host, path ->
-          Domain_name.of_string host >>= Domain_name.host >>= fun host ->
-          R.ok { scheme = `Git; path; host }
-      | Some "http", Some host, path ->
-          Domain_name.of_string host >>= Domain_name.host >>= fun host ->
-          R.ok { scheme = `HTTP []; path; host }
-      | Some "https", Some host, path ->
-          Domain_name.of_string host >>= Domain_name.host >>= fun host ->
-          R.ok { scheme = `HTTPS []; path; host }
+      | Some "git", Some str, path ->
+          host str >>= fun host -> R.ok { scheme = `Git; path; host }
+      | Some "http", Some str, path ->
+          host str >>= fun host -> R.ok { scheme = `HTTP []; path; host }
+      | Some "https", Some str, path ->
+          host str >>= fun host -> R.ok { scheme = `HTTPS []; path; host }
       | _ -> R.error_msgf "invalid uri: %a" Uri.pp uri
     in
     match parse_ssh str, parse_uri str with
@@ -315,7 +334,6 @@ struct
   let fetch_v1 ?(uses_git_transport = false) ~push_stdout ~push_stderr
       ~capabilities path ~ctx ?deepen ?want host store access fetch_cfg pack =
     let open Lwt.Infix in
-    Log.debug (fun m -> m "Try to resolve %a." Domain_name.pp host);
     Mimic.resolve ctx >>= function
     | Error _ as err ->
         pack None;
@@ -446,15 +464,17 @@ struct
           let fetch_cfg =
             Nss.Fetch.configuration ~stateless:true capabilities
           in
+          let pp_host ppf = function
+            | `Domain v -> Domain_name.pp ppf v
+            | `Addr v -> Ipaddr.pp ppf v
+          in
           let uri, headers =
             match scheme with
             | `HTTP headers ->
-                ( Uri.of_string
-                    (Fmt.str "http://%a%s.git" Domain_name.pp host path),
+                ( Uri.of_string (Fmt.str "http://%a%s.git" pp_host host path),
                   headers )
             | `HTTPS headers ->
-                ( Uri.of_string
-                    (Fmt.str "https://%a%s.git" Domain_name.pp host path),
+                ( Uri.of_string (Fmt.str "https://%a%s.git" pp_host host path),
                   headers )
           in
           let run () =

--- a/src/not-so-smart/smart_git.mli
+++ b/src/not-so-smart/smart_git.mli
@@ -55,7 +55,7 @@ module Endpoint : sig
       | `HTTP of (string * string) list
       | `HTTPS of (string * string) list ];
     path : string;
-    host : [ `host ] Domain_name.t;
+    host : [ `Addr of Ipaddr.t | `Domain of [ `host ] Domain_name.t ];
   }
 
   val pp : t Fmt.t

--- a/test/smart/dune
+++ b/test/smart/dune
@@ -17,6 +17,8 @@
 (rule
  (alias runtest)
  (package git-unix)
+ (enabled_if
+  (= %{os_type} "Unix"))
  (deps
   (:test test.exe)
   pack-testzone-0.pack

--- a/test/smart/dune
+++ b/test/smart/dune
@@ -1,11 +1,18 @@
 (executable
  (name test)
+ (modules append fifo hTTP loopback lwt_backend lwt_io ref store_backend test
+   uid unix_backend)
  (libraries mirage-flow mimic git.nss.unixiz git git-unix result curl.lwt
    mirage-crypto-rng.unix digestif digestif.c domain-name git.nss.git bos
    fpath bigarray-compat carton-lwt bigstringaf git.nss.sigs git.nss.hkt fmt
    git.nss.pck carton rresult alcotest git.nss.smart lwt.unix mmap astring
    lwt cstruct uri fmt.tty logs.fmt alcotest-lwt cohttp-lwt-unix
    git-cohttp-unix))
+
+(executable
+ (name test_edn)
+ (modules test_edn)
+ (libraries alcotest fmt ipaddr domain-name git.nss.git))
 
 (rule
  (alias runtest)
@@ -18,5 +25,13 @@
   pack-testzone-1.idx
   GET
   POST)
+ (action
+  (run %{test} --color=always)))
+
+(rule
+ (alias runtest)
+ (package git)
+ (deps
+  (:test test_edn.exe))
  (action
   (run %{test} --color=always)))

--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -1630,4 +1630,15 @@ let test =
         ] );
     ]
 
-let () = Lwt_main.run test
+let tmp = "tmp"
+
+let () =
+  let open Rresult in
+  let fiber =
+    Bos.OS.Dir.current () >>= fun current ->
+    Bos.OS.Dir.create Fpath.(current / tmp) >>= fun _ ->
+    R.ok Fpath.(current / tmp)
+  in
+  let tmp = R.failwith_error_msg fiber in
+  Bos.OS.Dir.set_default_tmp tmp;
+  Lwt_main.run test

--- a/test/smart/test_edn.ml
+++ b/test/smart/test_edn.ml
@@ -1,0 +1,87 @@
+let domain_name = Alcotest.testable Domain_name.pp Domain_name.equal
+let ipaddr = Alcotest.testable Ipaddr.pp (fun a b -> Ipaddr.compare a b = 0)
+let ( <.> ) f g x = f (g x)
+let github_com = Domain_name.(host_exn <.> of_string_exn) "github.com"
+let private_network = Ipaddr.of_string_exn "10.0.0.0"
+
+let test01 =
+  Alcotest.test_case "edn01" `Quick @@ fun () ->
+  match Smart_git.Endpoint.of_string "git@github.com:mirage/ocaml.git" with
+  | Ok
+      {
+        Smart_git.Endpoint.scheme = `SSH "git";
+        host = `Domain v;
+        path = "mirage/ocaml.git";
+      } ->
+      Alcotest.(check domain_name) "github.com" v github_com
+  | Ok v -> Alcotest.failf "Unexpected Git endpoint: %a" Smart_git.Endpoint.pp v
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
+
+let test02 =
+  Alcotest.test_case "edn02" `Quick @@ fun () ->
+  match Smart_git.Endpoint.of_string "git@10.0.0.0:mirage/ocaml.git" with
+  | Ok
+      {
+        Smart_git.Endpoint.scheme = `SSH "git";
+        host = `Addr v;
+        path = "mirage/ocaml.git";
+      } ->
+      Alcotest.(check ipaddr) "10.0.0.0" v private_network
+  | Ok v -> Alcotest.failf "Unexpeted Git endpoint: %a" Smart_git.Endpoint.pp v
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
+
+let test03 =
+  Alcotest.test_case "edn03" `Quick @@ fun () ->
+  match Smart_git.Endpoint.of_string "git@[10.0.0.0]:mirage/ocaml.git" with
+  | Ok
+      {
+        Smart_git.Endpoint.scheme = `SSH "git";
+        host = `Addr v;
+        path = "mirage/ocaml.git";
+      } ->
+      Alcotest.(check ipaddr) "10.0.0.0" v private_network
+  | Ok v -> Alcotest.failf "Unexpeted Git endpoint: %a" Smart_git.Endpoint.pp v
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
+
+let test04 =
+  Alcotest.test_case "edn04" `Quick @@ fun () ->
+  match Smart_git.Endpoint.of_string "git://github.com/mirage/ocaml.git" with
+  | Ok
+      {
+        Smart_git.Endpoint.scheme = `Git;
+        host = `Domain v;
+        path = "mirage/ocaml.git";
+      } ->
+      Alcotest.(check domain_name) "github.com" v github_com
+  | Ok v -> Alcotest.failf "Unexpeted Git endpoint: %a" Smart_git.Endpoint.pp v
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
+
+let test05 =
+  Alcotest.test_case "edn05" `Quick @@ fun () ->
+  match Smart_git.Endpoint.of_string "http://github.com/mirage/ocaml.git" with
+  | Ok
+      {
+        Smart_git.Endpoint.scheme = `HTTP [];
+        host = `Domain v;
+        path = "mirage/ocaml.git";
+      } ->
+      Alcotest.(check domain_name) "github.com" v github_com
+  | Ok v -> Alcotest.failf "Unexpeted Git endpoint: %a" Smart_git.Endpoint.pp v
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
+
+let test06 =
+  Alcotest.test_case "edn06" `Quick @@ fun () ->
+  match Smart_git.Endpoint.of_string "http://10.0.0.0/mirage/ocaml.git" with
+  | Ok
+      {
+        Smart_git.Endpoint.scheme = `HTTP [];
+        host = `Addr v;
+        path = "mirage/ocaml.git";
+      } ->
+      Alcotest.(check ipaddr) "10.0.0.0" v private_network
+  | Ok v -> Alcotest.failf "Unexpeted Git endpoint: %a" Smart_git.Endpoint.pp v
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
+
+let () =
+  Alcotest.run "smart git endpoint"
+    [ "endpoint", [ test01; test02; test03; test04; test05; test06 ] ]

--- a/unikernel/unikernel.ml
+++ b/unikernel/unikernel.ml
@@ -5,13 +5,14 @@ module Make
     (Time : Mirage_time.S)
     (Console : Mirage_console.S)
     (Resolver : Resolver_lwt.S)
-    (Conduit : Conduit_mirage.S) (_ : sig end) (_ : sig end) =
+    (Conduit : Conduit_mirage.S)
+    (_ : sig end) =
 struct
   module Sync = Git.Mem.Sync (Store) (Git_cohttp_mirage)
 
   exception Invalid_flow
 
-  let start git time console resolver conduit ctx is_ssh =
+  let start git time console resolver conduit ctx =
     let ctx =
       Git_cohttp_mirage.with_conduit
         (Cohttp_mirage.Client.ctx resolver conduit)
@@ -21,10 +22,6 @@ struct
       match Smart_git.Endpoint.of_string (Key_gen.remote ()) with
       | Ok edn -> edn
       | Error (`Msg err) -> failwith err in
-    let verify edn flow = match edn with
-      | Smart_git.Endpoint.{ scheme= `SSH _; _ } ->
-        if is_ssh flow then Lwt.return_ok () else Lwt.return_error (`Exn Invalid_flow)
-      | _ -> if not (is_ssh flow) then Lwt.return_ok () else Lwt.return_error (`Exn Invalid_flow) in
     Sync.fetch ~ctx edn git ~deepen:(`Depth 1) `All >>= function
     | Ok (Some (hash, references)) -> Lwt.return_unit
     | Ok None -> Lwt.return_unit


### PR DESCRIPTION
A minor patch (followed by a release) to be able to gives to an unikernel something like: `git@[10.0.0.1]:path` (mostly when we want to start a primary DNS server.