### PR TITLE
Adapt to conduit 2.3.0

### DIFF
--- a/git-cohttp-mirage.opam
+++ b/git-cohttp-mirage.opam
@@ -19,6 +19,8 @@ depends: [
   "result" {>= "1.5"}
   "rresult" {>= "0.6.0"}
   "uri" {>= "4.0.0"}
+  "mirage-clock"
+  "x509"
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}
   "bigstringaf" {>= "0.7.0" & with-test}

--- a/src/git-cohttp-mirage/dune
+++ b/src/git-cohttp-mirage/dune
@@ -2,4 +2,4 @@
  (name git_cohttp_mirage)
  (public_name git-cohttp-mirage)
  (libraries mimic lwt rresult result git.nss.git uri fmt cohttp cohttp-lwt
-   cohttp-mirage))
+   cohttp-mirage mirage-clock conduit-mirage x509))

--- a/src/git-cohttp-mirage/git_cohttp_mirage.ml
+++ b/src/git-cohttp-mirage/git_cohttp_mirage.ml
@@ -1,49 +1,59 @@
 open Lwt.Infix
 
-type error = |
+module Client
+    (P : Mirage_clock.PCLOCK)
+    (R : Resolver_mirage.S)
+    (S : Conduit_mirage.S) =
+struct
+  module Client = Cohttp_mirage.Client.Make (P) (R) (S)
 
-let pp_error : error Fmt.t = fun _ppf -> function _ -> .
-let conduit = Mimic.make ~name:"conduit"
-let with_conduit v ctx = Mimic.add conduit v ctx
+  type error = |
 
-let with_redirects ?(max = 10) ~f uri =
-  if max < 10 then invalid_arg "with_redirects";
-  let tbl = Hashtbl.create 0x10 in
-  let rec go max uri =
-    f uri >>= fun (resp, body) ->
-    let status_code = Cohttp.(Response.status resp |> Code.code_of_status) in
-    if Cohttp.Code.is_redirection status_code then
-      match Cohttp.(Response.headers resp |> Header.get_location) with
-      | Some uri' when Hashtbl.mem tbl uri' || max = 0 -> Lwt.return (resp, body)
-      | Some uri' ->
-          Hashtbl.add tbl uri' ();
-          Cohttp_lwt.Body.drain_body body >>= fun () -> go (pred max) uri'
-      | None -> Lwt.return (resp, body)
-    else Lwt.return (resp, body)
-  in
-  go max uri
+  let pp_error : error Fmt.t = fun _ppf -> function _ -> .
+  let conduit = Mimic.make ~name:"conduit"
 
-let get ~ctx ?(headers = []) uri =
-  let ctx =
-    match Mimic.get conduit ctx with
-    | Some ctx -> ctx
-    | None -> Cohttp_mirage.Client.default_ctx
-  in
-  let headers = Cohttp.Header.of_list headers in
-  let f uri = Cohttp_mirage.Client.get ~ctx ~headers uri in
-  with_redirects ~f uri >>= fun (_resp, body) ->
-  Cohttp_lwt.Body.to_string body >>= fun body -> Lwt.return_ok ((), body)
+  let ctx ?authenticator r s =
+    let v = Client.ctx ?authenticator r s in
+    Mimic.add conduit v Mimic.empty
 
-let post ~ctx ?(headers = []) uri body =
-  let ctx =
-    match Mimic.get conduit ctx with
-    | Some ctx -> ctx
-    | None -> Cohttp_mirage.Client.default_ctx
-  in
-  let headers = Cohttp.Header.of_list headers in
-  let body = Cohttp_lwt.Body.of_string body in
-  let f uri =
-    Cohttp_mirage.Client.post ~ctx ~headers ~chunked:false ~body uri
-  in
-  with_redirects ~f uri >>= fun (_resp, body) ->
-  Cohttp_lwt.Body.to_string body >>= fun body -> Lwt.return_ok ((), body)
+  let with_redirects ?(max = 10) ~f uri =
+    if max < 10 then invalid_arg "with_redirects";
+    let tbl = Hashtbl.create 0x10 in
+    let rec go max uri =
+      f uri >>= fun (resp, body) ->
+      let status_code = Cohttp.(Response.status resp |> Code.code_of_status) in
+      if Cohttp.Code.is_redirection status_code then
+        match Cohttp.(Response.headers resp |> Header.get_location) with
+        | Some uri' when Hashtbl.mem tbl uri' || max = 0 ->
+            Lwt.return (resp, body)
+        | Some uri' ->
+            Hashtbl.add tbl uri' ();
+            Cohttp_lwt.Body.drain_body body >>= fun () -> go (pred max) uri'
+        | None -> Lwt.return (resp, body)
+      else Lwt.return (resp, body)
+    in
+    go max uri
+
+  let get ~ctx ?(headers = []) uri =
+    let ctx =
+      match Mimic.get conduit ctx with
+      | Some ctx -> ctx
+      | None -> failwith "conduit not initialised"
+    in
+    let headers = Cohttp.Header.of_list headers in
+    let f uri = Client.get ~ctx ~headers uri in
+    with_redirects ~f uri >>= fun (_resp, body) ->
+    Cohttp_lwt.Body.to_string body >>= fun body -> Lwt.return_ok ((), body)
+
+  let post ~ctx ?(headers = []) uri body =
+    let ctx =
+      match Mimic.get conduit ctx with
+      | Some ctx -> ctx
+      | None -> failwith "conduit not initialised"
+    in
+    let headers = Cohttp.Header.of_list headers in
+    let body = Cohttp_lwt.Body.of_string body in
+    let f uri = Client.post ~ctx ~headers ~chunked:false ~body uri in
+    with_redirects ~f uri >>= fun (_resp, body) ->
+    Cohttp_lwt.Body.to_string body >>= fun body -> Lwt.return_ok ((), body)
+end

--- a/src/git-cohttp-mirage/git_cohttp_mirage.mli
+++ b/src/git-cohttp-mirage/git_cohttp_mirage.mli
@@ -1,4 +1,8 @@
-include Smart_git.HTTP
+module Client
+    (P : Mirage_clock.PCLOCK)
+    (R : Resolver_mirage.S)
+    (S : Conduit_mirage.S) : sig
+  include Smart_git.HTTP
 
-val conduit : Cohttp_mirage.Client.ctx Mimic.value
-val with_conduit : Cohttp_mirage.Client.ctx -> Mimic.ctx -> Mimic.ctx
+  val ctx : ?authenticator:X509.Authenticator.t -> R.t -> S.t -> Mimic.ctx
+end


### PR DESCRIPTION
Follow-up of https://github.com/mirage/ocaml-conduit/pull/376 and https://github.com/mirage/ocaml-cohttp/pull/742