### PR TITLE
Drop the support of 4.07.0 and remove stdlib-shims

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,7 +1,7 @@
 (executable
  (name bench_pack)
- (libraries bigstringaf mtime fmt decompress.de decompress.zl digestif.c
-   bigarray-compat carton unix)
+ (libraries bigstringaf bigarray-compat mtime fmt decompress.de decompress.zl
+   digestif.c carton unix)
  (foreign_stubs
   (language c)
   (names rdtsc)))

--- a/carton-git.opam
+++ b/carton-git.opam
@@ -16,8 +16,8 @@ depends: [
   "dune" {>= "2.6.0"}
   "carton"
   "carton-lwt"
-  "bigarray-compat"
   "bigstringaf"
+  "bigarray-compat"
   "lwt"
   "fpath"
   "result"

--- a/carton-lwt.opam
+++ b/carton-lwt.opam
@@ -19,6 +19,7 @@ depends: [
   "decompress" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf"
+  "bigarray-compat" {with-test}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}
   "cstruct" {>= "6.0.0" & with-test}
@@ -27,7 +28,6 @@ depends: [
   "mirage-flow" {>= "2.0.1" & with-test}
   "result" {>= "1.5" & with-test}
   "rresult" {>= "0.6.0" & with-test}
-  "bigarray-compat" {>= "1.0.0" & with-test}
   "ke" {>= "0.4" & with-test}
   "base64" {>= "3.4.0" & with-test}
   "bos" {>= "0.2.0" & with-test}
@@ -35,7 +35,6 @@ depends: [
   "digestif" {>= "1.0.0" & with-test}
   "fpath" {>= "0.7.3" & with-test}
   "mmap" {>= "1.1.0" & with-test}
-  "stdlib-shims" {>= "0.1.0" & with-test}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/carton.opam
+++ b/carton.opam
@@ -20,11 +20,10 @@ depends: [
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf"
-  "stdlib-shims"
-  "bigarray-compat"
   "checkseum" {>= "0.2.1"}
   "logs"
   "bigstringaf"
+  "bigarray-compat"
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.7"}
   "result" {with-test}

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -6,7 +6,7 @@
 (executable
  (name binary_search)
  (modules binary_search)
- (libraries crowbar bigstringaf carton))
+ (libraries crowbar bigarray-compat bigstringaf carton))
 
 (executable
  (name smart)

--- a/git-cohttp-mirage.opam
+++ b/git-cohttp-mirage.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "git" {= version}
   "mimic"
@@ -25,7 +25,6 @@ depends: [
   "cstruct" {>= "6.0.0" & with-test}
   "logs" {>= "0.7.0" & with-test}
   "mirage-flow" {>= "2.0.1" & with-test}
-  "bigarray-compat" {>= "1.0.0" & with-test}
   "ke" {>= "0.4" & with-test}
 ]
 build: [

--- a/git-cohttp-unix.opam
+++ b/git-cohttp-unix.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "git" {= version}
   "git-cohttp" {= version}
@@ -25,7 +25,6 @@ depends: [
   "cstruct" {>= "6.0.0" & with-test}
   "logs" {>= "0.7.0" & with-test}
   "mirage-flow" {>= "2.0.1" & with-test}
-  "bigarray-compat" {>= "1.0.0" & with-test}
   "ke" {>= "0.4" & with-test}
 ]
 build: [

--- a/git-cohttp.opam
+++ b/git-cohttp.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "git" {= version}
   "cohttp"
@@ -23,7 +23,6 @@ depends: [
   "cstruct" {>= "6.0.0" & with-test}
   "logs" {>= "0.7.0" & with-test}
   "mirage-flow" {>= "2.0.1" & with-test}
-  "bigarray-compat" {>= "1.0.0" & with-test}
   "ke" {>= "0.4" & with-test}
 ]
 build: [

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "mimic"
   "mirage-stack"
@@ -31,7 +31,6 @@ depends: [
   "bigstringaf" {>= "0.7.0" & with-test}
   "cstruct" {>= "6.0.0" & with-test}
   "logs" {>= "0.7.0" & with-test}
-  "bigarray-compat" {>= "1.0.0" & with-test}
   "ke" {>= "0.4" & with-test}
 ]
 build: [

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -7,15 +7,14 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "mmap" {>= "1.1.0"}
-  "stdlib-shims"
   "git" {= version}
   "rresult"
   "result"
-  "bigarray-compat"
   "bigstringaf"
+  "bigarray-compat"
   "fmt" {>= "0.8.7"}
   "bos"
   "fpath"

--- a/git.opam
+++ b/git.opam
@@ -15,14 +15,13 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "digestif" {>= "0.8.1"}
-  "stdlib-shims"
   "rresult"
   "result"
-  "bigarray-compat"
   "bigstringaf"
+  "bigarray-compat"
   "optint"
   "decompress"
   "logs"

--- a/mimic.opam
+++ b/mimic.opam
@@ -19,10 +19,10 @@ depends: [
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}
   "bigstringaf" {>= "0.7.0" & with-test}
+  "bigarray-compat" {with-test}
   "cstruct" {>= "6.0.0" & with-test}
   "logs" {>= "0.7.0"}
   "ke" {>= "0.4" & with-test}
-  "bigarray-compat" {with-test}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/src/carton-git/carton_git_unix.ml
+++ b/src/carton-git/carton_git_unix.ml
@@ -1,5 +1,4 @@
 open Lwt.Infix
-module Bigarray = Bigarray_compat
 
 module Store = struct
   type 'a rd = < rd : unit ; .. > as 'a

--- a/src/carton-git/dune
+++ b/src/carton-git/dune
@@ -2,11 +2,12 @@
  (name carton_git)
  (public_name carton-git)
  (modules carton_git)
- (libraries decompress.zl lwt decompress.de bigstringaf fmt carton))
+ (libraries decompress.zl lwt decompress.de bigstringaf bigarray-compat fmt
+   carton))
 
 (library
  (name carton_git_unix)
  (public_name carton-git.unix)
  (modules carton_git_unix)
- (libraries astring result bigarray-compat mmap bigstringaf fmt lwt fpath
+ (libraries astring result mmap bigstringaf bigarray-compat fmt lwt fpath
    carton carton-lwt carton-git lwt.unix))

--- a/src/carton/dune
+++ b/src/carton/dune
@@ -2,12 +2,12 @@
  (name carton)
  (modules carton dec enc h idx sigs zh)
  (public_name carton)
- (libraries stdlib-shims ke duff bigarray-compat optint checkseum
-   decompress.de decompress.zl bigstringaf psq fmt))
+ (libraries ke duff optint checkseum bigarray decompress.de decompress.zl
+   bigstringaf bigarray-compat psq fmt))
 
 (library
  (name thin)
  (modules thin)
  (public_name carton.thin)
- (libraries optint checkseum decompress.de decompress.zl bigarray-compat
-   bigstringaf logs carton cstruct ke))
+ (libraries bigarray-compat optint checkseum decompress.de decompress.zl
+   bigarray bigstringaf logs carton cstruct ke))

--- a/src/carton/dune
+++ b/src/carton/dune
@@ -2,12 +2,12 @@
  (name carton)
  (modules carton dec enc h idx sigs zh)
  (public_name carton)
- (libraries ke duff optint checkseum bigarray decompress.de decompress.zl
-   bigstringaf bigarray-compat psq fmt))
+ (libraries ke duff optint checkseum decompress.de decompress.zl bigstringaf
+   bigarray-compat psq fmt))
 
 (library
  (name thin)
  (modules thin)
  (public_name carton.thin)
  (libraries bigarray-compat optint checkseum decompress.de decompress.zl
-   bigarray bigstringaf logs carton cstruct ke))
+   bigstringaf logs carton cstruct ke))

