### PR TITLE
A fix about reporting status when we push

### DIFF
--- a/carton-git.opam
+++ b/carton-git.opam
@@ -24,7 +24,7 @@ depends: [
   "mmap"
   "fmt" {>= "0.8.7"}
   "base-unix"
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "astring" {>= "0.8.5"}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}

--- a/carton-lwt.opam
+++ b/carton-lwt.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "carton" {= version}
   "lwt"
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf"
   "bigarray-compat" {with-test}

--- a/carton.opam
+++ b/carton.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.6.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf"

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -33,7 +33,7 @@ depends: [
   "awa"
   "cmdliner" {>= "1.0.4"}
   "cohttp-lwt-unix" {>= "2.5.4"}
-  "decompress" {>= "1.2.0"}
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "5.0.1"}
   "mtime" {>= "1.2.0"}

--- a/git.opam
+++ b/git.opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf"
   "bigarray-compat"
   "optint"
-  "decompress"
+  "decompress" {>= "1.2.0" & < "1.3.0"}
   "logs"
   "lwt"
   "mimic"

--- a/src/not-so-smart/decoder.ml
+++ b/src/not-so-smart/decoder.ml
@@ -18,7 +18,7 @@ type error =
   | `No_enough_space
   | `Unexpected_end_of_input
   | `Assert_predicate of char -> bool
-  | `Invalid_pkt_line ]
+  | `Invalid_pkt_line of string ]
 
 let pp_error ppf = function
   | `End_of_input -> Fmt.string ppf "End of input"
@@ -30,7 +30,7 @@ let pp_error ppf = function
   | `No_enough_space -> Fmt.string ppf "No enough space"
   | `Unexpected_end_of_input -> Fmt.string ppf "Unexpected end of input"
   | `Assert_predicate _ -> Fmt.string ppf "Assert predicate"
-  | `Invalid_pkt_line -> Fmt.string ppf "Invalid PKT-line"
+  | `Invalid_pkt_line line -> Fmt.pf ppf "Invalid PKT-line (%S)" line
 
 type 'err info = {
   error : 'err;
@@ -256,7 +256,8 @@ let prompt :
         safe k decoder)
     with
     | _exn (* XXX(dinosaure): [at_least_one_pkt] can raise an exception. *) ->
-      fail decoder `Invalid_pkt_line
+      let line = Bytes.sub_string decoder.buffer decoder.pos off in
+      fail decoder (`Invalid_pkt_line line)
   in
   go decoder.max
 

--- a/src/not-so-smart/decoder.mli
+++ b/src/not-so-smart/decoder.mli
@@ -34,7 +34,7 @@ type error =
   | `Unexpected_end_of_input
   | `No_enough_space
   | `Assert_predicate of char -> bool
-  | `Invalid_pkt_line ]
+  | `Invalid_pkt_line of string ]
 
 val pp_error : error Fmt.t
 

--- a/src/not-so-smart/protocol.mli
+++ b/src/not-so-smart/protocol.mli
@@ -134,7 +134,7 @@ end
 module Status : sig
   type 'ref t = private {
     result : (unit, string) result;
-    commands : ('ref, 'ref * string) result list;
+    commands : [ `FF of 'ref | `OK of 'ref | `ER of 'ref * string ] list;
   }
 
   val map : f:('a -> 'b) -> 'a t -> 'b t
