### PR TITLE
ref-find-common

### DIFF
--- a/src/not-so-smart/find_common.ml
+++ b/src/not-so-smart/find_common.ml
@@ -1,30 +1,7 @@
 open Sigs
-open Smart_flow
-
-let ( <.> ) f g x = f (g x)
 
 module Log = (val let src = Logs.Src.create "find-common" in
                   Logs.src_log src : Logs.LOG)
-
-let _initial_flush = 16
-let _max_in_vain = 256
-let _large_flush = 16384
-let _pipe_safe_flush = 32
-
-(* XXX(dinosaure): this part is really **ugly**! But we must follow the same
-   behaviour of [git]. Instead to understand the synchronisation process of [git]
-   with Smart.v1 and implement a state of the art synchronisation algorithm, I
-   translated as is [fetch-pack.c:find_common] in OCaml. *)
-
-let unsafe_write_have ctx hex =
-  let packet = Fmt.str "have %s\n" hex in
-  Smart.Unsafe.write ctx packet
-
-let next_flush stateless count =
-  if stateless then
-    if count < _large_flush then count lsl 1 else count * 11 / 10
-  else if count < _pipe_safe_flush then count lsl 1
-  else count + _pipe_safe_flush
 
 type configuration = {
   stateless : bool;
@@ -38,76 +15,114 @@ type 'uid hex = {
   compare : 'uid -> 'uid -> int;
 }
 
-let tips { bind; return } { get; deref; locals; _ } store negotiator =
-  let ( >>= ) = bind in
-  let ( >>| ) x f = x >>= fun x -> return (f x) in
+(* Constants defined by the canoncial git implementation in C *)
+let initial_flush = 16
+let max_in_vain = 256
+let large_flush = 16384
+let pipe_safe_flush = 32
 
-  let rec go = function
-    | [] -> return ()
-    | reference :: others ->
-        deref store reference
-        >>= Option.fold ~none:(return None) ~some:(fun uid -> get uid store)
-        >>| Option.iter (fun obj -> Default.tip negotiator obj)
-        >>= fun () -> go others
-  in
-  locals store >>= go
+(** module type that defins common functions for a scheduler, e.g., Lwt or Async *)
+module type Io_monad = sig
+  type s
 
