### PR TITLE
Fill automatically the context with read/write capabilities depending on what the user want

### DIFF
--- a/src/git-mirage/git_mirage.ml
+++ b/src/git-mirage/git_mirage.ml
@@ -7,7 +7,10 @@ module Make
     end) =
 struct
   let git_path = Mimic.make ~name:"git-path"
-  let git_capabilities = Mimic.make ~name:"git-capabilities"
+  let git_capabilities = Smart_git.git_capabilities
+
+  (* XXX(dinosaure): keep the same dynamic identifier. *)
+
   let git_scheme = Mimic.make ~name:"git-scheme"
   let with_git_path v ctx = Mimic.add git_path v ctx
   let fetch ctx = Mimic.add git_capabilities `Rd ctx

--- a/src/git-mirage/git_mirage_ssh.ml
+++ b/src/git-mirage/git_mirage_ssh.ml
@@ -139,15 +139,3 @@ struct
     | Ok { Smart_git.Endpoint.scheme = `SSH user; _ } -> with_user user ctx
     | _ -> ctx
 end
-
-module Destruct (SSH : sig
-  type endpoint
-  type flow
-
-  val ssh_protocol : (endpoint, flow) Mimic.protocol
-end) =
-struct
-  include (val Mimic.repr SSH.ssh_protocol)
-
-  let is = function T _ -> true | _ -> false
-end

--- a/src/git-mirage/git_mirage_ssh.mli
+++ b/src/git-mirage/git_mirage_ssh.mli
@@ -37,12 +37,3 @@ module Make
   val ctx : Mimic.ctx
   val with_smart_git_endpoint : string -> Mimic.ctx -> Mimic.ctx
 end
-
-module Destruct (SSH : sig
-  type endpoint
-  type flow
-
-  val ssh_protocol : (endpoint, flow) Mimic.protocol
-end) : sig
-  val is : Mimic.flow -> bool
-end

--- a/src/not-so-smart/smart_git_intf.ml
+++ b/src/not-so-smart/smart_git_intf.ml
@@ -71,6 +71,8 @@ module type SMART_GIT = sig
         adds [hdrs] to [edn] *)
   end
 
+  val git_capabilities : [ `Rd | `Wr ] Mimic.value
+
   module Make
       (Scheduler : Sigs.SCHED with type +'a s = 'a Lwt.t)
       (Pack : APPEND with type +'a fiber = 'a Lwt.t)

--- a/unikernel/config.ml
+++ b/unikernel/config.ml
@@ -39,7 +39,7 @@ let mimic_tcp_conf () =
 
 let mimic_tcp_impl stackv4 = mimic_tcp_conf () $ stackv4
 
-let mimic_git_conf ~edn ~cap () =
+let mimic_git_conf ~edn () =
   let packages = [ package "git-mirage" ] in
   let edn = Key.abstract edn in
   impl @@ object
@@ -48,24 +48,18 @@ let mimic_git_conf ~edn ~cap () =
        method! keys = [ edn ]
        method module_name = "Git_mirage.Make"
        method! packages = Key.pure packages
-       method name = match cap with
-         | `Rd -> "git_ctx_rd"
-         | `Wr -> "git_ctx_wr"
+       method name = "git_ctx"
        method! connect _ modname _ =
-         let capability = match cap with
-           | `Rd -> "fetch" | `Wr -> "push" in
          Fmt.str
-           {|let ctx_git0 = %s.%s %s.ctx in
-             let ctx_git1 = %s.with_smart_git_endpoint (%a) ctx_git0 in
-             let ctx_git2 = %s.with_resolv ctx_git1 in
-             Lwt.return ctx_git2|}
-           modname capability modname
-           modname Key.serialize_call edn
+           {|let ctx_git0 = %s.with_smart_git_endpoint (%a) %s.ctx in
+             let ctx_git1 = %s.with_resolv ctx_git0 in
+             Lwt.return ctx_git1|}
+           modname Key.serialize_call edn modname
            modname
      end
 
-let mimic_git_impl ~edn ~cap stackv4 mimic_tcp =
-  mimic_git_conf ~edn ~cap () $ stackv4 $ mimic_tcp
+let mimic_git_impl ~edn stackv4 mimic_tcp =
+  mimic_git_conf ~edn () $ stackv4 $ mimic_tcp
 
 let mimic_ssh_conf ~edn ~kind ~seed ~auth () =
   let seed = Key.abstract seed in
@@ -209,9 +203,9 @@ let minigit =
     @-> mimic
     @-> job)
 
-let mimic ~edn ~cap ~kind ~seed ~auth stackv4 random mclock time =
+let mimic ~edn ~kind ~seed ~auth stackv4 random mclock time =
   let mtcp = mimic_tcp_impl stackv4 in
-  let mgit = mimic_git_impl ~edn ~cap stackv4 mtcp in
+  let mgit = mimic_git_impl ~edn stackv4 mtcp in
   let mdns = mimic_dns_impl ~edn random mclock time stackv4 mtcp in
   let mssh = mimic_ssh_impl ~edn ~kind ~seed ~auth stackv4 mtcp mgit mclock in
   merge mssh mdns
@@ -225,7 +219,7 @@ let mimic = mimic stackv4 random mclock time
 let console = default_console
 let resolver = resolver_dns stackv4
 let conduit = conduit_direct ~tls:true stackv4
-let mimic = mimic ~edn:remote ~cap:`Rd ~kind:`Rsa ~seed:ssh_seed ~auth:ssh_auth
+let mimic = mimic ~edn:remote ~kind:`Rsa ~seed:ssh_seed ~auth:ssh_auth
 
 let () =
   register "minigit" ~packages:[]


### PR DESCRIPTION
This PR should fix the problem to make 2 ctx depending on what we want:
- if we want to fetch
- if we want to push

Now, `Sync.fetch`/`Sync.push` will automatically fill the given ctx with such information needed by `Git_mirage_ssh` (to be able to call `git-receive-pack`/`git-upload-pack`). /cc @hannesm (no need to upgrade `irmin`)