### PR TITLE
Fix possible stack overflow in Tree.v

### DIFF
--- a/src/git/tree.ml
+++ b/src/git/tree.ml
@@ -126,9 +126,9 @@ let value_of_entry = function
 
 let v entries =
   List.rev_map (fun entry -> value_of_entry entry, entry) entries
-  |> List.rev
   |> List.sort (fun (a, _) (b, _) -> compare a b)
-  |> List.map snd
+  |> List.rev_map snd
+  |> List.rev
 
 let remove ~name t =
   let c = Contents name and n = Node name in

--- a/src/git/tree.ml
+++ b/src/git/tree.ml
@@ -126,9 +126,8 @@ let value_of_entry = function
 
 let v entries =
   List.rev_map (fun entry -> value_of_entry entry, entry) entries
-  |> List.sort (fun (a, _) (b, _) -> compare a b)
+  |> List.sort (fun (a, _) (b, _) -> compare b a)
   |> List.rev_map snd
-  |> List.rev
 
 let remove ~name t =
   let c = Contents name and n = Node name in


### PR DESCRIPTION
This PR fixes a possible stack overflow in `Tree.v` found when working with very wide trees in Irmin

See https://github.com/mirage/irmin/pull/1313