-let consume_shallow_list ({ bind; return } as scheduler) io flow cfg deepen
-    { of_hex; _ } _access _store ctx =
-  let ( >>= ) = bind in
+  val bind : ('a, s) io -> ('a -> ('b, s) io) -> ('b, s) io
+  val map : ('a -> 'b) -> ('a, s) io -> ('b, s) io
+  val ( >>= ) : ('a, s) io -> ('a -> ('b, s) io) -> ('b, s) io
+  val ( >>| ) : ('a, s) io -> ('a -> 'b) -> ('b, s) io
+  val return : 'a -> ('a, s) io
+
+  val fold_left_s :
+    f:('a -> 'b -> ('a, s) io) -> init:'a -> 'b list -> ('a, s) io
+end
+
+(** given ['s Sigs.scheduler], returns a module of type [Io_monad] that has
+    infix operations, etc. This allows us to avoid repetitive redefinition of common
+    functions. *)
+let io_monad (type t) { bind; return } =
+  (module struct
+    type s = t
+
+    let bind = bind
+    let return = return
+    let map f x = bind x (fun v -> return (f v))
+    let ( >>= ) = bind
+    let ( >>| ) x f = map f x
+
+    let fold_left_s ~f ~init l =
+      let rec go a = function
+        | [] -> return a
+        | x :: r -> bind (f a x) (fun a' -> go a' r)
+      in
+      go init l end : Io_monad
+    with type s = t)
+
+(* XXX(dinosaure): this part is really **ugly**! But we must follow the same
+   behaviour of [git]. Instead to understand the synchronisation process of [git]
+   with Smart.v1 and implement a state of the art synchronisation algorithm, I
+   translated as is [fetch-pack.c:find_common] in OCaml. *)
+
+let tips (type t) scheduler access store negotiator =
+  let open (val io_monad scheduler : Io_monad with type s = t) in
+  access.locals store >>= fun ref_lst ->
+  fold_left_s ref_lst ~init:() ~f:(fun () reference ->
+      access.deref store reference
+      >>= Option.fold ~none:(return None) ~some:(fun uid ->
+              access.get uid store)
+      >>| Option.iter (fun obj -> Default.tip negotiator obj))
+
+let consume_shallow_list (type t) scheduler io flow cfg deepen { of_hex; _ } ctx
+    =
+  let open (val io_monad scheduler : Io_monad with type s = t) in
   if cfg.stateless && Option.is_some deepen then
-    run scheduler raise io flow Smart.(recv ctx shallows) >>= fun shallows ->
-    let lst = List.map (Smart.Shallow.map ~f:of_hex) shallows in
-    return lst
+    Smart_flow.run scheduler raise io flow Smart.(recv ctx shallows)
+    >>| fun shallows -> List.map (Smart.Shallow.map ~f:of_hex) shallows
   else return []
 
-let handle_shallow ({ bind; return } as scheduler) io flow { of_hex; _ } access
-    store ctx =
-  let ( >>= ) = bind in
-  run scheduler raise io flow Smart.(recv ctx shallows) >>= fun shallows ->
-  let lst = List.map (Smart.Shallow.map ~f:of_hex) shallows in
-  let f = function
+let handle_shallow (type t) scheduler io flow { of_hex; _ } access store ctx =
+  let open (val io_monad scheduler : Io_monad with type s = t) in
+  Smart_flow.run scheduler raise io flow Smart.(recv ctx shallows)
+  >>= fun shallows ->
+  let shallows = List.map (Smart.Shallow.map ~f:of_hex) shallows in
+  fold_left_s shallows ~init:() ~f:(fun () -> function
     | Smart.Shallow.Shallow uid -> access.shallow store uid
-    | Smart.Shallow.Unshallow uid -> access.unshallow store uid
-  in
-  let rec go = function [] -> return () | h :: t -> f h >>= fun () -> go t in
-  go lst
+    | Unshallow uid -> access.unshallow store uid)
 
-let find_common ({ bind; return } as scheduler) io flow
-    ({ stateless; no_done; _ } as cfg) ({ to_hex; of_hex; compare } as hex)
-    access store negotiator ctx
+let unsafe_write_have ctx hex =
+  let packet = Fmt.str "have %s\n" hex in
+  Smart.Unsafe.write ctx packet
+
+let next_flush stateless count =
+  if stateless then if count < large_flush then count lsl 1 else count * 11 / 10
+  else if count < pipe_safe_flush then count lsl 1
+  else count + pipe_safe_flush
+
+let find_common (type t) scheduler io flow cfg
+    ({ to_hex; of_hex; compare } as hex) access store negotiator ctx
     ?(deepen : [ `Depth of int | `Timestamp of int64 ] option) refs =
-  let ( >>= ) = bind in
-  let ( >>| ) x f = x >>= fun x -> return (f x) in
-  let fold_left_s ~f a l =
-    let rec go a = function
-      | [] -> return a
-      | x :: r -> f a x >>= fun a -> go a r
-    in
-    go a l
-  in
+  let open (val io_monad scheduler : Io_monad with type s = t) in
+  let { stateless; no_done; _ } = cfg in
+
   let fold acc remote_uid =
-    Log.debug (fun m -> m "<%s> exists locally?" (to_hex remote_uid));
-    access.get remote_uid store >>= function
-    | Some _ -> return acc
-    | None -> return ((remote_uid, ref 0) :: acc)
+    access.get remote_uid store >>| function
+    | Some _ -> acc
+    | None -> (remote_uid, ref 0) :: acc
   in
-  fold_left_s ~f:fold [] refs
+
+  fold_left_s ~f:fold ~init:[] refs
   >>| List.sort_uniq (fun (a, _) (b, _) -> compare a b)
   >>= function
   | [] ->
       Log.debug (fun m -> m "Nothing to download.");
-      run scheduler raise io flow Smart.(send ctx flush ()) >>= fun () ->
-      return `Close
-  | uid :: others ->
-      Log.debug (fun m ->
-          m "We want %d commit(s)." (List.length (uid :: others)));
+      Smart_flow.run scheduler raise io flow Smart.(send ctx flush ())
+      >>= fun () -> return `Close
+  | (uid, _) :: others as refs ->
+      Log.debug (fun m -> m "We want %d commit(s)." (List.length refs));
       access.shallowed store >>= fun shallowed ->
       let shallowed = List.map to_hex shallowed in
-      run scheduler raise io flow
+      Smart_flow.run scheduler raise io flow
         Smart.(
-          let uid = (to_hex <.> fst) uid in
-          let others = List.map (to_hex <.> fst) others in
+          let uid = to_hex uid in
+          let others = List.map (fun (uid, _) -> to_hex uid) others in
           let capabilities, _ = Smart.Context.capabilities ctx in
           let deepen =
             (deepen
@@ -122,7 +137,7 @@ let find_common ({ bind; return } as scheduler) io flow
       >>= fun () ->
       let in_vain = ref 0 in
       let count = ref 0 in
-      let flush_at = ref _initial_flush in
+      let flush_at = ref initial_flush in
       let flushes = ref 0 in
       let got_continue = ref false in
       let got_ready = ref false in
@@ -144,33 +159,30 @@ let find_common ({ bind; return } as scheduler) io flow
                 m "count: %d, in-vain: %d, flush-at: %d.\n%!" !count !in_vain
                   !flush_at);
             if !flush_at <= !count then (
-              run scheduler raise io flow Smart.(send ctx flush ())
+              Smart_flow.run scheduler raise io flow Smart.(send ctx flush ())
               >>= fun () ->
               incr flushes;
               flush_at := next_flush stateless !count;
-              if (not stateless) && !count = _initial_flush then go negotiator
+              if (not stateless) && !count = initial_flush then go negotiator
               else
-                consume_shallow_list scheduler io flow cfg None hex access store
-                  ctx
+                consume_shallow_list scheduler io flow cfg None hex ctx
                 >>= fun _shallows ->
                 let rec loop () =
-                  run scheduler raise io flow Smart.(recv ctx ack)
+                  Smart_flow.run scheduler raise io flow Smart.(recv ctx ack)
                   >>| Smart.Negotiation.map ~f:of_hex
                   >>= fun ack ->
                   match ack with
                   | Smart.Negotiation.NAK ->
                       Log.debug (fun m -> m "Receive NAK.");
                       return `Continue
-                  | Smart.Negotiation.ACK _ ->
+                  | ACK _ ->
                       flushes := 0;
                       cfg.multi_ack <- `None;
                       (* XXX(dinosaure): [multi_ack] supported by the client but it
                          is not supported by the server. TODO: use [Context.shared]. *)
                       retval := 0;
                       return `Done
-                  | Smart.Negotiation.ACK_common uid
-                  | Smart.Negotiation.ACK_ready uid
-                  | Smart.Negotiation.ACK_continue uid -> (
+                  | ACK_common uid | ACK_ready uid | ACK_continue uid -> (
                       access.get uid store >>= function
                       | None -> assert false
                       | Some obj ->
@@ -212,7 +224,7 @@ let find_common ({ bind; return } as scheduler) io flow
                 | `Done -> return ()
                 | `Continue ->
                     decr flushes;
-                    if !got_continue && _max_in_vain < !in_vain then return ()
+                    if !got_continue && max_in_vain < !in_vain then return ()
                     else if !got_ready then return ()
                     else go negotiator)
             else go negotiator
@@ -221,7 +233,8 @@ let find_common ({ bind; return } as scheduler) io flow
       Log.debug (fun m ->
           m "Negotiation (got ready: %b, no-done: %b)." !got_ready no_done);
       (if (not !got_ready) || not no_done then
-       run scheduler raise io flow Smart.(send ctx negotiation_done ())
+       Smart_flow.run scheduler raise io flow
+         Smart.(send ctx negotiation_done ())
       else return ())
       >>= fun () ->
       if !retval <> 0 then (
@@ -229,23 +242,22 @@ let find_common ({ bind; return } as scheduler) io flow
         incr flushes);
       (if (not !got_ready) || not no_done then (
        Log.debug (fun m -> m "Negotiation is done!");
-       run scheduler raise io flow Smart.(recv ctx shallows)
+       Smart_flow.run scheduler raise io flow Smart.(recv ctx shallows)
        >>= fun _shallows -> return ())
       else return ())
       >>= fun () ->
       let rec go () =
         if !flushes > 0 || cfg.multi_ack = `Some || cfg.multi_ack = `Detailed
         then (
-          run scheduler raise io flow Smart.(recv ctx ack)
+          Smart_flow.run scheduler raise io flow Smart.(recv ctx ack)
           >>| Smart.Negotiation.map ~f:of_hex
           >>= fun ack ->
           match ack with
           | Smart.Negotiation.ACK _ -> return (`Continue 0)
-          | Smart.Negotiation.ACK_common _ | Smart.Negotiation.ACK_continue _
-          | Smart.Negotiation.ACK_ready _ ->
+          | ACK_common _ | ACK_continue _ | ACK_ready _ ->
               cfg.multi_ack <- `Some;
               go ()
-          | Smart.Negotiation.NAK ->
+          | NAK ->
               decr flushes;
               go ())
         else if !count > 0 then return (`Continue !retval)


### PR DESCRIPTION
- make semantically close things closer in file
	- removed underscores from variable names because they usually
	  mean values are not used, which is not the case here
	- use a first-class module to remove rebinding scheduler
	  functionality again and again