--- a/src/carton/h.ml
+++ b/src/carton/h.ml
@@ -1,5 +1,3 @@
-module Bigarray = Bigarray_compat
-
 type bigstring =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 

--- a/src/carton/h.mli
+++ b/src/carton/h.mli
@@ -1,5 +1,3 @@
-module Bigarray = Bigarray_compat
-
 type bigstring =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 

--- a/src/carton/idx.ml
+++ b/src/carton/idx.ml
@@ -1,7 +1,5 @@
 [@@@warning "-32"]
 
-module Bigarray = Bigarray_compat
-
 type bigstring =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 

--- a/src/carton/idx.mli
+++ b/src/carton/idx.mli
@@ -1,5 +1,3 @@
-module Bigarray = Bigarray_compat
-
 type bigstring =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 

--- a/src/carton/thin.ml
+++ b/src/carton/thin.ml
@@ -1,4 +1,3 @@
-module Bigarray = Bigarray_compat
 open Carton
 
 type ('uid, 's) light_load = 'uid -> (kind * int, 's) io

--- a/src/git-index/dune
+++ b/src/git-index/dune
@@ -1,5 +1,5 @@
 (library
  (name git_index)
  (public_name git-unix.index)
- (libraries stdlib-shims astring lwt mmap rresult result fmt digestif fpath
-   bigarray-compat bigstringaf git-unix))
+ (libraries bigarray-compat astring lwt mmap rresult result fmt digestif
+   fpath bigstringaf git-unix))