@@ -163,8 +163,9 @@ module Decoder : sig
     | `Invalid_result of string
     | `Invalid_command_result of string
     | `Invalid_command of string
+    | `Unexpected_pkt_line of string
     | `Unexpected_flush
-    | `Invalid_pkt_line ]
+    | `Invalid_pkt_line of string ]
 
   val pp_error : error Fmt.t
 
@@ -183,6 +184,7 @@ module Decoder : sig
 
   val decode_negotiation : decoder -> (string Negotiation.t, [> error ]) state
   val decode_shallows : decoder -> (string Shallow.t list, [> error ]) state
+  val decode_flush : decoder -> (unit, [> error ]) state
 
   val decode_status :
     ?sideband:bool -> decoder -> (string Status.t, [> error ]) state

--- a/src/not-so-smart/push.ml
+++ b/src/not-so-smart/push.ml
@@ -101,6 +101,12 @@ struct
                   Smart.(recv ctx (status side_band))
                 |> prj
                 >>| Smart.Status.map ~f:Ref.v
+              else if uses_git_transport then
+                Smart_flow.run sched fail io flow Smart.(recv ctx recv_flush)
+                |> prj
+                >>= fun () ->
+                let cmds = List.map R.ok (Smart.Commands.commands cmds) in
+                return (Smart.Status.v cmds)
               else
                 let cmds = List.map R.ok (Smart.Commands.commands cmds) in
                 return (Smart.Status.v cmds)

--- a/src/not-so-smart/smart.ml
+++ b/src/not-so-smart/smart.ml
@@ -38,6 +38,7 @@ module Witness = struct
       }
         -> bool recv
     | Ack : string Negotiation.t recv
+    | Flush : unit recv
     | Shallows : string Shallow.t list recv
 end
 
@@ -96,6 +97,7 @@ module Value = struct
           decode_pack ~side_band ~push_pack ~push_stdout ~push_stderr decoder
       | Ack -> decode_negotiation decoder
       | Status sideband -> decode_status ~sideband decoder
+      | Flush -> decode_flush decoder
       | Shallows -> decode_shallows decoder
       | Packet trim -> decode_packet ~trim decoder)
 end
@@ -140,8 +142,9 @@ let recv_pack ?(side_band = false) ?(push_stdout = ignore)
     ?(push_stderr = ignore) push_pack =
   Recv_pack { side_band; push_pack; push_stdout; push_stderr }
 
+let recv_flush : _ recv = Flush
 let status sideband = Status sideband
-let flush = Flush
+let flush : _ send = Flush
 let ack = Ack
 let shallows = Shallows
 

--- a/src/not-so-smart/smart.mli
+++ b/src/not-so-smart/smart.mli
@@ -136,7 +136,7 @@ end
 module Status : sig
   type 'ref t = private {
     result : (unit, string) result;
-    commands : ('ref, 'ref * string) result list;
+    commands : [ `FF of 'ref | `OK of 'ref | `ER of 'ref * string ] list;
   }
 
   val map : f:('a -> 'b) -> 'a t -> 'b t
@@ -189,8 +189,9 @@ type error =
   | `Invalid_command_result of string
   | `Invalid_command of string
   | `No_enough_space
+  | `Unexpected_pkt_line of string
   | `Unexpected_flush
-  | `Invalid_pkt_line ]
+  | `Invalid_pkt_line of string ]
 
 val pp_error : error Fmt.t
 
@@ -233,6 +234,7 @@ val recv_pack :
   (string * int * int -> unit) ->
   bool recv
 
+val recv_flush : unit recv
 val recv_commands : (string, string) Commands.t option recv
 val ack : string Negotiation.t recv
 val shallows : string Shallow.t list recv

--- a/test/smart/loopback.ml
+++ b/test/smart/loopback.ml
@@ -29,7 +29,7 @@ let read flow =
     let len = min (Cstruct.len res) (Cstruct.len flow.i) in
     Cstruct.blit flow.i 0 res 0 len;
     flow.i <- Cstruct.shift flow.i len;
-    Lwt.return_ok (`Data res)
+    Lwt.return_ok (`Data (Cstruct.sub res 0 len))
 
 let ( <.> ) f g x = f (g x)
 

--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -1656,7 +1656,7 @@ let simple_push =
   [
     "008e0000000000000000000000000000000000000000 \
      refs/heads/master\000report-status delete-refs side-band-64k quiet atomic \
-     ofs-delta agent=git/2.27.0";
+     ofs-delta agent=git/2.27.0"; "0000";
   ]
 
 let capability = Alcotest.testable Smart.Capability.pp Smart.Capability.equal


### PR DESCRIPTION
The current situation about `report-status` and protocols is a bit a mess. At this stage, I can say that with `Side_band_64k` and `Report_status` capabilities, all protocols works. I can say that `git://` works with any capabilities. However, SSH and HTTP(s) have some problems if we don't use these capabilities (even if we replace `Side_band_64k` by `Side_band`).

Because the protocol is completely under-documented, it's hard for me to understand where is the bug and reproducibility seems hard when the Git protocol involve along the versions.

However, this PR seems to fix problems for our use case (with `irmin`) and pass regression tests (thanks for the old version of me). Unikernels work with that and we are able to fetch/push correctly _without_ any problems.

- [ ] clean the PR