### PR TITLE
git-unix: make index and regression test work without global gitconfig

### DIFF
--- a/test/index/test.ml
+++ b/test/index/test.ml
@@ -183,6 +183,11 @@ let delete_should_be_empty =
   let run path =
     let open Rresult in
     Bos.OS.Dir.with_current path @@ fun () ->
+    Bos.OS.Cmd.run Bos.Cmd.(v "git" % "config" % "user.name" % "test")
+    >>= fun () ->
+    Bos.OS.Cmd.run
+      Bos.Cmd.(v "git" % "config" % "user.email" % "pseudo@pseudo.invalid")
+    >>= fun () ->
     Bos.OS.Cmd.run Bos.Cmd.(v "git" % "commit" % "-m" % ".") >>= fun () ->
     load ~hash:SHA1 Fpath.(v ".git" / "index") >>= fun t ->
     (* XXX(dinosaure): [git] deletes [should-be-empty] into the index file **AND**

--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -385,6 +385,11 @@ let commit_foo store =
   let commit =
     let open Rresult in
     Bos.OS.Dir.with_current path @@ fun () ->
+    Bos.OS.Cmd.run Bos.Cmd.(v "git" % "config" % "user.name" % "test")
+    >>= fun () ->
+    Bos.OS.Cmd.run
+      Bos.Cmd.(v "git" % "config" % "user.email" % "pseudo@pseudo.invalid")
+    >>= fun () ->
     Bos.OS.File.write (Fpath.v "foo") "" >>= fun () ->
     Bos.OS.Cmd.run Bos.Cmd.(v "git" % "add" % "foo") >>= fun () ->
     Bos.OS.Cmd.run Bos.Cmd.(v "git" % "commit" % "-m" % ".") >>= fun () ->
@@ -1490,6 +1495,11 @@ let test_partial_fetch_ssh () =
     let fiber =
       let open Rresult in
       OS.Dir.with_current path @@ fun () ->
+      OS.Cmd.run Bos.Cmd.(v "git" % "config" % "user.name" % "test")
+      >>= fun () ->
+      OS.Cmd.run
+        Bos.Cmd.(v "git" % "config" % "user.email" % "pseudo@pseudo.invalid")
+      >>= fun () ->
       OS.Cmd.run Cmd.(v "touch" % "foo") >>= fun () ->
       OS.Cmd.run Cmd.(v "git" % "add" % "foo") >>= fun () ->
       OS.Cmd.run Cmd.(v "git" % "commit" % "-m" % ".")
@@ -1503,6 +1513,11 @@ let test_partial_fetch_ssh () =
     let fiber =
       let open Rresult in
       OS.Dir.with_current path @@ fun () ->
+      OS.Cmd.run Bos.Cmd.(v "git" % "config" % "user.name" % "test")
+      >>= fun () ->
+      OS.Cmd.run
+        Bos.Cmd.(v "git" % "config" % "user.email" % "pseudo@pseudo.invalid")
+      >>= fun () ->
       OS.Cmd.run Cmd.(v "touch" % "bar") >>= fun () ->
       OS.Cmd.run Cmd.(v "git" % "add" % "bar") >>= fun () ->
       OS.Cmd.run Cmd.(v "git" % "commit" % "-m" % ".") >>= fun () ->


### PR DESCRIPTION
The tests of git-unix fail if there's no global `.gitconfig` setting
user.name and user.email in every `git commit` being run. This easily
fixed by setting a local git config per repository/store used.

This fixes the tests failing in sandboxed environments or on systems
without git set up properly.