### PR TITLE
test/unix: fix write test without a git config

### DIFF
--- a/test/unix/test.ml
+++ b/test/unix/test.ml
@@ -258,6 +258,11 @@ let empty_commit =
     let open Rresult in
     R.join
     <.> Bos.OS.Dir.with_current path @@ fun () ->
+        Bos.OS.Cmd.run Bos.Cmd.(v "git" % "config" % "user.name" % "test")
+        >>= fun () ->
+        Bos.OS.Cmd.run
+          Bos.Cmd.(v "git" % "config" % "user.email" % "pseudo@pseudo.invalid")
+        >>= fun () ->
         Bos.OS.Cmd.run
           Bos.Cmd.(v "git" % "commit" % "--allow-empty" % "-m" % ".")
   in


### PR DESCRIPTION
This is becoming a similar sight, but easily fixed, updates in NixOS should be done soon as well :)

---

git commit fails if user.email and user.name are not set which may be
the case for sandboxed environments for example. This is easily fixed by
setting a local git config for the current directory before commiting.