### PR TITLE
Unmonad mmap

### DIFF
--- a/bin/carton/dune
+++ b/bin/carton/dune
@@ -1,0 +1,6 @@
+(executable
+ (name verify_pack)
+ (public_name carton.verify-pack)
+ (package carton)
+ (libraries cmdliner bos result rresult fpath mmap decompress.de
+   decompress.zl bigarray-compat bigstringaf fmt carton fiber digestif.c))

--- a/bin/carton/verify_pack.ml
+++ b/bin/carton/verify_pack.ml
@@ -1,0 +1,309 @@
+open Rresult
+
+let ( <.> ) f g x = f (g x)
+
+module Scheduler = Carton.Make (Fiber)
+
+module SHA1 = struct
+  include Digestif.SHA1
+
+  let feed ctx ?off ?len bs = feed_bigstring ctx ?off ?len bs
+  let null = digest_string ""
+  let length = digest_size
+  let compare a b = String.compare (to_raw_string a) (to_raw_string b)
+end
+
+module Verify = Carton.Dec.Verify (SHA1) (Scheduler) (Fiber)
+module First_pass = Carton.Dec.Fp (SHA1)
+open Fiber
+
+let sched =
+  let open Scheduler in
+  {
+    Carton.bind = (fun x f -> inj (bind (prj x) (fun x -> prj (f x))));
+    return = (fun x -> inj (return x));
+  }
+
+let z = De.bigstring_create De.io_buffer_size
+let allocate bits = De.make_window ~bits
+
+let replace hashtbl k v =
+  try
+    let v' = Hashtbl.find hashtbl k in
+    if v < v' then Hashtbl.replace hashtbl k v'
+  with _ -> Hashtbl.add hashtbl k v
+
+let never _ = assert false
+
+let digest ~kind ?(off = 0) ?len buf =
+  let len =
+    match len with Some len -> len | None -> Bigstringaf.length buf - off
+  in
+  let ctx = SHA1.empty in
+  let ctx =
+    match kind with
+    | `A -> SHA1.feed_string ctx (Fmt.str "commit %d\000" len)
+    | `B -> SHA1.feed_string ctx (Fmt.str "tree %d\000" len)
+    | `C -> SHA1.feed_string ctx (Fmt.str "blob %d\000" len)
+    | `D -> SHA1.feed_string ctx (Fmt.str "tag %d\000" len)
+  in
+  let ctx = SHA1.feed_bigstring ctx ~off ~len buf in
+  SHA1.get ctx
+
+let ( >>= ) = sched.bind
+let return = sched.return
+
+let read fd buf ~off ~len =
+  let len = input fd buf off len in
+  return len
+
+let first_pass fpath =
+  let ic = open_in (Fpath.to_string fpath) in
+  let zw = De.make_window ~bits:15 in
+  let allocate _ = zw in
+
+  First_pass.check_header sched read ic >>= fun (max, _, _) ->
+  seek_in ic 0;
+
+  let decoder = First_pass.decoder ~o:z ~allocate (`Channel ic) in
+  let children = Hashtbl.create 0x100 in
+  let where = Hashtbl.create 0x100 in
+  let weight = Hashtbl.create 0x100 in
+  let length = Hashtbl.create 0x100 in
+  let carbon = Hashtbl.create 0x100 in
+  let matrix = Array.make max Verify.unresolved_node in
+
+  let rec go decoder =
+    match First_pass.decode decoder with
+    | `Await _ | `Peek _ -> assert false
+    | `Entry ({ First_pass.kind = Base _; offset; size; consumed; _ }, decoder)
+      ->
+        let n = First_pass.count decoder - 1 in
+        Hashtbl.add weight offset size;
+        Hashtbl.add length offset size;
+        Hashtbl.add carbon offset consumed;
+        Hashtbl.add where offset n;
+        matrix.(n) <- Verify.unresolved_base ~cursor:offset;
+        go decoder
+    | `Entry
+        ( {
+            First_pass.kind = Ofs { sub = s; source; target };
+            offset;
+            size;
+            consumed;
+            _;
+          },
+          decoder ) ->
+        let n = First_pass.count decoder - 1 in
+        replace weight Int64.(sub offset (Int64.of_int s)) source;
+        replace weight offset target;
+        Hashtbl.add length offset size;
+        Hashtbl.add carbon offset consumed;
+        Hashtbl.add where offset n;
+        (try
+           let vs =
+             Hashtbl.find children (`Ofs Int64.(sub offset (of_int s)))
+           in
+           Hashtbl.replace children
+             (`Ofs Int64.(sub offset (of_int s)))
+             (offset :: vs)
+         with _ ->
+           Hashtbl.add children (`Ofs Int64.(sub offset (of_int s))) [ offset ]);
+        go decoder
+    | `Entry
+        ( {
+            First_pass.kind = Ref { ptr; target; source };
+            offset;
+            size;
+            consumed;
+            _;
+          },
+          decoder ) ->
+        let n = First_pass.count decoder - 1 in
+        replace weight offset (Stdlib.max target source);
+        Hashtbl.add length offset size;
+        Hashtbl.add carbon offset consumed;
+        Hashtbl.add where offset n;
+        (try
+           let vs = Hashtbl.find children (`Ref ptr) in
+           Hashtbl.replace children (`Ref ptr) (offset :: vs)
+         with _ -> Hashtbl.add children (`Ref ptr) [ offset ]);
+        go decoder
+    | `End hash ->
+        close_in ic;
+        return (Ok hash)
+    | `Malformed err -> return (Error (`Msg err))
+  in
+  go decoder >>= function
+  | Error _ as err -> return err
+  | Ok hash ->
+      let where ~cursor = Hashtbl.find where cursor in
+      let children ~cursor ~uid =
+        match
+          ( Hashtbl.find_opt children (`Ofs cursor),
+            Hashtbl.find_opt children (`Ref uid) )
+        with
+        | Some a, Some b -> List.sort_uniq compare (a @ b)
+        | Some x, None | None, Some x -> x
+        | None, None -> []
+      in
+      let weight ~cursor = Hashtbl.find weight cursor in
+      let oracle = { Carton.Dec.where; children; digest; weight } in
+      return (Ok (hash, oracle, matrix, length, carbon))
+
+let map ~max fd ~pos len =
+  let len = Stdlib.min len Int64.(to_int (sub max pos)) in
+  let res =
+    Mmap.V1.map_file fd ~pos Bigarray.char Bigarray.c_layout false [| len |]
+  in
+  Bigarray.array1_of_genarray res
+
+let second_pass fpath (hash, oracle, matrix) =
+  let open Fiber in
+  let fd = Unix.openfile (Fpath.to_string fpath) Unix.[ O_RDONLY ] 0o644 in
+  let max = (Unix.LargeFile.fstat fd).Unix.LargeFile.st_size in
+  let map fd ~pos len = map ~max fd ~pos len in
+  let pack =
+    Carton.Dec.make fd ~allocate ~z ~uid_ln:SHA1.length
+      ~uid_rw:SHA1.of_raw_string never
+  in
+  Verify.verify ~threads:(Fiber.get_concurrency ()) pack ~map ~oracle ~matrix
+  >>= fun () ->
+  match Array.for_all Verify.is_resolved matrix with
+  | false -> return (R.error_msgf "Thin PACK file")
+  | true -> return (Ok (hash, matrix))
+
+let pp_kind ppf = function
+  | `A -> Fmt.string ppf "commit"
+  | `B -> Fmt.string ppf "tree  "
+  | `C -> Fmt.string ppf "blob  "
+  | `D -> Fmt.string ppf "tag   "
+
+let pp_delta ppf status =
+  match Verify.source_of_status status with
+  | Some uid -> Fmt.pf ppf "%d %a" (Verify.depth_of_status status) SHA1.pp uid
+  | None -> ()
+
+let verify_hash ~memory hash =
+  let max = Bigstringaf.length memory in
+  let hash' =
+    SHA1.of_raw_string
+      (Bigstringaf.substring memory
+         ~off:(max - (2 * SHA1.length))
+         ~len:SHA1.length)
+  in
+  SHA1.equal hash hash'
+
+let verify ~verbose fpath hash length carbon matrix =
+  let fd = Unix.openfile (Fpath.to_string fpath) Unix.[ O_RDONLY ] 0o644 in
+  let len = (Unix.fstat fd).Unix.st_size in
+  let memory =
+    Mmap.V1.map_file fd ~pos:0L Bigarray.char Bigarray.c_layout false [| len |]
+  in
+  let memory = Bigarray.array1_of_genarray memory in
+  Unix.close fd;
+  let idx =
+    Carton.Dec.Idx.make memory ~uid_ln:SHA1.length ~uid_rw:SHA1.to_raw_string
+      ~uid_wr:SHA1.of_raw_string
+  in
+  if not (verify_hash ~memory hash) then
+    return (R.error_msgf "Invalid PACK hash")
+  else
+    match verbose with
+    | false ->
+        if
+          Array.for_all
+            (Carton.Dec.Idx.exists idx <.> Verify.uid_of_status)
+            matrix
+        then return (Ok ())
+        else return (R.error_msgf "Invalid PACK file")
+    | true -> (
+        let chains = Hashtbl.create 0x10 in
+
+        let f status =
+          let uid = Verify.uid_of_status status in
+          let kind = Verify.kind_of_status status in
+          let offset = Verify.offset_of_status status in
+          let (size : Carton.Dec.weight) = Hashtbl.find length offset in
+          let size_in_pack = Hashtbl.find carbon offset in
+          let depth = Verify.depth_of_status status in
+          (match Hashtbl.find chains depth with
+          | v -> Hashtbl.replace chains depth (succ v)
+          | exception _ -> Hashtbl.replace chains depth 1);
+          match Carton.Dec.Idx.find idx uid with
+          | Some (_crc, offset') when offset = offset' ->
+              Fmt.pr "%a %a %d %d %Ld %a\n%!" SHA1.pp uid pp_kind kind
+                (size :> int)
+                size_in_pack offset pp_delta status
+          | _ -> Fmt.failwith "Invalid PACK file"
+        in
+
+        let pp_chain ppf (depth, n) =
+          match depth with
+          | 0 -> Fmt.pf ppf "non delta: %d objects\n%!" n
+          | _ -> Fmt.pf ppf "chain length = %d: %d objects\n%!" depth n
+        in
+
+        try
+          Array.iter f matrix;
+          let chains =
+            List.sort_uniq
+              (fun (a, _) (b, _) -> compare a b)
+              ((List.of_seq <.> Hashtbl.to_seq) chains)
+          in
+          Fmt.pr "%a%!" (Fmt.list ~sep:Fmt.nop pp_chain) chains;
+          Fmt.pr "%a: ok\n%!" Fpath.pp Fpath.(set_ext "pack" (base fpath));
+          return (Ok ())
+        with _exn -> return (R.error_msgf "Invalid PACK file"))
+
+let ( >>? ) x f =
+  let open Fiber in
+  x >>= function Ok x -> f x | Error err -> return (Error err)
+
+let run ~verbose fpath =
+  let pack = Fpath.set_ext "pack" fpath in
+  Bos.OS.File.must_exist pack |> Fiber.return >>? fun pack ->
+  first_pass pack |> Scheduler.prj
+  >>? fun (hash, oracle, matrix, length, carbon) ->
+  second_pass pack (hash, oracle, matrix) >>? fun (hash, matrix) ->
+  verify ~verbose fpath hash length carbon matrix |> Scheduler.prj
+
+let run verbose fpath = Fiber.run (run ~verbose fpath)
+
+open Cmdliner
+
+let verbose =
+  let doc =
+    "After verifying the pack, show list of objects contained in the pack and \
+     histogram of delta chain length."
+  in
+  Arg.(value & flag & info [ "v"; "verbose" ] ~doc)
+
+let fpath =
+  let parser x =
+    match Fpath.of_string x with
+    | Ok v when Sys.file_exists x -> Ok v
+    | Ok v -> R.error_msgf "%a not found" Fpath.pp v
+    | Error _ as err -> err
+  in
+  Arg.conv (parser, Fpath.pp)
+
+let fpath =
+  let doc = "The idx files to verify." in
+  Arg.(required & pos ~rev:true 0 (some fpath) None & info [] ~doc)
+
+let cmd =
+  let doc = "Validate packed Git archive files" in
+  let exits = Term.default_exits in
+  let man =
+    [
+      `S Manpage.s_description;
+      `P
+        "Reads given idx file for packed Git archive created with the $(i,git) \
+         $(i,pack-objets) command and verifies idx file and the corresponding \
+         pack file.";
+    ]
+  in
+  Term.(const run $ verbose $ fpath), Term.info "verify-pack" ~doc ~exits ~man
+
+let () = Term.(exit @@ eval cmd)

--- a/bin/fiber/dune
+++ b/bin/fiber/dune
@@ -1,0 +1,5 @@
+(library
+ (name fiber)
+ (flags
+  (:standard -thread))
+ (libraries fmt threads))

--- a/bin/fiber/fiber.ml
+++ b/bin/fiber/fiber.ml
@@ -1,0 +1,252 @@
+type +'a t = ('a -> unit) -> unit
+
+let return x k = k x
+let bind t f k = t (fun x -> f x k)
+let ( >>> ) a b k = a (fun () -> b k)
+let ( >>= ) t f k = t (fun x -> f x k)
+let ( >>| ) t f k = t (fun x -> k (f x))
+
+let both a b =
+  a >>= fun a ->
+  b >>= fun b -> return (a, b)
+
+module Ivar = struct
+  type 'a state = Full of 'a | Empty of ('a -> unit) Queue.t
+  type 'a t = { mutable state : 'a state }
+
+  let create () = { state = Empty (Queue.create ()) }
+
+  let fill t x =
+    match t.state with
+    | Full _ -> failwith "Ivar.fill"
+    | Empty q ->
+        t.state <- Full x;
+        Queue.iter (fun f -> f x) q
+
+  let read t k = match t.state with Full x -> k x | Empty q -> Queue.push k q
+end
+
+let fork f k =
+  let ivar = Ivar.create () in
+  f () (fun x -> Ivar.fill ivar x);
+  k ivar
+
+let fork_and_join f g =
+  fork f >>= fun a ->
+  fork g >>= fun b -> both (Ivar.read a) (Ivar.read b)
+
+let fork_and_join_unit f g =
+  fork f >>= fun a ->
+  fork g >>= fun b -> Ivar.read a >>> Ivar.read b
+
+type seq = { mutable prev : seq; mutable next : seq }
+type prgn = Prgn : ('a -> unit) * 'a -> prgn
+
+type node = {
+  mutable node_prev : seq;
+  mutable node_next : seq;
+  prgn : prgn;
+  mutable active : bool;
+}
+
+external node_of_seq : seq -> node = "%identity"
+external seq_of_node : node -> seq = "%identity"
+
+let is_empty seq = seq.next == seq
+
+let remove node =
+  if node.active then (
+    node.active <- true;
+    let seq = seq_of_node node in
+    seq.prev.next <- seq.next;
+    seq.next.prev <- seq.prev)
+
+let pop seq =
+  if is_empty seq then None
+  else
+    let res = node_of_seq seq.next in
+    remove res;
+    Some res.prgn
+
+let add seq prgn =
+  let node = { node_prev = seq.prev; node_next = seq; prgn; active = true } in
+  seq.prev.next <- seq_of_node node;
+  seq.prev <- seq_of_node node
+
+let make_seq () =
+  let rec seq = { prev = seq; next = seq } in
+  seq
+
+type pool = {
+  seq : seq;
+  work_mutex : Mutex.t;
+  work_cond : Condition.t;
+  working_cond : Condition.t;
+  mutable working_cnt : int;
+  mutable thread_cnt : int;
+  mutable stop : bool;
+}
+
+let wait pool =
+  Mutex.lock pool.work_mutex;
+  let rec loop () =
+    if
+      ((not pool.stop) && (pool.working_cnt <> 0 || not (is_empty pool.seq)))
+      || (pool.stop && pool.thread_cnt <> 0)
+    then (
+      Condition.wait pool.working_cond pool.work_mutex;
+      loop ())
+  in
+  loop ();
+  Mutex.unlock pool.work_mutex
+
+let worker pool =
+  let rec loop () =
+    Mutex.lock pool.work_mutex;
+    while is_empty pool.seq && not pool.stop do
+      Condition.wait pool.work_cond pool.work_mutex
+    done;
+    if not pool.stop then (
+      let res = pop pool.seq in
+      pool.working_cnt <- pool.working_cnt + 1;
+      Mutex.unlock pool.work_mutex;
+      Option.iter (fun (Prgn (f, a)) -> f a) res;
+      Mutex.lock pool.work_mutex;
+      pool.working_cnt <- pool.working_cnt - 1;
+      if (not pool.stop) && pool.working_cnt = 0 && is_empty pool.seq then
+        Condition.signal pool.working_cond;
+      Mutex.unlock pool.work_mutex;
+      loop ())
+  in
+  loop ();
+  pool.thread_cnt <- pool.thread_cnt - 1;
+  Condition.signal pool.working_cond;
+  Mutex.unlock pool.work_mutex
+
+let get_concurrency () =
+  try
+    let ic = Unix.open_process_in "getconf _NPROCESSORS_ONLN" in
+    let close () = ignore (Unix.close_process_in ic) in
+    let sc = Scanf.Scanning.from_channel ic in
+    try
+      Scanf.bscanf sc "%d" (fun n ->
+          close ();
+          n)
+    with exn ->
+      close ();
+      raise exn
+  with
+  | Not_found | Sys_error _ | Failure _ | Scanf.Scan_failure _ | End_of_file
+  | Unix.Unix_error (_, _, _)
+  ->
+    1
+
+let concurrency = ref (get_concurrency ())
+let get_concurrency () = !concurrency
+let set_concurrency v = concurrency := v
+
+let make () =
+  let pool =
+    {
+      working_cnt = 0;
+      thread_cnt = !concurrency;
+      stop = false;
+      work_mutex = Mutex.create ();
+      work_cond = Condition.create ();
+      working_cond = Condition.create ();
+      seq = make_seq ();
+    }
+  in
+  for _ = 0 to !concurrency - 1 do
+    ignore @@ Thread.create worker pool
+  done;
+  pool
+
+let drop seq =
+  let rec loop () = match pop seq with Some _ -> loop () | None -> () in
+  loop ()
+
+let reset pool =
+  Mutex.lock pool.work_mutex;
+  drop pool.seq;
+  pool.stop <- true;
+  Condition.broadcast pool.work_cond;
+  Mutex.unlock pool.work_mutex;
+  wait pool;
+  pool.stop <- false;
+  pool.thread_cnt <- !concurrency;
+  for _ = 0 to !concurrency - 1 do
+    ignore @@ Thread.create worker pool
+  done
+
+let pool = make ()
+
+let run fiber =
+  let result = ref None in
+  fiber (fun x -> result := Some x);
+  wait pool;
+  match !result with
+  | Some x ->
+      reset pool;
+      x
+  | None -> failwith "Fiber.run"
+
+let detach prgn =
+  let ivar = Ivar.create () in
+  Mutex.lock pool.work_mutex;
+  add pool.seq
+    (Prgn
+       ( (fun ivar ->
+           let res = prgn () in
+           Ivar.fill ivar res),
+         ivar ));
+  Condition.signal pool.work_cond;
+  Mutex.unlock pool.work_mutex;
+  Ivar.read ivar
+
+module Mutex = struct
+  type 'a fiber = 'a t
+  type t = Mutex.t
+
+  let create () = Mutex.create ()
+
+  let lock t =
+    fork (fun () ->
+        Mutex.lock t;
+        return ())
+    >>= fun ivar -> Ivar.read ivar
+
+  let unlock t = Mutex.unlock t
+end
+
+module Condition = struct
+  type 'a fiber = 'a t
+  type mutex = Mutex.t
+  type t = Condition.t
+
+  let create () = Condition.create ()
+
+  let wait t mutex =
+    fork (fun () ->
+        Condition.wait t mutex;
+        return ())
+    >>= fun ivar -> Ivar.read ivar
+
+  let signal t = Condition.signal t
+  let broadcast t = Condition.broadcast t
+end
+
+let rec parallel_iter ~f lst =
+  match lst with
+  | [] -> return ()
+  | x :: r ->
+      fork (fun () -> f x) >>= fun ivar ->
+      parallel_iter ~f r >>= fun () -> Ivar.read ivar
+
+let rec parallel_map ~f lst =
+  match lst with
+  | [] -> return []
+  | x :: r ->
+      fork (fun () -> f x) >>= fun ivar ->
+      parallel_map ~f r >>= fun r ->
+      Ivar.read ivar >>= fun x -> return (x :: r)

--- a/bin/fiber/fiber.mli
+++ b/bin/fiber/fiber.mli
@@ -1,0 +1,36 @@
+type +'a t
+
+val return : 'a -> 'a t
+val bind : 'a t -> ('a -> 'b t) -> 'b t
+val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+val ( >>| ) : 'a t -> ('a -> 'b) -> 'b t
+val ( >>> ) : unit t -> unit t -> unit t
+val both : 'a t -> 'b t -> ('a * 'b) t
+val fork_and_join : (unit -> 'a t) -> (unit -> 'b t) -> ('a * 'b) t
+val fork_and_join_unit : (unit -> unit t) -> (unit -> unit t) -> unit t
+val parallel_map : f:('a -> 'b t) -> 'a list -> 'b list t
+val parallel_iter : f:('a -> unit t) -> 'a list -> unit t
+val detach : (unit -> 'a) -> 'a t
+val run : 'a t -> 'a
+val set_concurrency : int -> unit
+val get_concurrency : unit -> int
+
+module Mutex : sig
+  type +'a fiber = 'a t
+  type t
+
+  val create : unit -> t
+  val lock : t -> unit fiber
+  val unlock : t -> unit
+end
+
+module Condition : sig
+  type +'a fiber = 'a t
+  type mutex = Mutex.t
+  type t
+
+  val create : unit -> t
+  val wait : t -> mutex -> unit fiber
+  val signal : t -> unit
+  val broadcast : t -> unit
+end

--- a/carton.opam
+++ b/carton.opam
@@ -24,6 +24,13 @@ depends: [
   "logs"
   "bigstringaf"
   "bigarray-compat"
+  "bos"
+  "cmdliner" {>= "1.0.4"}
+  "digestif"
+  "fpath"
+  "mmap" 
+  "result"
+  "rresult"
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.7"}
   "result" {with-test}

--- a/carton.opam
+++ b/carton.opam
@@ -28,18 +28,18 @@ depends: [
   "cmdliner" {>= "1.0.4"}
   "digestif"
   "fpath"
-  "mmap" 
+  "mmap"
   "result"
   "rresult"
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.7"}
-  "result" {with-test}
-  "rresult" {with-test}
-  "fpath" {with-test}
+  "result"
+  "rresult"
+  "fpath"
   "base64" {with-test & >= "3.0.0"}
-  "bos" {with-test}
-  "digestif" {with-test & >= "0.8.1"}
-  "mmap" {with-test}
+  "bos"
+  "digestif" {>= "0.8.1"}
+  "mmap"
   "base-unix" {with-test}
   "base-threads" {with-test}
   "alcotest" {with-test}

--- a/fuzz/pack_headers.ml
+++ b/fuzz/pack_headers.ml
@@ -11,14 +11,14 @@ let allocate bits = De.make_window ~bits
 let o = Bigstringaf.create De.io_buffer_size
 
 let map payload ~pos len =
-  if pos < 0L then Us.inj Bigstringaf.empty
+  if pos < 0L then Bigstringaf.empty
   else if pos >= Int64.of_int (Bigstringaf.length payload) then
-    Us.inj Bigstringaf.empty
+    Bigstringaf.empty
   else
     let max = Int64.sub (Int64.of_int (Bigstringaf.length payload)) pos in
     let len = min (Int64.of_int len) max in
     let len = Int64.to_int len in
-    Us.inj (Bigstringaf.sub payload ~off:(Int64.to_int pos) ~len)
+    Bigstringaf.sub payload ~off:(Int64.to_int pos) ~len
 
 let () =
   Crowbar.add_test ~name:"pack-headers never fails" Crowbar.[ int64; bytes ]
@@ -30,13 +30,12 @@ let () =
       (fun _ -> assert false)
   in
   let kind, length, _pos, _slice =
-    Us.prj
-      (Carton.Dec.header_of_entry unix ~map t pos
-         {
-           Carton.Dec.W.payload;
-           offset = pos;
-           length = Bigstringaf.length payload;
-         })
+    Carton.Dec.header_of_entry ~map t pos
+      {
+        Carton.Dec.W.payload;
+        offset = pos;
+        length = Bigstringaf.length payload;
+      }
   in
   ignore @@ (kind, length)
 
@@ -54,13 +53,8 @@ let () =
       (fun _ -> assert false)
   in
   let kind', length', _pos, _slice =
-    Us.prj
-      (Carton.Dec.header_of_entry unix ~map t 0L
-         {
-           Carton.Dec.W.payload;
-           offset = 0L;
-           length = Bigstringaf.length payload;
-         })
+    Carton.Dec.header_of_entry ~map t 0L
+      { Carton.Dec.W.payload; offset = 0L; length = Bigstringaf.length payload }
   in
   Crowbar.check_eq ~pp:Fmt.int kind kind';
   Crowbar.check_eq ~pp:Fmt.int length length'

--- a/src/carton-git/carton_git.mli
+++ b/src/carton-git/carton_git.mli
@@ -15,7 +15,7 @@ module type STORE = sig
 
   val pp_error : error Fmt.t
   val create : mode:'a mode -> t -> uid -> ('a fd, error) result fiber
-  val map : t -> 'm rd fd -> pos:int64 -> int -> Bigstringaf.t fiber
+  val map : t -> 'm rd fd -> pos:int64 -> int -> Bigstringaf.t
   val close : t -> 'm fd -> (unit, error) result fiber
   val list : t -> uid list fiber
   val length : 'm fd -> int64 fiber

--- a/src/carton-git/carton_git_unix.ml
+++ b/src/carton-git/carton_git_unix.ml
@@ -39,13 +39,13 @@ module Store = struct
     in
     Lwt.catch process error
 
-  let map : t -> 'm rd fd -> pos:int64 -> int -> Bigstringaf.t fiber =
+  let map : t -> 'm rd fd -> pos:int64 -> int -> Bigstringaf.t =
    fun _ fd ~pos len ->
     let fd = Lwt_unix.unix_file_descr fd in
     let payload =
       Mmap.V1.map_file fd ~pos Bigarray.char Bigarray.c_layout false [| len |]
     in
-    Lwt.return (Bigarray.array1_of_genarray payload)
+    Bigarray.array1_of_genarray payload
 
   let close _ fd = Lwt_unix.close fd >>= fun () -> Lwt.return_ok ()
 

--- a/src/carton-lwt/carton_lwt.ml
+++ b/src/carton-lwt/carton_lwt.ml
@@ -25,7 +25,7 @@ module Dec = struct
       payload : Bigstringaf.t;
     }
 
-    and 'fd map = 'fd -> pos:int64 -> int -> Bigstringaf.t Lwt.t
+    and 'fd map = 'fd Carton.Dec.W.map
 
     let make fd = Carton.Dec.W.make fd
   end
@@ -69,49 +69,31 @@ module Dec = struct
    * about internal use. *)
 
   let weight_of_offset ~map t ~weight cursor =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj (Carton.Dec.weight_of_offset lwt ~map t ~weight cursor)
+    Carton.Dec.weight_of_offset ~map t ~weight cursor
 
   let weight_of_uid ~map t ~weight uid =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj (Carton.Dec.weight_of_uid lwt ~map t ~weight uid)
+    Carton.Dec.weight_of_uid ~map t ~weight uid
 
-  let of_offset ~map t raw ~cursor =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj (Carton.Dec.of_offset lwt ~map t raw ~cursor)
-
-  let of_uid ~map t raw uid =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj (Carton.Dec.of_uid lwt ~map t raw uid)
+  let of_offset ~map t raw ~cursor = Carton.Dec.of_offset ~map t raw ~cursor
+  let of_uid ~map t raw uid = Carton.Dec.of_uid ~map t raw uid
 
   type path = Carton.Dec.path
 
   let path_to_list path = Carton.Dec.path_to_list path
   let kind_of_path path = Carton.Dec.kind_of_path path
-
-  let path_of_offset ~map t ~cursor =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj (Carton.Dec.path_of_offset lwt ~map t ~cursor)
-
-  let path_of_uid ~map t uid =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj (Carton.Dec.path_of_uid lwt ~map t uid)
+  let path_of_offset ~map t ~cursor = Carton.Dec.path_of_offset ~map t ~cursor
+  let path_of_uid ~map t uid = Carton.Dec.path_of_uid ~map t uid
 
   let of_offset_with_path ~map t ~path raw ~cursor =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj (Carton.Dec.of_offset_with_path lwt ~map t ~path raw ~cursor)
+    Carton.Dec.of_offset_with_path ~map t ~path raw ~cursor
 
   type 'uid digest = 'uid Carton.Dec.digest
 
   let uid_of_offset ~map ~digest t raw ~cursor =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj (Carton.Dec.uid_of_offset lwt ~map ~digest t raw ~cursor)
+    Carton.Dec.uid_of_offset ~map ~digest t raw ~cursor
 
   let uid_of_offset_with_source ~map ~digest t ~kind raw ~depth ~cursor =
-    let map fd ~pos len = inj (map fd ~pos len) in
-    prj
-      (Carton.Dec.uid_of_offset_with_source lwt ~map ~digest t ~kind raw ~depth
-         ~cursor)
+    Carton.Dec.uid_of_offset_with_source ~map ~digest t ~kind raw ~depth ~cursor
 
   type 'uid oracle = 'uid Carton.Dec.oracle
 
@@ -119,7 +101,6 @@ module Dec = struct
     include Carton.Dec.Verify (Uid) (Lwt_scheduler) (Lwt_io)
 
     let verify ~threads ~map ~oracle t ~matrix =
-      let map fd ~pos len = inj (map fd ~pos len) in
       verify ~threads ~map ~oracle t ~matrix
   end
 

--- a/src/carton-lwt/carton_lwt.mli
+++ b/src/carton-lwt/carton_lwt.mli
@@ -16,7 +16,7 @@ module Dec : sig
       payload : Bigstringaf.t;
     }
 
-    and 'fd map = 'fd -> pos:int64 -> int -> Bigstringaf.t Lwt.t
+    and 'fd map = 'fd -> pos:int64 -> int -> Bigstringaf.t
 
     val make : 'fd -> 'fd t
   end
@@ -99,33 +99,23 @@ module Dec : sig
     ('fd, 'uid) t
 
   val weight_of_offset :
-    map:'fd W.map -> ('fd, 'uid) t -> weight:weight -> int64 -> weight Lwt.t
+    map:'fd W.map -> ('fd, 'uid) t -> weight:weight -> int64 -> weight
 
   val weight_of_uid :
-    map:'fd W.map -> ('fd, 'uid) t -> weight:weight -> 'uid -> weight Lwt.t
+    map:'fd W.map -> ('fd, 'uid) t -> weight:weight -> 'uid -> weight
 
-  val of_offset :
-    map:'fd W.map -> ('fd, 'uid) t -> raw -> cursor:int64 -> v Lwt.t
-
-  val of_uid : map:'fd W.map -> ('fd, 'uid) t -> raw -> 'uid -> v Lwt.t
+  val of_offset : map:'fd W.map -> ('fd, 'uid) t -> raw -> cursor:int64 -> v
+  val of_uid : map:'fd W.map -> ('fd, 'uid) t -> raw -> 'uid -> v
 
   type path = Carton.Dec.path
 
   val path_to_list : path -> int64 list
   val kind_of_path : path -> [ `A | `B | `C | `D ]
-
-  val path_of_offset :
-    map:'fd W.map -> ('fd, 'uid) t -> cursor:int64 -> path Lwt.t
-
-  val path_of_uid : map:'fd W.map -> ('fd, 'uid) t -> 'uid -> path Lwt.t
+  val path_of_offset : map:'fd W.map -> ('fd, 'uid) t -> cursor:int64 -> path
+  val path_of_uid : map:'fd W.map -> ('fd, 'uid) t -> 'uid -> path
 
   val of_offset_with_path :
-    map:'fd W.map ->
-    ('fd, 'uid) t ->
-    path:path ->
-    raw ->
-    cursor:int64 ->
-    v Lwt.t
+    map:'fd W.map -> ('fd, 'uid) t -> path:path -> raw -> cursor:int64 -> v
 
   type 'uid digest = 'uid Carton.Dec.digest
 
@@ -135,7 +125,7 @@ module Dec : sig
     ('fd, 'uid) t ->
     raw ->
     cursor:int64 ->
-    (Carton.kind * 'uid) Lwt.t
+    Carton.kind * 'uid
 
   val uid_of_offset_with_source :
     map:'fd W.map ->
@@ -145,7 +135,7 @@ module Dec : sig
     raw ->
     depth:int ->
     cursor:int64 ->
-    'uid Lwt.t
+    'uid
 
   type 'uid oracle = 'uid Carton.Dec.oracle
 
@@ -266,7 +256,7 @@ module Thin : sig
     type ('t, 'path, 'fd, 'error) fs = {
       create : 't -> 'path -> ('fd, 'error) result Lwt.t;
       append : 't -> 'fd -> string -> unit Lwt.t;
-      map : 't -> 'fd -> pos:int64 -> int -> Bigstringaf.t Lwt.t;
+      map : 't -> 'fd -> pos:int64 -> int -> Bigstringaf.t;
       close : 't -> 'fd -> (unit, 'error) result Lwt.t;
     }
 

--- a/src/carton/dec.ml
+++ b/src/carton/dec.ml
@@ -568,7 +568,7 @@ module W = struct
 
   and slice = { offset : int64; length : int; payload : Bigstringaf.t }
 
-  and ('fd, 's) map = 'fd -> pos:int64 -> int -> (Bigstringaf.t, 's) io
+  and 'fd map = 'fd -> pos:int64 -> int -> Bigstringaf.t
 
   let make fd = { cur = 0; w = Weak.create (0xffff + 1); m = 0xffff; fd }
   let reset { w; _ } = Weak.fill w 0 (Weak.length w) None
@@ -578,27 +578,21 @@ module W = struct
   let window_length = Int64.mul 1024L 1024L
   let length = window_length
 
-  let heavy_load :
-      type fd s.
-      s scheduler -> map:(fd, s) map -> fd t -> int64 -> (slice option, s) io =
-   fun { bind; return } ~map t w ->
-    let ( >>= ) = bind in
-
+  let heavy_load : type fd. map:fd map -> fd t -> int64 -> slice option =
+   fun ~map t w ->
     let pos = Int64.(div w window_length) in
     let pos = Int64.(mul pos window_length) in
 
-    map t.fd ~pos (1024 * 1024) >>= fun payload ->
+    let payload = map t.fd ~pos (1024 * 1024) in
     let slice =
       Some { offset = pos; length = Bigstringaf.length payload; payload }
     in
     Weak.set t.w (t.cur land 0xffff) slice;
     t.cur <- t.cur + 1;
-    return slice
+    slice
 
-  let load :
-      type fd s.
-      s scheduler -> map:(fd, s) map -> fd t -> int64 -> (slice option, s) io =
-   fun ({ return; _ } as s) ~map t w ->
+  let load : type fd. map:fd map -> fd t -> int64 -> slice option =
+   fun ~map t w ->
     let exception Found in
     let slice = ref None in
     try
@@ -618,8 +612,8 @@ module W = struct
               raise_notrace Found)
         | None -> ()
       done;
-      heavy_load s ~map t w
-    with Found -> return !slice
+      heavy_load ~map t w
+    with Found -> !slice
 end
 
 type ('fd, 'uid) t = {
@@ -656,16 +650,14 @@ let weight_of_int_exn x =
 let null = 0
 
 let weight_of_delta :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     weight:weight ->
     cursor:int64 ->
     W.slice ->
-    (weight, s) io =
- fun ({ return; bind } as s) ~map t ~weight ~cursor slice ->
-  let ( >>= ) = bind in
+    weight =
+ fun ~map t ~weight ~cursor slice ->
   let decoder = Zh.M.decoder ~o:t.tmp ~allocate:t.allocate `Manual in
   let rec go cursor decoder =
     match Zh.M.decode decoder with
@@ -673,9 +665,9 @@ let weight_of_delta :
         assert false
         (* XXX(dinosaure): [`End] never appears before [`Header]. *)
     | `Malformed err -> failwith err
-    | `Header (src_len, dst_len, _) -> return (max weight (max src_len dst_len))
+    | `Header (src_len, dst_len, _) -> max weight (max src_len dst_len)
     | `Await decoder -> (
-        W.load s ~map t.ws cursor >>= function
+        match W.load ~map t.ws cursor with
         | None ->
             let decoder = Zh.M.src decoder De.bigstring_empty 0 0 in
             (* XXX(dinosaure): End of stream, [Zh] should return [`Malformed] then. *)
@@ -693,17 +685,17 @@ let weight_of_delta :
   let decoder = Zh.M.src decoder slice.W.payload off len in
   go Int64.(add slice.W.offset (of_int slice.W.length)) decoder
 
-let header_of_ref_delta ({ bind; return } as s) ~map t cursor slice =
-  let ( >>= ) = bind in
+let header_of_ref_delta ~map t cursor slice =
   let slice = ref slice in
   let i_pos = ref Int64.(to_int (sub cursor !slice.W.offset)) in
   let i_rem = !slice.W.length - !i_pos in
 
-  let fiber =
-    if i_rem >= t.uid_ln then return (fun () -> incr i_pos)
+  let consume =
+    if i_rem >= t.uid_ln then fun () -> incr i_pos
     else
-      W.load s ~map t.ws Int64.(add !slice.W.offset (of_int !slice.W.length))
-      >>= function
+      match
+        W.load ~map t.ws Int64.(add !slice.W.offset (of_int !slice.W.length))
+      with
       | None -> assert false
       | Some next_slice ->
           let consume () =
@@ -718,9 +710,8 @@ let header_of_ref_delta ({ bind; return } as s) ~map t cursor slice =
                         next_slice.W.offset)));
               slice := next_slice)
           in
-          return consume
+          consume
   in
-  fiber >>= fun consume ->
   let uid =
     if i_rem >= t.uid_ln then (
       let uid =
@@ -740,19 +731,19 @@ let header_of_ref_delta ({ bind; return } as s) ~map t cursor slice =
       t.uid_rw (Bytes.unsafe_to_string uid)
   in
 
-  return (uid, !i_pos, !slice)
+  uid, !i_pos, !slice
 
-let header_of_ofs_delta ({ bind; return } as s) ~map t cursor slice =
-  let ( >>= ) = bind in
+let header_of_ofs_delta ~map t cursor slice =
   let slice = ref slice in
   let i_pos = ref Int64.(to_int (sub cursor !slice.W.offset)) in
   let i_rem = !slice.W.length - !i_pos in
 
-  let fiber =
-    if i_rem >= 10 then return (fun () -> incr i_pos)
+  let consume =
+    if i_rem >= 10 then fun () -> incr i_pos
     else
-      W.load s ~map t.ws Int64.(add !slice.W.offset (of_int !slice.W.length))
-      >>= function
+      match
+        W.load ~map t.ws Int64.(add !slice.W.offset (of_int !slice.W.length))
+      with
       | None -> assert false
       | Some next_slice ->
           let consume () =
@@ -767,9 +758,8 @@ let header_of_ofs_delta ({ bind; return } as s) ~map t cursor slice =
                         next_slice.W.offset)));
               slice := next_slice)
           in
-          return consume
+          consume
   in
-  fiber >>= fun consume ->
   let c = ref (Char.code (Bigstringaf.get !slice.W.payload !i_pos)) in
   consume ();
   let base_offset = ref (!c land 127) in
@@ -781,19 +771,19 @@ let header_of_ofs_delta ({ bind; return } as s) ~map t cursor slice =
     base_offset := (!base_offset lsl 7) + (!c land 127)
   done;
 
-  return (!base_offset, !i_pos, !slice)
+  !base_offset, !i_pos, !slice
 
-let header_of_entry ({ bind; return } as s) ~map t cursor slice0 =
-  let ( >>= ) = bind in
+let header_of_entry ~map t cursor slice0 =
   let slice = ref slice0 in
   let i_pos = ref Int64.(to_int (sub cursor !slice.W.offset)) in
   let i_rem = !slice.W.length - !i_pos in
 
-  let fiber =
-    if i_rem >= 10 then return (fun () -> incr i_pos)
+  let consume =
+    if i_rem >= 10 then fun () -> incr i_pos
     else
-      W.load s ~map t.ws Int64.(add !slice.W.offset (of_int !slice.W.length))
-      >>= function
+      match
+        W.load ~map t.ws Int64.(add !slice.W.offset (of_int !slice.W.length))
+      with
       | None -> assert false
       | Some next_slice ->
           let consume () =
@@ -808,9 +798,8 @@ let header_of_entry ({ bind; return } as s) ~map t cursor slice0 =
                         next_slice.W.offset)));
               slice := next_slice)
           in
-          return consume
+          consume
   in
-  fiber >>= fun consume ->
   try
     let c = ref (Char.code (Bigstringaf.get !slice.W.payload !i_pos)) in
     consume ();
@@ -825,114 +814,106 @@ let header_of_entry ({ bind; return } as s) ~map t cursor slice0 =
       shft := !shft + 7
     done;
 
-    return (kind, !size, !i_pos, !slice)
+    kind, !size, !i_pos, !slice
   with Invalid_argument _index_out_of_bounds ->
     let i_pos = Int64.(to_int (sub cursor slice0.W.offset)) in
-    return (0, 0, i_pos, slice0)
+    0, 0, i_pos, slice0
 
 (* TODO(dinosaure): use [ewah] instead a list to check [visited]. *)
 
 exception Cycle
 
 let rec weight_of_ref_delta :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     weight:weight ->
     ?visited:int64 list ->
     cursor:int64 ->
     W.slice ->
-    (weight, s) io =
- fun ({ bind; _ } as s) ~map t ~weight ?(visited = []) ~cursor slice ->
-  let ( >>= ) = bind in
-
-  header_of_ref_delta s ~map t cursor slice >>= fun (uid, pos, slice) ->
-  weight_of_delta s ~map t ~weight
-    ~cursor:Int64.(add slice.W.offset (of_int pos))
-    slice
-  >>= fun weight -> (weight_of_uid [@tailcall]) s ~map t ~weight ~visited uid
+    weight =
+ fun ~map t ~weight ?(visited = []) ~cursor slice ->
+  let uid, pos, slice = header_of_ref_delta ~map t cursor slice in
+  let weight =
+    weight_of_delta ~map t ~weight
+      ~cursor:Int64.(add slice.W.offset (of_int pos))
+      slice
+  in
+  (weight_of_uid [@tailcall]) ~map t ~weight ~visited uid
 
 and weight_of_ofs_delta :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     weight:weight ->
     ?visited:int64 list ->
     anchor:int64 ->
     cursor:int64 ->
     W.slice ->
-    (weight, s) io =
- fun ({ bind; _ } as s) ~map t ~weight ?(visited = []) ~anchor ~cursor slice ->
-  let ( >>= ) = bind in
-
-  header_of_ofs_delta s ~map t cursor slice >>= fun (base_offset, pos, slice) ->
-  weight_of_delta s ~map t ~weight
-    ~cursor:Int64.(add slice.W.offset (of_int pos))
-    slice
-  >>= fun weight ->
-  (weight_of_offset [@tailcall]) s ~map t ~weight ~visited
+    weight =
+ fun ~map t ~weight ?(visited = []) ~anchor ~cursor slice ->
+  let base_offset, pos, slice = header_of_ofs_delta ~map t cursor slice in
+  let weight =
+    weight_of_delta ~map t ~weight
+      ~cursor:Int64.(add slice.W.offset (of_int pos))
+      slice
+  in
+  (weight_of_offset [@tailcall]) ~map t ~weight ~visited
     Int64.(sub anchor (of_int base_offset))
 
 and weight_of_uid :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     weight:weight ->
     ?visited:int64 list ->
     uid ->
-    (weight, s) io =
- fun s ~map t ~weight ?(visited = []) uid ->
+    weight =
+ fun ~map t ~weight ?(visited = []) uid ->
   let cursor = t.fd uid in
-  (weight_of_offset [@tailcall]) s ~map t ~weight ~visited cursor
+  (weight_of_offset [@tailcall]) ~map t ~weight ~visited cursor
 
 and weight_of_offset :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     weight:weight ->
     ?visited:int64 list ->
     int64 ->
-    (weight, s) io =
- fun ({ bind; return } as s) ~map t ~weight ?(visited = []) cursor ->
-  let ( >>= ) = bind in
+    weight =
+ fun ~map t ~weight ?(visited = []) cursor ->
   if List.exists (Int64.equal cursor) visited then raise Cycle;
   let visited = cursor :: visited in
 
-  W.load s ~map t.ws cursor >>= function
+  match W.load ~map t.ws cursor with
   | None ->
       Fmt.failwith "Reach end of pack (ask: %Ld, [weight_of_offset])" cursor
   | Some slice -> (
-      header_of_entry s ~map t cursor slice >>= fun (kind, size, pos, slice) ->
+      let kind, size, pos, slice = header_of_entry ~map t cursor slice in
       match kind with
       | 0b000 | 0b101 -> failwith "bad type"
-      | 0b001 | 0b010 | 0b011 | 0b100 -> return (max size weight)
+      | 0b001 | 0b010 | 0b011 | 0b100 -> max size weight
       | 0b110 ->
-          (weight_of_ofs_delta [@tailcall]) s ~map t ~weight:(max size weight)
+          (weight_of_ofs_delta [@tailcall]) ~map t ~weight:(max size weight)
             ~visited ~anchor:cursor
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b111 ->
-          (weight_of_ref_delta [@tailcall]) s ~map t ~weight:(max size weight)
+          (weight_of_ref_delta [@tailcall]) ~map t ~weight:(max size weight)
             ~visited
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | _ -> assert false)
 
-let length_of_offset :
-    type fd uid s.
-    s scheduler -> map:(fd, s) W.map -> (fd, uid) t -> int64 -> (int, s) io =
- fun ({ bind; return } as s) ~map t cursor ->
-  let ( >>= ) = bind in
-  W.load s ~map t.ws cursor >>= function
+let length_of_offset : type fd uid. map:fd W.map -> (fd, uid) t -> int64 -> int
+    =
+ fun ~map t cursor ->
+  match W.load ~map t.ws cursor with
   | None ->
       Fmt.failwith "Reach end of pack (ask: %Ld, [weight_of_offset])" cursor
   | Some slice ->
-      header_of_entry s ~map t cursor slice >>= fun (_, size, _, _) ->
-      return size
+      let _, size, _, _ = header_of_entry ~map t cursor slice in
+      size
 
 type raw = { raw0 : Bigstringaf.t; raw1 : Bigstringaf.t; flip : bool }
 type v = { kind : kind; raw : raw; len : int; depth : int }
@@ -965,18 +946,9 @@ let len { len; _ } = len
 let depth { depth; _ } = depth
 
 let uncompress :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
-    (fd, uid) t ->
-    kind ->
-    raw ->
-    cursor:int64 ->
-    W.slice ->
-    (v, s) io =
- fun ({ bind; return } as s) ~map t kind raw ~cursor slice ->
-  let ( >>= ) = bind in
-
+    type fd uid.
+    map:fd W.map -> (fd, uid) t -> kind -> raw -> cursor:int64 -> W.slice -> v =
+ fun ~map t kind raw ~cursor slice ->
   let o = get_payload raw in
   let decoder = Zl.Inf.decoder `Manual ~o ~allocate:t.allocate in
   let anchor = cursor in
@@ -991,7 +963,7 @@ let uncompress :
            inflated data. At the end, [decoder] should not return more than one
            [`Flush]. A special case is when we inflate nothing: [`Flush] never
            appears and we reach [`End] directly, so [!p (still) = false and len (must) = 0]. *)
-        return { kind; raw; len = l; depth = 1 }
+        { kind; raw; len = l; depth = 1 }
     | `Flush decoder ->
         let l = Bigstringaf.length o - Zl.Inf.dst_rem decoder in
         assert (not p);
@@ -999,7 +971,7 @@ let uncompress :
         let decoder = Zl.Inf.flush decoder in
         (go [@tailcall]) l p cursor decoder
     | `Await decoder -> (
-        W.load s ~map t.ws cursor >>= function
+        match W.load ~map t.ws cursor with
         | Some slice ->
             let off = Int64.(to_int (sub cursor slice.W.offset)) in
             let len = slice.W.length - off in
@@ -1017,26 +989,23 @@ let uncompress :
   go 0 false Int64.(add slice.W.offset (of_int slice.W.length)) decoder
 
 let of_delta :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     kind ->
     raw ->
     depth:int ->
     cursor:int64 ->
     W.slice ->
-    (v, s) io =
- fun ({ bind; return } as s) ~map t kind raw ~depth ~cursor slice ->
-  let ( >>= ) = bind in
-
+    v =
+ fun ~map t kind raw ~depth ~cursor slice ->
   let decoder = Zh.M.decoder ~o:t.tmp ~allocate:t.allocate `Manual in
 
   let rec go cursor raw decoder =
     match Zh.M.decode decoder with
     | `End decoder ->
         let len = Zh.M.dst_len decoder in
-        return { kind; raw; len; depth }
+        { kind; raw; len; depth }
     | `Malformed err -> failwith err
     | `Header (_src_len, dst_len, decoder) ->
         let source = get_source raw in
@@ -1046,7 +1015,7 @@ let of_delta :
         let decoder = Zh.M.dst decoder payload 0 dst_len in
         (go [@tailcall]) cursor raw decoder
     | `Await decoder -> (
-        W.load s ~map t.ws cursor >>= function
+        match W.load ~map t.ws cursor with
         | None ->
             let decoder = Zh.M.src decoder Bigstringaf.empty 0 0 in
             (go [@tailcall]) cursor raw decoder
@@ -1064,89 +1033,70 @@ let of_delta :
   go Int64.(add slice.W.offset (of_int slice.W.length)) raw decoder
 
 let rec of_ofs_delta :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     raw ->
     anchor:int64 ->
     cursor:int64 ->
     W.slice ->
-    (v, s) io =
- fun ({ bind; _ } as s) ~map t raw ~anchor ~cursor slice ->
-  let ( >>= ) = bind in
-
-  header_of_ofs_delta s ~map t cursor slice >>= fun (base_offset, pos, slice) ->
-  of_offset s ~map t (flip raw) ~cursor:Int64.(sub anchor (of_int base_offset))
-  >>= fun v ->
-  of_delta s ~map t v.kind raw ~depth:(succ v.depth)
+    v =
+ fun ~map t raw ~anchor ~cursor slice ->
+  let base_offset, pos, slice = header_of_ofs_delta ~map t cursor slice in
+  let v =
+    of_offset ~map t (flip raw) ~cursor:Int64.(sub anchor (of_int base_offset))
+  in
+  of_delta ~map t v.kind raw ~depth:(succ v.depth)
     ~cursor:Int64.(add slice.W.offset (of_int pos))
     slice
 
 and of_ref_delta :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
-    (fd, uid) t ->
-    raw ->
-    cursor:int64 ->
-    W.slice ->
-    (v, s) io =
- fun ({ bind; _ } as s) ~map t raw ~cursor slice ->
-  let ( >>= ) = bind in
-
-  header_of_ref_delta s ~map t cursor slice >>= fun (uid, pos, slice) ->
-  of_uid s ~map t (flip raw) uid >>= fun v ->
-  of_delta s ~map t v.kind raw ~depth:(succ v.depth)
+    type fd uid.
+    map:fd W.map -> (fd, uid) t -> raw -> cursor:int64 -> W.slice -> v =
+ fun ~map t raw ~cursor slice ->
+  let uid, pos, slice = header_of_ref_delta ~map t cursor slice in
+  let v = of_uid ~map t (flip raw) uid in
+  of_delta ~map t v.kind raw ~depth:(succ v.depth)
     ~cursor:Int64.(add slice.W.offset (of_int pos))
     slice
 
-and of_uid :
-    type fd uid s.
-    s scheduler -> map:(fd, s) W.map -> (fd, uid) t -> raw -> uid -> (v, s) io =
- fun s ~map t raw uid ->
+and of_uid : type fd uid. map:fd W.map -> (fd, uid) t -> raw -> uid -> v =
+ fun ~map t raw uid ->
   let cursor = t.fd uid in
-  of_offset s ~map t raw ~cursor
+  of_offset ~map t raw ~cursor
 
 and of_offset :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
-    (fd, uid) t ->
-    raw ->
-    cursor:int64 ->
-    (v, s) io =
- fun ({ bind; _ } as s) ~map t raw ~cursor ->
-  let ( >>= ) = bind in
-  W.load s ~map t.ws cursor >>= function
+    type fd uid. map:fd W.map -> (fd, uid) t -> raw -> cursor:int64 -> v =
+ fun ~map t raw ~cursor ->
+  match W.load ~map t.ws cursor with
   | None ->
       Fmt.failwith "Reach end of pack (ask: %Ld, [weight_of_offset])" cursor
   | Some slice -> (
-      header_of_entry s ~map t cursor slice >>= fun (kind, _, pos, slice) ->
+      let kind, _, pos, slice = header_of_entry ~map t cursor slice in
       match kind with
       | 0b000 | 0b101 -> failwith "bad type"
       | 0b001 ->
-          uncompress s ~map t `A raw
+          uncompress ~map t `A raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b010 ->
-          uncompress s ~map t `B raw
+          uncompress ~map t `B raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b011 ->
-          uncompress s ~map t `C raw
+          uncompress ~map t `C raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b100 ->
-          uncompress s ~map t `D raw
+          uncompress ~map t `D raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b110 ->
-          of_ofs_delta s ~map t raw ~anchor:cursor
+          of_ofs_delta ~map t raw ~anchor:cursor
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b111 ->
-          of_ref_delta s ~map t raw
+          of_ref_delta ~map t raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | _ -> assert false)
@@ -1163,172 +1113,141 @@ let kind_of_int = function
   | _ -> assert false
 
 let rec fill_path_from_ofs_delta :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     depth:int ->
     int64 array ->
     anchor:int64 ->
     cursor:int64 ->
     W.slice ->
-    (int * [ `A | `B | `C | `D ], s) io =
- fun ({ bind; _ } as s) ~map t ~depth path ~anchor ~cursor slice ->
-  let ( >>= ) = bind in
-
-  header_of_ofs_delta s ~map t cursor slice >>= fun (base_offset, _, _) ->
-  (fill_path_from_offset [@tailcall]) s ~map t ~depth:(succ depth) path
+    int * [ `A | `B | `C | `D ] =
+ fun ~map t ~depth path ~anchor ~cursor slice ->
+  let base_offset, _, _ = header_of_ofs_delta ~map t cursor slice in
+  (fill_path_from_offset [@tailcall]) ~map t ~depth:(succ depth) path
     ~cursor:Int64.(sub anchor (of_int base_offset))
 
 and fill_path_from_ref_delta :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     depth:int ->
     int64 array ->
     cursor:int64 ->
     W.slice ->
-    (int * [ `A | `B | `C | `D ], s) io =
- fun ({ bind; _ } as s) ~map t ~depth path ~cursor slice ->
-  let ( >>= ) = bind in
-
-  header_of_ref_delta s ~map t cursor slice >>= fun (uid, _, _) ->
-  (fill_path_from_uid [@tailcall]) s ~map t ~depth path uid
+    int * [ `A | `B | `C | `D ] =
+ fun ~map t ~depth path ~cursor slice ->
+  let uid, _, _ = header_of_ref_delta ~map t cursor slice in
+  (fill_path_from_uid [@tailcall]) ~map t ~depth path uid
 
 and fill_path_from_uid :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     depth:int ->
     int64 array ->
     uid ->
-    (int * [ `A | `B | `C | `D ], s) io =
- fun s ~map t ~depth path uid ->
+    int * [ `A | `B | `C | `D ] =
+ fun ~map t ~depth path uid ->
   let cursor = t.fd uid in
   path.(depth - 1) <- cursor;
-  (fill_path_from_offset [@tailcall]) s ~map t ~depth:(succ depth) path ~cursor
+  (fill_path_from_offset [@tailcall]) ~map t ~depth:(succ depth) path ~cursor
 
 and fill_path_from_offset :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     (fd, uid) t ->
     depth:int ->
     int64 array ->
     cursor:int64 ->
-    (int * [ `A | `B | `C | `D ], s) io =
- fun ({ return; bind } as s) ~map t ~depth path ~cursor ->
-  let ( >>= ) = bind in
-  W.load s ~map t.ws cursor >>= function
+    int * [ `A | `B | `C | `D ] =
+ fun ~map t ~depth path ~cursor ->
+  match W.load ~map t.ws cursor with
   | None ->
       Fmt.failwith "Reach end of pack (ask: %Ld, [weight_of_offset])" cursor
   | Some slice -> (
       path.(depth - 1) <- cursor;
-      header_of_entry s ~map t cursor slice >>= fun (kind, _, pos, slice) ->
+      let kind, _, pos, slice = header_of_entry ~map t cursor slice in
       match kind with
       | 0b000 | 0b101 -> failwith "bad type"
-      | (0b001 | 0b010 | 0b011 | 0b100) as v -> return (depth, kind_of_int v)
+      | (0b001 | 0b010 | 0b011 | 0b100) as v -> depth, kind_of_int v
       | 0b110 ->
-          (fill_path_from_ofs_delta [@tailcall]) s ~map t ~depth path
+          (fill_path_from_ofs_delta [@tailcall]) ~map t ~depth path
             ~anchor:cursor
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b111 ->
-          (fill_path_from_ref_delta [@tailcall]) s ~map t ~depth path
+          (fill_path_from_ref_delta [@tailcall]) ~map t ~depth path
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | _ -> assert false)
 
 let path_of_offset :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
-    (fd, uid) t ->
-    cursor:int64 ->
-    (path, s) io =
- fun ({ return; bind } as s) ~map t ~cursor ->
-  let ( >>= ) = bind in
+    type fd uid. map:fd W.map -> (fd, uid) t -> cursor:int64 -> path =
+ fun ~map t ~cursor ->
   let path = Array.make _max_depth 0L in
-  fill_path_from_offset s ~map t ~depth:1 path ~cursor >>= fun (depth, kind) ->
-  return { depth; path; kind }
+  let depth, kind = fill_path_from_offset ~map t ~depth:1 path ~cursor in
+  { depth; path; kind }
 
-let path_of_uid :
-    type fd uid s.
-    s scheduler -> map:(fd, s) W.map -> (fd, uid) t -> uid -> (path, s) io =
- fun s ~map t uid ->
+let path_of_uid : type fd uid. map:fd W.map -> (fd, uid) t -> uid -> path =
+ fun ~map t uid ->
   let cursor = t.fd uid in
-  path_of_offset s ~map t ~cursor
+  path_of_offset ~map t ~cursor
 
 let of_offset_with_source :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
-    (fd, uid) t ->
-    kind ->
-    raw ->
-    depth:int ->
-    cursor:int64 ->
-    (v, s) io =
- fun ({ bind; _ } as s) ~map t kind raw ~depth ~cursor ->
-  let ( >>= ) = bind in
-  W.load s ~map t.ws cursor >>= function
+    type fd uid.
+    map:fd W.map -> (fd, uid) t -> kind -> raw -> depth:int -> cursor:int64 -> v
+    =
+ fun ~map t kind raw ~depth ~cursor ->
+  match W.load ~map t.ws cursor with
   | None ->
       Fmt.failwith "Reach end of pack (ask: %Ld, [weight_of_offset])" cursor
   | Some slice -> (
-      header_of_entry s ~map t cursor slice >>= fun (hdr, _, pos, slice) ->
+      let hdr, _, pos, slice = header_of_entry ~map t cursor slice in
       match hdr with
       | 0b000 | 0b101 -> failwith "bad type"
       | 0b001 ->
           assert (kind = `A);
-          uncompress s ~map t `A raw
+          uncompress ~map t `A raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b010 ->
           assert (kind = `B);
-          uncompress s ~map t `B raw
+          uncompress ~map t `B raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b011 ->
           assert (kind = `C);
-          uncompress s ~map t `C raw
+          uncompress ~map t `C raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b100 ->
           assert (kind = `D);
-          uncompress s ~map t `D raw
+          uncompress ~map t `D raw
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b110 ->
           let cursor = Int64.add slice.W.offset (Int64.of_int pos) in
-          header_of_ofs_delta s ~map t cursor slice >>= fun (_, pos, slice) ->
-          of_delta s ~map t kind raw ~depth
+          let _, pos, slice = header_of_ofs_delta ~map t cursor slice in
+          of_delta ~map t kind raw ~depth
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | 0b111 ->
           let cursor = Int64.add slice.W.offset (Int64.of_int pos) in
-          header_of_ref_delta s ~map t cursor slice >>= fun (_, pos, slice) ->
-          of_delta s ~map t kind raw ~depth
+          let _, pos, slice = header_of_ref_delta ~map t cursor slice in
+          of_delta ~map t kind raw ~depth
             ~cursor:Int64.(add slice.W.offset (of_int pos))
             slice
       | _ -> assert false)
 
 let base_of_offset :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
-    (fd, uid) t ->
-    raw ->
-    cursor:int64 ->
-    (v, s) io =
- fun ({ bind; _ } as s) ~map t raw ~cursor ->
-  let ( >>= ) = bind in
-  W.load s ~map t.ws cursor >>= function
+    type fd uid. map:fd W.map -> (fd, uid) t -> raw -> cursor:int64 -> v =
+ fun ~map t raw ~cursor ->
+  match W.load ~map t.ws cursor with
   | None ->
       Fmt.failwith "Reach end of pack (ask: %Ld, [weight_of_offset])" cursor
   | Some slice ->
-      header_of_entry s ~map t cursor slice >>= fun (hdr, _, pos, slice) ->
+      let hdr, _, pos, slice = header_of_entry ~map t cursor slice in
       let kind =
         match hdr with
         | 0b001 -> `A
@@ -1337,7 +1256,7 @@ let base_of_offset :
         | 0b100 -> `D
         | _ -> failwith "Invalid object"
       in
-      uncompress s ~map t kind raw
+      uncompress ~map t kind raw
         ~cursor:Int64.(add slice.W.offset (of_int pos))
         slice
 
@@ -1345,45 +1264,36 @@ let base_of_path { depth; path; _ } = path.(depth - 1)
 let kind_of_path { kind; _ } = kind
 
 let of_offset_with_path :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
-    (fd, uid) t ->
-    path:path ->
-    raw ->
-    cursor:int64 ->
-    (v, s) io =
- fun ({ bind; return } as s) ~map t ~path raw ~cursor ->
+    type fd uid.
+    map:fd W.map -> (fd, uid) t -> path:path -> raw -> cursor:int64 -> v =
+ fun ~map t ~path raw ~cursor ->
   assert (cursor = path.path.(0));
-  let ( >>= ) = bind in
-
-  base_of_offset s ~map t raw ~cursor:(base_of_path path) >>= fun base ->
+  let base = base_of_offset ~map t raw ~cursor:(base_of_path path) in
   let rec go depth raw =
-    of_offset_with_source s ~map t base.kind raw ~depth
-      ~cursor:path.path.(depth - 1)
-    >>= fun v ->
-    if depth == 1 then return v else (go [@tailcall]) (pred depth) (flip raw)
+    let v =
+      of_offset_with_source ~map t base.kind raw ~depth
+        ~cursor:path.path.(depth - 1)
+    in
+    if depth == 1 then v else (go [@tailcall]) (pred depth) (flip raw)
   in
-  if path.depth > 1 then go (path.depth - 1) (flip raw) else return base
+  if path.depth > 1 then go (path.depth - 1) (flip raw) else base
 
 type 'uid digest = kind:kind -> ?off:int -> ?len:int -> Bigstringaf.t -> 'uid
 
 let uid_of_offset :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     digest:uid digest ->
     (fd, uid) t ->
     raw ->
     cursor:int64 ->
-    (kind * uid, s) io =
- fun ({ bind; return } as s) ~map ~digest t raw ~cursor ->
-  let ( >>= ) = bind in
-  W.load s ~map t.ws cursor >>= function
+    kind * uid =
+ fun ~map ~digest t raw ~cursor ->
+  match W.load ~map t.ws cursor with
   | None ->
       Fmt.failwith "Reach end of pack (ask: %Ld, [weight_of_offset])" cursor
   | Some slice ->
-      header_of_entry s ~map t cursor slice >>= fun (hdr, _, pos, slice) ->
+      let hdr, _, pos, slice = header_of_entry ~map t cursor slice in
       let kind =
         match hdr with
         | 0b001 -> `A
@@ -1392,78 +1302,91 @@ let uid_of_offset :
         | 0b100 -> `D
         | _ -> failwith "Invalid object"
       in
-      uncompress s ~map t kind raw
-        ~cursor:Int64.(add slice.W.offset (of_int pos))
-        slice
-      >>= fun v -> return (kind, digest ~kind ~len:v.len (get_payload raw))
+      let v =
+        uncompress ~map t kind raw
+          ~cursor:Int64.(add slice.W.offset (of_int pos))
+          slice
+      in
+      kind, digest ~kind ~len:v.len (get_payload raw)
 
 let uid_of_offset_with_source :
-    type fd uid s.
-    s scheduler ->
-    map:(fd, s) W.map ->
+    type fd uid.
+    map:fd W.map ->
     digest:uid digest ->
     (fd, uid) t ->
     kind:kind ->
     raw ->
     depth:int ->
     cursor:int64 ->
-    (uid, s) io =
- fun ({ bind; return } as s) ~map ~digest t ~kind raw ~depth ~cursor ->
-  let ( >>= ) = bind in
-  W.load s ~map t.ws cursor >>= function
+    uid =
+ fun ~map ~digest t ~kind raw ~depth ~cursor ->
+  match W.load ~map t.ws cursor with
   | None ->
       Fmt.failwith "Reach end of pack (ask: %Ld, [weight_of_offset])" cursor
   | Some slice -> (
-      header_of_entry s ~map t cursor slice >>= fun (hdr, _, pos, slice) ->
+      let hdr, _, pos, slice = header_of_entry ~map t cursor slice in
       match hdr with
       | 0b000 | 0b101 -> failwith "bad type"
       | 0b001 ->
           assert (kind = `A);
           assert (depth = 1);
-          uncompress s ~map t `A raw
-            ~cursor:Int64.(add slice.W.offset (of_int pos))
-            slice
-          >>= fun v -> return (digest ~kind ~len:v.len (get_payload raw))
+          let v =
+            uncompress ~map t `A raw
+              ~cursor:Int64.(add slice.W.offset (of_int pos))
+              slice
+          in
+          digest ~kind ~len:v.len (get_payload raw)
       | 0b010 ->
           assert (kind = `B);
           assert (depth = 1);
-          uncompress s ~map t `B raw
-            ~cursor:Int64.(add slice.W.offset (of_int pos))
-            slice
-          >>= fun v -> return (digest ~kind ~len:v.len (get_payload raw))
+          let v =
+            uncompress ~map t `B raw
+              ~cursor:Int64.(add slice.W.offset (of_int pos))
+              slice
+          in
+          digest ~kind ~len:v.len (get_payload raw)
       | 0b011 ->
           assert (kind = `C);
           assert (depth = 1);
-          uncompress s ~map t `C raw
-            ~cursor:Int64.(add slice.W.offset (of_int pos))
-            slice
-          >>= fun v -> return (digest ~kind ~len:v.len (get_payload raw))
+          let v =
+            uncompress ~map t `C raw
+              ~cursor:Int64.(add slice.W.offset (of_int pos))
+              slice
+          in
+          digest ~kind ~len:v.len (get_payload raw)
       | 0b100 ->
           assert (kind = `D);
           assert (depth = 1);
-          uncompress s ~map t `D raw
-            ~cursor:Int64.(add slice.W.offset (of_int pos))
-            slice
-          >>= fun v -> return (digest ~kind ~len:v.len (get_payload raw))
+          let v =
+            uncompress ~map t `D raw
+              ~cursor:Int64.(add slice.W.offset (of_int pos))
+              slice
+          in
+          digest ~kind ~len:v.len (get_payload raw)
       | 0b110 ->
-          header_of_ofs_delta s ~map t
-            Int64.(add slice.W.offset (of_int pos))
-            slice
-          >>= fun (_, pos, slice) ->
-          of_delta s ~map t kind raw ~depth
-            ~cursor:Int64.(add slice.W.offset (of_int pos))
-            slice
-          >>= fun v -> return (digest ~kind ~len:v.len (get_payload raw))
+          let _, pos, slice =
+            header_of_ofs_delta ~map t
+              Int64.(add slice.W.offset (of_int pos))
+              slice
+          in
+          let v =
+            of_delta ~map t kind raw ~depth
+              ~cursor:Int64.(add slice.W.offset (of_int pos))
+              slice
+          in
+          digest ~kind ~len:v.len (get_payload raw)
       | 0b111 ->
-          header_of_ref_delta s ~map t
-            Int64.(add slice.W.offset (of_int pos))
-            slice
-          >>= fun (_, pos, slice) ->
-          of_delta s ~map t kind raw ~depth
-            ~cursor:Int64.(add slice.W.offset (of_int pos))
-            slice
-          >>= fun ({ raw; _ } as v) ->
-          return (digest ~kind ~len:v.len (get_payload raw))
+          let _, pos, slice =
+            header_of_ref_delta ~map t
+              Int64.(add slice.W.offset (of_int pos))
+              slice
+          in
+          let ({ raw; _ } as v) =
+            of_delta ~map t kind raw ~depth
+              ~cursor:Int64.(add slice.W.offset (of_int pos))
+              slice
+          in
+          digest ~kind ~len:v.len (get_payload raw)
       | _ -> assert false)
 
 type 'uid node = Node of int64 * 'uid * 'uid node list | Leaf of int64 * 'uid
@@ -1537,39 +1460,32 @@ struct
     | Resolved_node (_, _, _, _, source) -> Some source
     | Unresolved_node -> Fmt.invalid_arg "Current status is not resolved"
 
-  let rev_mapi f l =
-    let rec rmap_f i accu = function
-      | [] -> accu
-      | a :: l -> rmap_f (succ i) (f i a :: accu) l
-    in
-    rmap_f 0 [] l
-
-  let mapi f l = List.rev (rev_mapi f l)
-
   let rec nodes_of_offsets :
       type fd.
-      map:(fd, Scheduler.t) W.map ->
+      map:fd W.map ->
       oracle:Uid.t oracle ->
       (fd, Uid.t) t ->
       kind:kind ->
       raw ->
       depth:int ->
       cursors:int64 list ->
-      Uid.t node list IO.t =
+      Uid.t node list =
    fun ~map ~oracle t ~kind raw ~depth ~cursors ->
     match cursors with
-    | [] -> IO.return []
+    | [] -> []
     | [ cursor ] -> (
-        uid_of_offset_with_source s ~map ~digest:oracle.digest t ~kind raw
-          ~depth ~cursor
-        |> Scheduler.prj
-        >>= fun uid ->
+        let uid =
+          uid_of_offset_with_source ~map ~digest:oracle.digest t ~kind raw
+            ~depth ~cursor
+        in
         match oracle.children ~cursor ~uid with
-        | [] -> IO.return [ Leaf (cursor, uid) ]
+        | [] -> [ Leaf (cursor, uid) ]
         | cursors ->
-            nodes_of_offsets ~map ~oracle t ~kind (flip raw) ~depth:(succ depth)
-              ~cursors
-            >>= fun nodes -> IO.return [ Node (cursor, uid, nodes) ])
+            let nodes =
+              nodes_of_offsets ~map ~oracle t ~kind (flip raw)
+                ~depth:(succ depth) ~cursors
+            in
+            [ Node (cursor, uid, nodes) ])
     | cursors ->
         let source = get_source raw in
         let source =
@@ -1578,28 +1494,24 @@ struct
         (* allocation *)
         let res = Array.make (List.length cursors) (Leaf (-1L, Uid.null)) in
 
-        let fibers =
-          mapi
-            (fun i cursor ->
-              uid_of_offset_with_source s ~map ~digest:oracle.digest t ~kind raw
+        List.iteri
+          (fun i cursor ->
+            let uid =
+              uid_of_offset_with_source ~map ~digest:oracle.digest t ~kind raw
                 ~depth ~cursor
-              |> Scheduler.prj
-              >>= fun uid ->
-              match oracle.children ~cursor ~uid with
-              | [] ->
-                  res.(i) <- Leaf (cursor, uid);
-                  IO.return ()
-              | cursors ->
+            in
+            match oracle.children ~cursor ~uid with
+            | [] -> res.(i) <- Leaf (cursor, uid)
+            | cursors ->
+                let nodes =
                   nodes_of_offsets ~map ~oracle t ~kind (flip raw)
                     ~depth:(succ depth) ~cursors
-                  >>= fun nodes ->
-                  Bigstringaf.blit source ~src_off:0 (get_source raw) ~dst_off:0
-                    ~len:(Bigstringaf.length source);
-                  res.(i) <- Node (cursor, uid, nodes);
-                  IO.return ())
-            cursors
-        in
-        IO.all_unit fibers >>= fun () -> IO.return (Array.to_list res)
+                in
+                Bigstringaf.blit source ~src_off:0 (get_source raw) ~dst_off:0
+                  ~len:(Bigstringaf.length source);
+                res.(i) <- Node (cursor, uid, nodes))
+          cursors;
+        Array.to_list res
 
   let weight_of_tree : cursor:int64 -> ?uid:Uid.t -> Uid.t oracle -> int =
    fun ~cursor ?uid oracle ->
@@ -1619,19 +1531,18 @@ struct
 
   let resolver :
       type fd.
-      map:(fd, Scheduler.t) W.map ->
+      map:fd W.map ->
       oracle:Uid.t oracle ->
       (fd, Uid.t) t ->
       cursor:int64 ->
-      Uid.t tree IO.t =
+      Uid.t tree =
    fun ~map ~oracle t ~cursor ->
     let weight = weight_of_tree ~cursor oracle in
     let raw = make_raw ~weight in
     (* allocation *)
-    uid_of_offset s ~map ~digest:oracle.digest t raw ~cursor |> Scheduler.prj
-    >>= fun (kind, uid) ->
+    let kind, uid = uid_of_offset ~map ~digest:oracle.digest t raw ~cursor in
     match oracle.children ~cursor ~uid with
-    | [] -> IO.return (Base (kind, cursor, uid, []))
+    | [] -> Base (kind, cursor, uid, [])
     | cursors ->
         let weight' = weight_of_tree ~cursor ~uid oracle in
         let raw =
@@ -1642,21 +1553,25 @@ struct
             raw')
           else raw
         in
-        nodes_of_offsets ~map ~oracle t ~kind (flip raw) ~depth:1 ~cursors
-        >>= fun nodes -> IO.return (Base (kind, cursor, uid, nodes))
+        let nodes =
+          nodes_of_offsets ~map ~oracle t ~kind (flip raw) ~depth:1 ~cursors
+        in
+        Base (kind, cursor, uid, nodes)
 
   let update :
       type fd.
-      map:(fd, Scheduler.t) W.map ->
+      map:fd W.map ->
       oracle:Uid.t oracle ->
       (fd, Uid.t) t ->
       cursor:int64 ->
       matrix:status array ->
-      unit IO.t =
+      unit =
    fun ~map ~oracle t ~cursor ~matrix ->
-    resolver ~map ~oracle t ~cursor
-    >>= fun (Base (kind, cursor, uid, children)) ->
+    let (Base (kind, cursor, uid, children)) =
+      resolver ~map ~oracle t ~cursor
+    in
     matrix.(oracle.where ~cursor) <- Resolved_base (cursor, uid, kind);
+    Fmt.epr ">>> %Ld resolved!\n%!" cursor;
     let rec go depth source = function
       | Leaf (cursor, uid) ->
           matrix.(oracle.where ~cursor) <-
@@ -1666,8 +1581,7 @@ struct
             Resolved_node (cursor, uid, kind, depth, source);
           List.iter (go (succ depth) uid) children
     in
-    List.iter (go 1 uid) children;
-    IO.return ()
+    List.iter (go 1 uid) children
 
   type m = { mutable v : int; m : IO.Mutex.t }
 
@@ -1683,7 +1597,7 @@ struct
   let dispatcher :
       type fd.
       i:int ->
-      map:(fd, Scheduler.t) W.map ->
+      map:fd W.map ->
       oracle:Uid.t oracle ->
       (fd, Uid.t) t ->
       matrix:status array ->
@@ -1706,14 +1620,15 @@ struct
         IO.Mutex.unlock mutex.m;
         let[@warning "-8"] (Unresolved_base cursor) = matrix.(root) in
         (* XXX(dinosaure): Oh god, save me! *)
-        update ~map ~oracle t ~cursor ~matrix >>= fun () -> (go [@tailcall]) ()
+        IO.detach (fun () -> update ~map ~oracle t ~cursor ~matrix)
+        >>= fun () -> (go [@tailcall]) ()
     in
     go ()
 
   let verify :
       type fd.
       threads:int ->
-      map:(fd, Scheduler.t) W.map ->
+      map:fd W.map ->
       oracle:Uid.t oracle ->
       (fd, Uid.t) t ->
       matrix:status array ->
@@ -1721,7 +1636,7 @@ struct
    fun ~threads ~map ~oracle t0 ~matrix ->
     let mutex = { v = 0; m = IO.Mutex.create () } in
 
-    IO.nfork_map
+    IO.parallel_iter
       ~f:(fun (i, t) -> dispatcher ~i ~map ~oracle t ~matrix ~mutex)
       (List.init threads (fun th ->
            let z =
@@ -1730,7 +1645,6 @@ struct
            ( th,
              { t0 with ws = W.make t0.ws.W.fd; tmp = z; allocate = t0.allocate }
            )))
-    >>= fun futures -> IO.all_unit (List.map IO.Future.wait futures)
 end
 
 module Ip
@@ -1815,10 +1729,9 @@ struct
     let finish = ref false in
     let q = ref Q.empty in
 
-    IO.nfork_map
+    IO.parallel_iter
       ~f:(function
         | Producer -> producer ~idx ~q ~finish ~signal ~mutex
         | Consumer t -> consumer ~f:(f t) ~q ~finish ~signal ~mutex)
       (Producer :: List.map (fun x -> Consumer x) threads)
-    >>= fun futures -> IO.all_unit (List.map IO.Future.wait futures)
 end

--- a/src/carton/dec.ml
+++ b/src/carton/dec.ml
@@ -1571,7 +1571,6 @@ struct
       resolver ~map ~oracle t ~cursor
     in
     matrix.(oracle.where ~cursor) <- Resolved_base (cursor, uid, kind);
-    Fmt.epr ">>> %Ld resolved!\n%!" cursor;
     let rec go depth source = function
       | Leaf (cursor, uid) ->
           matrix.(oracle.where ~cursor) <-

--- a/src/carton/enc.ml
+++ b/src/carton/enc.ml
@@ -398,11 +398,10 @@ struct
   let delta ~threads ~weight ~uid_ln entries =
     let mutex = { v = 0; m = IO.Mutex.create () } in
     let targets = Array.make (Array.length entries) None in
-    IO.nfork_map
+    IO.parallel_iter
       ~f:(fun load -> dispatcher ~load ~mutex ~entries ~targets)
       threads
-    >>= fun futures ->
-    IO.all_unit (List.map IO.Future.wait futures) >>= fun () ->
+    >>= fun () ->
     let targets = Array.map get targets in
     delta ~load:(List.hd threads) ~weight ~uid_ln targets >>= fun () ->
     return targets

--- a/src/carton/sigs.ml
+++ b/src/carton/sigs.ml
@@ -26,14 +26,6 @@ module type MUTEX = sig
   val unlock : t -> unit
 end
 
-module type FUTURE = sig
-  type +'a fiber
-  type 'a t
-
-  val wait : 'a t -> 'a fiber
-  val peek : 'a t -> 'a option
-end
-
 module type CONDITION = sig
   type +'a fiber
   type mutex
@@ -48,7 +40,6 @@ end
 module type IO = sig
   type +'a t
 
-  module Future : FUTURE with type 'a fiber = 'a t
   module Mutex : MUTEX with type 'a fiber = 'a t
 
   module Condition :
@@ -56,8 +47,9 @@ module type IO = sig
 
   val bind : 'a t -> ('a -> 'b t) -> 'b t
   val return : 'a -> 'a t
-  val nfork_map : 'a list -> f:('a -> 'b t) -> 'b Future.t list t
-  val all_unit : unit t list -> unit t
+  val detach : (unit -> 'a) -> 'a t
+  val parallel_map : f:('a -> 'b t) -> 'a list -> 'b list t
+  val parallel_iter : f:('a -> unit t) -> 'a list -> unit t
 end
 
 module Make (T : FUNCTOR) : SCHEDULER with type 'a s = 'a T.t = struct

--- a/src/carton/sigs.mli
+++ b/src/carton/sigs.mli
@@ -26,14 +26,6 @@ module type MUTEX = sig
   val unlock : t -> unit
 end
 
-module type FUTURE = sig
-  type +'a fiber
-  type 'a t
-
-  val wait : 'a t -> 'a fiber
-  val peek : 'a t -> 'a option
-end
-
 module type CONDITION = sig
   type +'a fiber
   type mutex
@@ -48,7 +40,6 @@ end
 module type IO = sig
   type +'a t
 
-  module Future : FUTURE with type 'a fiber = 'a t
   module Mutex : MUTEX with type 'a fiber = 'a t
 
   module Condition :
@@ -56,8 +47,9 @@ module type IO = sig
 
   val bind : 'a t -> ('a -> 'b t) -> 'b t
   val return : 'a -> 'a t
-  val nfork_map : 'a list -> f:('a -> 'b t) -> 'b Future.t list t
-  val all_unit : unit t list -> unit t
+  val detach : (unit -> 'a) -> 'a t
+  val parallel_map : f:('a -> 'b t) -> 'a list -> 'b list t
+  val parallel_iter : f:('a -> unit t) -> 'a list -> unit t
 end
 
 module Make (T : FUNCTOR) : SCHEDULER with type 'a s = 'a T.t

--- a/src/carton/thin.ml
+++ b/src/carton/thin.ml
@@ -189,7 +189,7 @@ struct
   type ('t, 'path, 'fd, 'error) fs = {
     create : 't -> 'path -> ('fd, 'error) result IO.t;
     append : 't -> 'fd -> string -> unit IO.t;
-    map : 't -> 'fd -> pos:int64 -> int -> Bigstringaf.t IO.t;
+    map : 't -> 'fd -> pos:int64 -> int -> Bigstringaf.t;
     close : 't -> 'fd -> (unit, 'error) result IO.t;
   }
 
@@ -231,7 +231,7 @@ struct
     in
     let map fd ~pos len =
       let len = min len Int64.(to_int (sub weight pos)) in
-      Scheduler.inj (map t fd ~pos len)
+      map t fd ~pos len
     in
     Log.debug (fun m -> m "Start to verify incoming PACK file (second pass).");
     Verify.verify ~threads pack ~map ~oracle ~matrix >>= fun () ->
@@ -344,7 +344,7 @@ struct
       let max = Int64.sub top pos in
       let len = min max (Int64.mul 1024L 1024L) in
       let len = Int64.to_int len in
-      map t src ~pos len >>= fun raw ->
+      let raw = map t src ~pos len in
       append t fd (Bigstringaf.to_string raw) >>= fun () ->
       ctx := Uid.feed !ctx raw;
       cursor := Int64.add !cursor (Int64.of_int len);

--- a/src/carton/thin.mli
+++ b/src/carton/thin.mli
@@ -11,7 +11,7 @@ module Make
   type ('t, 'path, 'fd, 'error) fs = {
     create : 't -> 'path -> ('fd, 'error) result IO.t;
     append : 't -> 'fd -> string -> unit IO.t;
-    map : 't -> 'fd -> pos:int64 -> int -> Bigstringaf.t IO.t;
+    map : 't -> 'fd -> pos:int64 -> int -> Bigstringaf.t;
     close : 't -> 'fd -> (unit, 'error) result IO.t;
   }
   (** A record to manipulate a {i file-system}.

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -629,7 +629,6 @@ module Make (Digestif : Digestif.S) = struct
     let dotgit =
       match dotgit with Some v -> v | None -> Fpath.(root / ".git")
     in
-    Fmt.epr ">>> dotgit: %a.\n%!" Fpath.pp dotgit;
     let packed = Packed_refs.load ~of_hex:Hash.of_hex dotgit in
     let minor = Fpath.(dotgit / "objects") in
     let major = Fpath.(dotgit / "objects" / "pack") in

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -375,13 +375,13 @@ module Major_heap = struct
     in
     Lwt.catch process error
 
-  let map : t -> [> `Rd ] fd -> pos:int64 -> int -> Bigstringaf.t fiber =
+  let map : t -> [> `Rd ] fd -> pos:int64 -> int -> Bigstringaf.t =
    fun _ fd ~pos len ->
     let fd = Lwt_unix.unix_file_descr fd in
     let payload =
       Mmap.V1.map_file fd ~pos Bigarray.char Bigarray.c_layout false [| len |]
     in
-    Lwt.return (Bigarray.array1_of_genarray payload)
+    Bigarray.array1_of_genarray payload
 
   let close _ fd =
     let rec process () = Lwt_unix.close fd >>= fun () -> Lwt.return_ok ()

--- a/src/git/cstruct_append.ml
+++ b/src/git/cstruct_append.ml
@@ -142,11 +142,11 @@ let append _ fd str =
 let map _ fd ~pos len =
   Log.debug (fun m -> m "map on fd(length:%d) ~pos:%Ld %d." fd.length pos len);
   let pos = Int64.to_int pos in
-  if pos > fd.length then Lwt.return Bigstringaf.empty
+  if pos > fd.length then Bigstringaf.empty
   else
     let len = min len (fd.length - pos) in
     let { Cstruct.buffer; off; _ } = fd.buffer in
-    Lwt.return (Bigstringaf.sub ~off:(off + pos) ~len buffer)
+    Bigstringaf.sub ~off:(off + pos) ~len buffer
 
 let close tbl fd =
   let result = Cstruct.sub fd.buffer 0 fd.length in

--- a/src/not-so-smart/smart_git_intf.ml
+++ b/src/not-so-smart/smart_git_intf.ml
@@ -15,7 +15,7 @@ module type APPEND = sig
 
   val pp_error : error Fmt.t
   val create : mode:'a mode -> t -> uid -> ('a fd, error) result fiber
-  val map : t -> 'm rd fd -> pos:int64 -> int -> Bigstringaf.t fiber
+  val map : t -> 'm rd fd -> pos:int64 -> int -> Bigstringaf.t
   val append : t -> 'm wr fd -> string -> unit fiber
   val move : t -> src:uid -> dst:uid -> (unit, error) result fiber
   val close : t -> 'm fd -> (unit, error) result fiber

--- a/test/carton/prelude.ml
+++ b/test/carton/prelude.ml
@@ -1,81 +1,252 @@
-module Mutex = struct
-  type 'a fiber = 'a
-  type t = Mutex.t
-
-  let create () = Mutex.create ()
-  let lock t = Mutex.lock t
-  let unlock t = Mutex.unlock t
-end
-
-module Future = struct
-  type 'a fiber = 'a
-  type 'a t = { th : Thread.t; v : 'a option ref }
-
-  let wait { th; v } =
-    Thread.join th;
-    match !v with Some v -> v | None -> assert false
-
-  let peek { v; _ } = !v
-end
-
-module Condition = struct
-  type 'a fiber = 'a
-  type mutex = Mutex.t
-  type t = Condition.t
-
-  let create () = Condition.create ()
-  let wait mutex t = Condition.wait mutex t
-  let signal t = Condition.signal t
-  let broadcast t = Condition.broadcast t
-end
-
-module Us = Carton.Make (struct type 'a t = 'a end)
-
-let unix =
-  {
-    Carton.bind = (fun x f -> f (Us.prj x));
-    Carton.return = (fun x -> Us.inj x);
-  }
-
 type fd = { fd : Unix.file_descr; mx : int64 }
 
-let unix_map : (fd, Us.t) Carton.Dec.W.map =
+let unix_map : fd Carton.Dec.W.map =
  fun fd ~pos len ->
   let payload =
     let len = min Int64.(to_int (sub fd.mx pos)) len in
     Mmap.V1.map_file fd.fd ~pos Bigarray.char Bigarray.c_layout false [| len |]
   in
-  Us.inj (Bigarray.array1_of_genarray payload)
+  Bigarray.array1_of_genarray payload
+
+module IO = struct
+  type 'a t = ('a -> unit) -> unit
+
+  let return x k = k x
+  let bind t f k = t (fun x -> f x k)
+  let ( >>= ) x f = bind x f
+
+  module Ivar = struct
+    type 'a state = Full of 'a | Empty of ('a -> unit) Queue.t
+    type 'a t = { mutable state : 'a state }
+
+    let create () = { state = Empty (Queue.create ()) }
+
+    let fill t x =
+      match t.state with
+      | Full _ -> failwith "Ivar.fill"
+      | Empty q ->
+          t.state <- Full x;
+          Queue.iter (fun f -> f x) q
+
+    let read t k =
+      match t.state with Full x -> k x | Empty q -> Queue.push k q
+  end
+
+  module Future = struct let wait = Ivar.read end
+
+  let fork f k =
+    let ivar = Ivar.create () in
+    f () (fun x -> Ivar.fill ivar x);
+    k ivar
+
+  type tpool = {
+    seq : seq;
+    work_mutex : Mutex.t;
+    work_cond : Condition.t;
+    working_cond : Condition.t;
+    mutable working_cnt : int;
+    mutable thread_cnt : int;
+    mutable stop : bool;
+  }
+
+  and seq = { mutable prev : seq; mutable next : seq }
+
+  let make_seq () =
+    let rec seq = { prev = seq; next = seq } in
+    seq
+
+  type prgn = Prgn : ('a -> unit) * 'a -> prgn
+
+  type node = {
+    mutable node_prev : seq;
+    mutable node_next : seq;
+    prgn : prgn;
+    mutable active : bool;
+  }
+
+  external node_of_seq : seq -> node = "%identity"
+  external seq_of_node : node -> seq = "%identity"
+
+  let is_empty tm = tm.seq.next == tm.seq
+
+  let wait tm =
+    Mutex.lock tm.work_mutex;
+    let rec loop () =
+      if
+        ((not tm.stop) && (tm.working_cnt <> 0 || not (is_empty tm)))
+        || (tm.stop && tm.thread_cnt <> 0)
+      then (
+        Condition.wait tm.working_cond tm.work_mutex;
+        loop ())
+    in
+    loop ();
+    Mutex.unlock tm.work_mutex
+
+  let remove node =
+    if node.active then (
+      node.active <- false;
+      let seq = seq_of_node node in
+      seq.prev.next <- seq.next;
+      seq.next.prev <- seq.prev)
+
+  let pop tm =
+    if is_empty tm then None
+    else
+      let res = node_of_seq tm.seq.next in
+      remove res;
+      Some res.prgn
+
+  let worker tm =
+    let rec loop () =
+      Mutex.lock tm.work_mutex;
+      while is_empty tm && not tm.stop do
+        Condition.wait tm.work_cond tm.work_mutex
+      done;
+      if not tm.stop then (
+        let res = pop tm in
+        tm.working_cnt <- tm.working_cnt + 1;
+        Mutex.unlock tm.work_mutex;
+        (match res with Some (Prgn (f, a)) -> f a | None -> ());
+        Mutex.lock tm.work_mutex;
+        tm.working_cnt <- tm.working_cnt - 1;
+        if (not tm.stop) && tm.working_cnt = 0 && is_empty tm then
+          Condition.signal tm.working_cond;
+        Mutex.unlock tm.work_mutex;
+        loop ())
+    in
+    loop ();
+    tm.thread_cnt <- tm.thread_cnt - 1;
+    Condition.signal tm.working_cond;
+    Mutex.unlock tm.work_mutex
+
+  let concurrency = ref 4
+
+  let make () =
+    let tm =
+      {
+        working_cnt = 0;
+        thread_cnt = !concurrency;
+        stop = false;
+        work_mutex = Mutex.create ();
+        work_cond = Condition.create ();
+        working_cond = Condition.create ();
+        seq = make_seq ();
+      }
+    in
+    for _ = 0 to !concurrency - 1 do
+      let _ = Thread.create worker tm in
+      ()
+    done;
+    tm
+
+  let drop tm =
+    let rec loop () = match pop tm with Some _ -> loop () | None -> () in
+    loop ()
+
+  let reset tm =
+    Mutex.lock tm.work_mutex;
+    drop tm;
+    tm.stop <- true;
+    Condition.broadcast tm.work_cond;
+    Mutex.unlock tm.work_mutex;
+    wait tm;
+    tm.stop <- false;
+    tm.thread_cnt <- !concurrency;
+    for _ = 0 to !concurrency - 1 do
+      let _ = Thread.create worker tm in
+      ()
+    done
+
+  let add tm prgn =
+    Mutex.lock tm.work_mutex;
+    let node =
+      { node_prev = tm.seq.prev; node_next = tm.seq; prgn; active = true }
+    in
+    tm.seq.prev.next <- seq_of_node node;
+    tm.seq.prev <- seq_of_node node;
+    Condition.signal tm.work_cond;
+    Mutex.unlock tm.work_mutex
+
+  let tm = make ()
+
+  let run fiber =
+    let result = ref None in
+    fiber (fun x -> result := Some x);
+    wait tm;
+    match !result with
+    | Some x ->
+        reset tm;
+        x
+    | None -> failwith "IO.run"
+
+  module Mutex = struct
+    type 'a fiber = 'a t
+
+    let create () = Mutex.create ()
+
+    let lock : Mutex.t -> unit t =
+     fun t ->
+      fork (fun () ->
+          Mutex.lock t;
+          return ())
+      >>= fun future -> Future.wait future
+
+    let unlock t = Mutex.unlock t
+
+    type t = Mutex.t
+  end
+
+  module Condition = struct
+    type 'a fiber = 'a t
+    type mutex = Mutex.t
+    type t = Condition.t
+
+    let create () = Condition.create ()
+
+    let wait mutex t =
+      fork (fun () ->
+          Condition.wait mutex t;
+          return ())
+      >>= fun future -> Future.wait future
+
+    let signal t = Condition.signal t
+    let broadcast t = Condition.broadcast t
+  end
+
+  let rec parallel_iter ~f = function
+    | [] -> return ()
+    | x :: r ->
+        fork (fun () -> f x) >>= fun future ->
+        parallel_iter ~f r >>= fun () -> Future.wait future
+
+  let create_process tm prgn = add tm (Prgn (prgn, ()))
+
+  let detach prgn =
+    let ivar = Ivar.create () in
+    create_process tm (fun () ->
+        let res = prgn () in
+        Ivar.fill ivar res);
+    Ivar.read ivar
+
+  let rec parallel_map ~f = function
+    | [] -> return []
+    | x :: r ->
+        fork (fun () -> f x) >>= fun future ->
+        parallel_map ~f r >>= fun r ->
+        Future.wait future >>= fun x -> return (x :: r)
+end
+
+module Us = Carton.Make (struct type 'a t = 'a IO.t end)
+
+let unix =
+  let open IO in
+  let open Us in
+  {
+    Carton.bind = (fun x f -> inj (bind (prj x) (fun x -> prj (f x))));
+    Carton.return = (fun x -> inj (return x));
+  }
 
 let unix_read : (in_channel, Us.t) Carton.Dec.read =
  fun fd buf ~off ~len ->
   let n = input fd buf off len in
-  Us.inj n
-
-module IO = struct
-  type 'a t = 'a
-
-  module Mutex = Mutex
-  module Future = Future
-  module Condition = Condition
-
-  let bind x f = f x
-  let return x = x
-
-  let nfork_map l ~f =
-    match l with
-    | [] -> []
-    | [ x ] ->
-        let v = ref None in
-        let th = Thread.create (fun () -> v := Some (f x)) () in
-        [ { Future.th; Future.v } ]
-    | vs ->
-        let f x =
-          let v = ref None in
-          let th = Thread.create (fun () -> v := Some (f x)) () in
-          { Future.th; Future.v }
-        in
-        List.map f vs
-
-  let all_unit l = List.iter Sys.opaque_identity l
-end
+  Us.inj (IO.return n)

--- a/test/carton/test.ml
+++ b/test/carton/test.ml
@@ -521,7 +521,6 @@ let verify_bomb_pack () =
       ~uid_rw:Uid.of_raw_string (fun _ -> Alcotest.fail "Invalid call to IDX")
   in
   IO.run (Verify.verify ~threads:1 ~map ~oracle t ~matrix);
-  Fmt.epr ">>> End of verify.\n%!";
   Unix.close fd;
 
   let offsets =
@@ -758,9 +757,7 @@ let pack_bomb_pack () =
   in
 
   let output_bigstring ctx oc buf ~off ~len =
-    Fmt.epr "[+] %S.\n%!" (Bigstringaf.substring buf ~off ~len);
     let ctx = Uid.feed ctx buf ~off ~len in
-    Fmt.epr "[-] %a.\n%!" Uid.pp (Uid.get ctx);
     let s = Bigstringaf.substring buf ~off ~len in
     output_string oc s;
     (Us.inj <.> IO.return) ctx
@@ -800,9 +797,6 @@ let pack_bomb_pack () =
     >>= fun targets ->
     Carton.Enc.header_of_pack ~length:(Array.length targets) header 0 12;
     output_bigstring ctx oc header ~off:0 ~len:12 |> Us.prj >>= fun ctx ->
-    Fmt.epr ">>> @[<hov>%a@].\n%!"
-      Fmt.(Dump.array (using Carton.Enc.target_uid Uid.pp))
-      targets;
     let rec go ctx idx arr =
       if idx < Array.length arr then
         iter ctx arr.(idx) |> Us.prj >>= fun ctx -> go ctx (succ idx) arr
@@ -815,7 +809,6 @@ let pack_bomb_pack () =
   output_string oc (Uid.to_raw_string hash);
   close_out oc;
 
-  Fmt.epr ">>> hash of new.pack: %a.\n%!" Uid.pp hash;
   Alcotest.(check pass) "new.pack" () ();
   let res =
     let cmd = Bos.Cmd.(v "git" % "index-pack" % "new.pack") in

--- a/test/carton/test_lwt.ml
+++ b/test/carton/test_lwt.ml
@@ -5,7 +5,7 @@ let map _ fd ~pos len =
   let payload =
     Mmap.V1.map_file fd ~pos Bigarray.char Bigarray.c_layout false [| len |]
   in
-  Lwt.return (Bigarray.array1_of_genarray payload)
+  Bigarray.array1_of_genarray payload
 
 let yield_map root fd ~pos len = map root fd ~pos len
 

--- a/test/cstruct_append/test.ml
+++ b/test/cstruct_append/test.ml
@@ -53,7 +53,7 @@ let test_trunk_mode =
   >>= fun () ->
   Gc.full_major ();
   with_fd ~mode:Rd
-    ~f:(fun fd _ -> Cstruct_append.map device fd ~pos:0L 12)
+    ~f:(fun fd _ -> Cstruct_append.map device fd ~pos:0L 12 |> Lwt.return)
     device a Bigstringaf.empty
   >>= fun v ->
   Gc.full_major ();
@@ -93,7 +93,7 @@ let test_three_contents =
   Gc.full_major ();
   with_fd ~mode:RdWr
     ~f:(fun fd str ->
-      Cstruct_append.map device fd ~pos:0L 3 >>= fun v ->
+      let v = Cstruct_append.map device fd ~pos:0L 3 in
       Alcotest.(check string) "contents" (Bigstringaf.to_string v) "";
       (* O_TRUNC *)
       Cstruct_append.append device fd str)

--- a/test/index/test.ml
+++ b/test/index/test.ml
@@ -84,7 +84,6 @@ let blob_of_path path =
     Git.Blob.of_string contents
   else
     let ic = open_in_bin (Fpath.to_string path) in
-    Fmt.epr ">>> blob_of_path: %a.\n%!" Fpath.pp path;
     let ln = in_channel_length ic in
     let rs = Bytes.create ln in
     really_input ic rs 0 ln;

--- a/test/smart/append.ml
+++ b/test/smart/append.ml
@@ -27,7 +27,7 @@ let map _ fd ~pos len =
       (Lwt_unix.unix_file_descr fd)
       ~pos Bigarray.char Bigarray.c_layout false [| len |]
   in
-  Lwt.return (Bigarray.array1_of_genarray res)
+  Bigarray.array1_of_genarray res
 
 let append _ fd str =
   let rec go off len =


### PR DESCRIPTION
If we assume that `mmap` does not block the execution, we can unwrap it from the IO monad. Such update unlock the ability to really take the opportunity to unpack Git objects in concurrency/with true parallelism as Git does. The diff is huge because we update the interface of `carton`.

However, tests are green about decode/encode PACK file and we should don't have errors on large PACK file (however, I need to test such case). Finally, for LWT/Git, we are able to use `Lwt_list.iter_p` and `Lwt_list.map_p` which should be very good when we clone large PACK file.

About tests, a derivation of [minifiber] was done with `Thread` to test, as `git` does, `git index-pack`/`git verify-pack` with real threads (and, in this context, if `carton` works properly into a concurrent context). We should know easily if we have a performance improvement, but naively, I can say yes when multiples threads can unpack several objects cooperatively now.