### PR TITLE
Implementation of HTTP push and fix bug about commit

### DIFF
--- a/git.opam
+++ b/git.opam
@@ -19,6 +19,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "digestif" {>= "0.8.1"}
   "rresult"
+  "base64" {>= "3.0.0"}
   "result"
   "bigstringaf"
   "bigarray-compat"
@@ -45,7 +46,6 @@ depends: [
   "cmdliner" {with-test}
   "base-unix" {with-test}
   "fpath"
-  "base64" {with-test & >= "3.0.0"}
   "mirage-flow" {>= "2.0.1"}
   "domain-name" {>= "0.3.0"}
   "emile" {>= "1.1"}

--- a/src/git/commit.ml
+++ b/src/git/commit.ml
@@ -146,7 +146,7 @@ module Make (Hash : S.HASH) = struct
       <*> binding ~key:"author" user
       <*> binding ~key:"committer" user
       <*> rep0 extra
-      <*> rest
+      <*> (Encore.Bij.char '\x0a' <$> any) *> rest
 
     let format = Encore.Syntax.map Encore.Bij.(compose obj6 commit) t
   end
@@ -186,6 +186,7 @@ module Make (Hash : S.HASH) = struct
     + List.fold_left
         (fun acc (key, v) -> string key + 1L + values v + acc)
         0L t.extra
+    + 1L
     + string t.message
 
   let pp ppf { tree; parents; author; committer; extra; message } =

--- a/src/not-so-smart/decoder.mli
+++ b/src/not-so-smart/decoder.mli
@@ -103,3 +103,7 @@ val prompt_pkt :
   (decoder -> ('a, ([> error ] as 'b)) state) ->
   decoder ->
   ('a, 'b) state
+
+(**/*)
+
+val pkt_len_unsafe : decoder -> int

--- a/src/not-so-smart/dune
+++ b/src/not-so-smart/dune
@@ -58,6 +58,7 @@
  (name smart_git)
  (public_name git.nss.git)
  (modules smart_git smart_git_intf)
- (libraries bigarray-compat mimic mirage-flow unixiz ipaddr decompress.de
-   decompress.zl cstruct logs astring result rresult bigstringaf fmt emile
-   lwt domain-name uri sigs smart pck nss digestif carton carton-lwt))
+ (libraries base64 bigarray-compat mimic mirage-flow unixiz ipaddr
+   decompress.de decompress.zl cstruct logs astring result rresult
+   bigstringaf fmt emile lwt domain-name uri sigs smart pck nss digestif
+   carton carton-lwt))

--- a/src/not-so-smart/smart.ml
+++ b/src/not-so-smart/smart.ml
@@ -27,7 +27,7 @@ module Witness = struct
   type 'a recv =
     | Advertised_refs : (string, string) Advertised_refs.t recv
     | Result : string Result.t recv
-    | Status : string Status.t recv
+    | Status : bool -> string Status.t recv
     | Packet : bool -> string recv
     | Commands : (string, string) Commands.t option recv
     | Recv_pack : {
@@ -95,7 +95,7 @@ module Value = struct
       | Recv_pack { side_band; push_pack; push_stdout; push_stderr } ->
           decode_pack ~side_band ~push_pack ~push_stdout ~push_stderr decoder
       | Ack -> decode_negotiation decoder
-      | Status -> decode_status decoder
+      | Status sideband -> decode_status ~sideband decoder
       | Shallows -> decode_shallows decoder
       | Packet trim -> decode_packet ~trim decoder)
 end
@@ -140,7 +140,7 @@ let recv_pack ?(side_band = false) ?(push_stdout = ignore)
     ?(push_stderr = ignore) push_pack =
   Recv_pack { side_band; push_pack; push_stdout; push_stderr }
 
-let status = Status
+let status sideband = Status sideband
 let flush = Flush
 let ack = Ack
 let shallows = Shallows

--- a/src/not-so-smart/smart.mli
+++ b/src/not-so-smart/smart.mli
@@ -236,7 +236,7 @@ val recv_pack :
 val recv_commands : (string, string) Commands.t option recv
 val ack : string Negotiation.t recv
 val shallows : string Shallow.t list recv
-val status : string Status.t recv
+val status : bool -> string Status.t recv
 val packet : trim:bool -> string recv
 val send_advertised_refs : (string, string) Advertised_refs.t send
 val bind : ('a, 'err) t -> f:('a -> ('b, 'err) t) -> ('b, 'err) t

--- a/src/not-so-smart/smart_git.ml
+++ b/src/not-so-smart/smart_git.ml
@@ -464,13 +464,19 @@ struct
             | `Domain v -> Domain_name.pp ppf v
             | `Addr v -> Ipaddr.pp ppf v
           in
+          let pp_port ppf = function
+            | Some port -> Fmt.pf ppf ":%d" port
+            | None -> ()
+          in
           let uri, headers =
             match scheme with
             | `HTTP headers ->
-                ( Uri.of_string (Fmt.str "http://%a%s.git" pp_host host path),
+                ( Uri.of_string
+                    (Fmt.str "http://%a%a%s" pp_host host pp_port edn.port path),
                   headers )
             | `HTTPS headers ->
-                ( Uri.of_string (Fmt.str "https://%a%s.git" pp_host host path),
+                ( Uri.of_string
+                    (Fmt.str "https://%a%a%s" pp_host host pp_port edn.port path),
                   headers )
           in
           let run () =


### PR DESCRIPTION
This PR has two things:
- fix a bug about commit
  Indeed, we should have an extra-LF between the commit header and the message. I suspect that Git broke something about that and it silently accepts such commit without verification (`git log` deals with that). However, it seems that `git fsck` checks such assumption and when we want to push over HTTP on GitHub, this command is launched and invalidate our PACK file.

  It's a breaking change! Due to the design of `ocaml-git`/`encore`, old commits (without the double LF) **are not** accepted anymore - we are surely more conservative than Git on this aspect... I advise (/cc @hannesm) to make a fake commit (`git commit --allow-empty -m.`) to sanitize, at least, the last commit (and properly do, then, the `git fetch --depth=1`).

  For the story, I think that the first commit of Linux is **not** well-serialized and it's why I decided to accept such format. May be a solution should be about an optional LF but I'm not sure that I'm able to do that and, at the same time, respect the isomorphism. At least, `ocaml-git` should produce valid commits.

- I implemented the HTTP push and we accept a remote such as: `http://user:password@github.com/repo`. I tested the unikernel example with GitHub and I rewrite the `report-status` decoder to be correct with HTTP responses. Regression tests help me to keep the compatibility with `git://` and SSH (big thank to the old version of me). It still is a pain to parse something which is **not** specified. So HTTP push should work but I did not write tests yet.