### PR TITLE
A git commit can have an empty message

### DIFF
--- a/src/git/commit.mli
+++ b/src/git/commit.mli
@@ -36,7 +36,7 @@ module type S = sig
     committer:User.t ->
     ?parents:hash list ->
     ?extra:(string * string list) list ->
-    string ->
+    string option ->
     t
   (** [make ~author ~committer ?parents ~tree msg] makes an OCaml value {!t}.
       [?parents] should be a non-empty list and corresponds to a list of hashes
@@ -68,7 +68,7 @@ module type S = sig
   val author : t -> User.t
   (** [author c] returns the author of the given commit object. *)
 
-  val message : t -> string
+  val message : t -> string option
   (** [message c] returns the message of the given commit object. *)
 
   val extra : t -> (string * string list) list

--- a/src/git/tag.mli
+++ b/src/git/tag.mli
@@ -34,7 +34,7 @@ module type S = sig
   type hash
   type nonrec t = hash t
 
-  val make : hash -> kind -> ?tagger:User.t -> tag:string -> string -> t
+  val make : hash -> kind -> ?tagger:User.t -> tag:string -> string option -> t
   (** [make hash kind ?tagger ~tag descr] makes a new tag with the kind [kind]
       by the [tagger] with the name [tag] and the description [descr].
 
@@ -56,7 +56,7 @@ module type S = sig
   val tag : t -> string
   (** [tag t] returns the information of the given tag. *)
 
-  val message : t -> string
+  val message : t -> string option
   val kind : t -> kind
   val tagger : t -> User.t option
 end

--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -1694,7 +1694,8 @@ let test_push_capabilities () =
   let tree0 = Git.Mem.Store.Value.(tree (Tree.v [])) in
   let commit0 root =
     Git.Mem.Store.Value.(
-      commit (Commit.make ~parents:[] ~tree:root ~author ~committer:author "."))
+      commit
+        (Commit.make ~parents:[] ~tree:root ~author ~committer:author (Some ".")))
   in
   let fiber =
     Git.Mem.Store.v (Fpath.v "/") >|= store_err >>? fun store ->

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -63,7 +63,7 @@ struct
     {
       Git.User.name = "John Doe";
       email = "john@doe.org";
-      date = Random.int64 Int64.max_int, None;
+      date = Int64.of_int (Random.int (0x40000000 - 1)), None;
     }
 
   let c1 =
@@ -89,7 +89,7 @@ struct
     {
       Git.User.name = "Thomas Gazagnaire";
       email = "thomas@gazagnaire.org";
-      date = Random.int64 Int64.max_int, None;
+      date = Int64.of_int (Random.int (0x40000000 - 1)), None;
     }
 
   let c4 =

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -69,13 +69,13 @@ struct
   let c1 =
     Store.Value.Commit.make
       ~tree:(Store.Value.Tree.digest t2)
-      ~author:john_doe ~committer:john_doe "hello r1"
+      ~author:john_doe ~committer:john_doe (Some "hello r1")
 
   let c2 =
     Store.Value.Commit.make
       ~tree:(Store.Value.Tree.digest t4)
       ~parents:[ Store.Value.Commit.digest c1 ]
-      ~author:john_doe ~committer:john_doe "hello r1!"
+      ~author:john_doe ~committer:john_doe (Some "hello r1!")
 
   let c3 =
     Store.Value.Commit.make
@@ -98,7 +98,7 @@ struct
       ~parents:[ Store.Value.Commit.digest c3 ]
       ~author:thomas ~committer:thomas
       ~extra:[ "simple-key", [ "simple value" ] ]
-      "with extra-fields"
+      (Some "with extra-fields")
 
   let gpg =
     [
@@ -116,17 +116,18 @@ struct
     Store.Value.Commit.make
       ~tree:(Store.Value.Tree.digest t5)
       ~parents:[ Store.Value.Commit.digest c3 ]
-      ~author:thomas ~committer:thomas ~extra:[ "gpgsig", gpg ] "with GPG"
+      ~author:thomas ~committer:thomas ~extra:[ "gpgsig", gpg ]
+      (Some "with GPG")
 
   let tt1 =
     Store.Value.Tag.make
       (Store.Value.Commit.digest c1)
-      Git.Tag.Commit ~tag:"foo" ~tagger:john_doe "Ho yeah!"
+      Git.Tag.Commit ~tag:"foo" ~tagger:john_doe (Some "Ho yeah!")
 
   let tt2 =
     Store.Value.Tag.make
       (Store.Value.Commit.digest c2)
-      Git.Tag.Commit ~tag:"bar" ~tagger:john_doe "Haha!"
+      Git.Tag.Commit ~tag:"bar" ~tagger:john_doe (Some "Haha!")
 
   let r1 = Git.Reference.v "refs/origin/head"
   let r2 = Git.Reference.v "refs/upstream/head"

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -1,7 +1,8 @@
 (executable
  (name test)
- (libraries git digestif cmdliner rresult result alcotest fpath lwt lwt.unix
-   alcotest-lwt base64 bos git-unix fmt.tty logs.fmt test_store))
+ (libraries ptime ptime.clock.os git digestif cmdliner rresult result
+   alcotest fpath lwt lwt.unix alcotest-lwt base64 bos git-unix fmt.tty
+   logs.fmt test_store))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
Fix mirage/irmin#917. A `git fsck` is launched to check some invariants about format of Git objects. Note that `cgit` silently accepts our commits for a long time without errors. This PR has a breaking change about the API. A patch on `irmin` will coming soon to keep the compatibility.