--- a/src/git-index/git_index.ml
+++ b/src/git-index/git_index.ml
@@ -1,7 +1,5 @@
 [@@@warning "-32"]
 
-module Bigarray = Bigarray_compat
-
 let io_buffer_size = 65536
 
 type _ hash = SHA1 : Digestif.SHA1.t hash

--- a/src/git-unix/dune
+++ b/src/git-unix/dune
@@ -2,6 +2,6 @@
  (name git_unix)
  (public_name git-unix)
  (modules git_unix packed_refs)
- (libraries stdlib-shims decompress.de bos astring carton git.nss.smart
-   rresult result bigarray-compat bigstringaf fmt git.nss.git fpath digestif
-   mmap git logs.fmt lwt lwt.unix))
+ (libraries bigarray-compat decompress.de bos astring carton git.nss.smart
+   rresult result bigstringaf fmt git.nss.git fpath digestif mmap git
+   logs.fmt lwt lwt.unix))

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Bigarray = Bigarray_compat
 open Lwt.Infix
 
 let ( >>? ) x f =

--- a/src/git/dune
+++ b/src/git/dune
@@ -1,8 +1,7 @@
 (library
  (name git)
  (public_name git)
- (libraries mimic stdlib-shims rresult git.nss.sigs git.nss.pck
-   bigarray-compat optint loose decompress.de decompress.zl result
-   git.nss.smart logs lwt cstruct angstrom bigstringaf carton ke fmt
-   checkseum git.nss.git git.nss.hkt ocamlgraph astring fpath loose_git
-   carton-lwt carton-git digestif encore))
+ (libraries bigarray-compat mimic rresult git.nss.sigs git.nss.pck optint
+   loose decompress.de decompress.zl result git.nss.smart logs lwt cstruct
+   angstrom bigstringaf carton ke fmt checkseum git.nss.git git.nss.hkt
+   ocamlgraph astring fpath loose_git carton-lwt carton-git digestif encore))

--- a/src/loose/loose_git_unix.ml
+++ b/src/loose/loose_git_unix.ml
@@ -1,4 +1,3 @@
-module Bigarray = Bigarray_compat
 open Lwt.Infix
 
 type error = |

--- a/src/not-so-smart/dune
+++ b/src/not-so-smart/dune
@@ -8,8 +8,7 @@
  (name smart)
  (public_name git.nss.smart)
  (modules smart filter capability state protocol)
