### PR TITLE
git-unix: Fix new smart test without a global git config

### DIFF
--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -1620,6 +1620,11 @@ let test_partial_fetch_ssh () =
 
 let make_one_commit path =
   Bos.OS.Dir.with_current path @@ fun () ->
+  Bos.OS.Cmd.run Bos.Cmd.(v "git" % "config" % "user.name" % "test")
+  >>= fun () ->
+  Bos.OS.Cmd.run
+    Bos.Cmd.(v "git" % "config" % "user.email" % "pseudo@peudo.invalid")
+  >>= fun () ->
   Bos.OS.File.write Fpath.(v "foo") "" >>= fun () ->
   Bos.OS.Cmd.run Bos.Cmd.(v "git" % "add" % "foo") >>= fun () ->
   Bos.OS.Cmd.run Bos.Cmd.(v "git" % "commit" % "-m" % ".") >>= fun () -> R.ok ()


### PR DESCRIPTION
The issue fixed here is the same as #439. We also make sure the git
config is set in make_one_commit in case tests are run in an environment
without a global git config.