### PR TITLE
Add missing library depends on `fmt` and `logs`

### DIFF
--- a/src/git-top/dune
+++ b/src/git-top/dune
@@ -8,4 +8,5 @@
   git
   fmt
   logs
+  logs.fmt
   compiler-libs.toplevel))

--- a/src/git-unix/dune
+++ b/src/git-unix/dune
@@ -27,6 +27,7 @@
   digestif
   mmap
   git
+  logs
   logs.fmt
   cstruct
   mirage-flow

--- a/test/cstruct_append/dune
+++ b/test/cstruct_append/dune
@@ -3,6 +3,7 @@
  (libraries
   fmt
   fmt.tty
+  logs
   logs.cli
   logs.fmt
   lwt

--- a/test/index/dune
+++ b/test/index/dune
@@ -9,6 +9,7 @@
   digestif.c
   astring
   fmt
+  fmt.tty
   fpath
   bos
   rresult

--- a/test/mem/dune
+++ b/test/mem/dune
@@ -11,7 +11,9 @@
   git
   digestif
   base64
+  fmt
   fmt.tty
+  logs
   logs.fmt
   test_store))
 

--- a/test/unix/dune
+++ b/test/unix/dune
@@ -16,7 +16,9 @@
   base64
   bos
   git-unix
+  fmt
   fmt.tty
+  logs
   logs.fmt
   test_store))
 


### PR DESCRIPTION
This project uses `(implicit_transitive_deps false)`, but doesn't
specify all transitive deps in the case of these libraries. With the
main releases, this is OK since they don't build with Dune, but it's a
bug when using the Dune overlays / `opam monorepo` for development.