- (libraries git.nss.pkt-line stdlib-shims result rresult ipaddr domain-name
-   astring fmt))
+ (libraries git.nss.pkt-line result rresult ipaddr domain-name astring fmt))
 
 (library
  (name sigs)
@@ -33,8 +32,7 @@
  (name neg)
  (public_name git.nss.neg)
  (modules neg find_common default)
- (libraries stdlib-shims fmt rresult cstruct sigs logs psq smart
-   git.nss.smart-flow))
+ (libraries fmt rresult cstruct sigs logs psq smart git.nss.smart-flow))
 
 (library
  (name pck)
@@ -53,13 +51,13 @@
  (name unixiz)
  (public_name git.nss.unixiz)
  (modules unixiz)
- (libraries git.nss.sigs lwt result rresult fmt bigarray-compat mirage-flow
+ (libraries bigarray-compat git.nss.sigs lwt result rresult fmt mirage-flow
    ke cstruct))
 
 (library
  (name smart_git)
  (public_name git.nss.git)
  (modules smart_git smart_git_intf)
- (libraries mimic mirage-flow unixiz ipaddr decompress.de decompress.zl
-   cstruct logs astring result rresult bigstringaf fmt emile lwt domain-name
-   uri sigs smart pck nss digestif carton carton-lwt))
+ (libraries bigarray-compat mimic mirage-flow unixiz ipaddr decompress.de
+   decompress.zl cstruct logs astring result rresult bigstringaf fmt emile
+   lwt domain-name uri sigs smart pck nss digestif carton carton-lwt))

--- a/test/carton/dune
+++ b/test/carton/dune
@@ -2,9 +2,9 @@
  (name test)
  (flags
   (:standard -thread))
- (libraries stdlib-shims lwt lwt.unix result rresult fpath decompress.de
-   decompress.zl optint fmt bigarray-compat bigstringaf base64 bos
-   checkseum.c digestif.c mmap unix threads carton carton-lwt alcotest))
+ (libraries lwt lwt.unix result rresult fpath decompress.de decompress.zl
+   optint fmt bigarray-compat bigstringaf base64 bos checkseum.c digestif.c
+   mmap unix threads carton carton-lwt alcotest))
 
 (rule
  (alias runtest)

--- a/test/carton/prelude.ml
+++ b/test/carton/prelude.ml
@@ -1,5 +1,3 @@
-module Bigarray = Bigarray_compat
-
 module Mutex = struct
   type 'a fiber = 'a
   type t = Mutex.t

--- a/test/mimic/dune
+++ b/test/mimic/dune
@@ -1,7 +1,7 @@
 (executable
  (name test)
- (libraries mimic mirage-flow result rresult lwt lwt.unix logs logs.fmt ke
-   bigarray bigarray-compat fmt.tty cstruct fmt alcotest alcotest-lwt))
+ (libraries bigarray-compat mimic mirage-flow result rresult lwt lwt.unix
+   logs logs.fmt ke bigarray fmt.tty cstruct fmt alcotest alcotest-lwt))
 
 (rule
  (alias runtest)

--- a/test/smart/dune
+++ b/test/smart/dune
@@ -2,9 +2,9 @@
  (name test)
  (modules append fifo hTTP loopback lwt_backend ref store_backend test uid
    unix_backend)
- (libraries mirage-flow mimic git.nss.unixiz git git-unix result curl.lwt
-   mirage-crypto-rng.unix digestif digestif.c domain-name git.nss.git bos
-   fpath bigarray-compat carton-lwt bigstringaf git.nss.sigs git.nss.hkt fmt
+ (libraries bigarray-compat mirage-flow mimic git.nss.unixiz git git-unix
+   result curl.lwt mirage-crypto-rng.unix digestif digestif.c domain-name
+   git.nss.git bos fpath carton-lwt bigstringaf git.nss.sigs git.nss.hkt fmt
    git.nss.pck carton rresult alcotest git.nss.smart lwt.unix mmap astring
    lwt cstruct uri fmt.tty logs.fmt alcotest-lwt cohttp-lwt-unix
    git-cohttp-unix))


### PR DESCRIPTION
`bigarray-compat` still exists for:
- `bigstringaf`
- `decompress`

Which are a long-term support of OCaml versions.