### PR TITLE
Use Ns decompress in atomic get and add

### DIFF
--- a/git.opam
+++ b/git.opam
@@ -60,3 +60,6 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+pin-depends: [
+  [ "decompress.dev" "git+https://github.com/clecat/decompress.git#f66aee137083296877d0fa94e2078d54a4d5db58" ]
+]

--- a/src/loose/loose.ml
+++ b/src/loose/loose.ml
@@ -44,62 +44,21 @@ module Make (Uid : UID) = struct
     let ( >>? ) x f =
       x >>= function Ok x -> f x | Error _ as err -> return err
     in
-
-    let hdr = hdr ~buffer:buffers.hdr v in
-    De.Queue.reset buffers.queue;
-    let encoder =
-      Zl.Def.encoder `Manual `Manual ~q:buffers.queue ~w:buffers.lz ~level:6
-    in
-    (* TODO(dinosaure): delete [rec], we should have only one [`Flush] and [`End]. *)
-    let rec go encoder srcs dst =
-      match srcs, Zl.Def.encode encoder with
-      | src :: srcs, `Await encoder ->
-          let encoder =
-            Zl.Def.src encoder (Cstruct.to_bigarray src) 0 (Cstruct.len src)
-          in
-          go encoder srcs dst
-      | [], `Await encoder ->
-          let encoder = Zl.Def.src encoder Bigstringaf.empty 0 0 in
-          go encoder [] dst
-      | _, `Flush encoder ->
-          let len = Cstruct.len dst - Zl.Def.dst_rem encoder in
-          (* XXX(dinosaure): the [Zl] encoder assumes that, at least,
-           * we have 2 remaining bytes - when it wants to write 2 bytes
-           * per 2 bytes. This is the smallest requirement of [decompress]
-           * to deflate a flow. A case appears then [Cstruct.len dst = 1]
-           * and [len]/remaining bytes is [0]. In that case, a call
-           * to [Zl.Def.encode] does not change anything because it requires,
-           * at least, 2 bytes. [-1] protects us from this special situation. *)
-          if len = Cstruct.len dst then Error `Non_atomic
-          else if len = 0 && Cstruct.len dst = 1 then Error `Non_atomic
-          else
-            let dst = Cstruct.shift dst len in
-            go
-              (Zl.Def.dst encoder (Cstruct.to_bigarray dst) 0 (Cstruct.len dst))
-              srcs dst
-      | _, `End encoder ->
-          let len = Cstruct.len dst - Zl.Def.dst_rem encoder in
-          Rresult.R.ok (Cstruct.len (Cstruct.shift dst len))
-    in
-    let encoder =
-      Zl.Def.dst encoder buffers.o 0 (Bigstringaf.length buffers.o)
-    in
-    let contents =
-      Cstruct.of_bigarray (Carton.Dec.raw v) ~off:0 ~len:(Carton.Dec.len v)
-    in
-    let uid =
-      let fold ctx payload = Uid.feed ctx (Cstruct.to_bigarray payload) in
-      let ctx = List.fold_left fold Uid.empty [ hdr; contents ] in
-      Uid.get ctx
-    in
-    match go encoder [ hdr; contents ] (Cstruct.of_bigarray buffers.o) with
-    | Ok rest ->
-        let len = Bigstringaf.length buffers.o - rest in
+    let hdr = Cstruct.to_bigarray @@ hdr ~buffer:buffers.hdr v in
+    let len_hdr = Bigstringaf.length hdr in
+    let raw = Carton.Dec.raw v in
+    let len_raw = Bigstringaf.length raw in
+    let contents = Bigstringaf.create (len_hdr + len_raw) in
+    Bigstringaf.blit hdr ~src_off:0 contents ~dst_off:0 ~len:len_hdr;
+    Bigstringaf.blit raw ~src_off:0 contents ~dst_off:len_hdr ~len:len_raw;
+    let uid = Uid.get @@ Uid.feed Uid.empty contents in
+    match Zl.Def.Ns.deflate contents buffers.o with
+    | Ok len ->
         Log.debug (fun m -> m "Atomic write of %a." Uid.pp uid);
         store.append t uid (Bigstringaf.sub buffers.o ~off:0 ~len)
         >>| reword_error (fun err -> `Store err)
         >>? fun () -> return (Ok (uid, len))
-    | Error _ as err -> return err
+    | Error _ -> return (Error `Non_atomic)
 
   let add { Carton.return; bind } t buffers store ~hdr stream =
     let ( >>= ) = bind in
@@ -155,28 +114,15 @@ module Make (Uid : UID) = struct
     let ( >>= ) = bind in
 
     store.map t uid ~pos:0L (Bigstringaf.length buffers.i) >>= fun i ->
-    let decoder =
-      Zl.Inf.decoder `Manual ~allocate:(fun _ -> buffers.window) ~o:buffers.o
-    in
-    let decoder = Zl.Inf.src decoder i 0 (Bigstringaf.length i) in
-    let res =
-      match Zl.Inf.decode decoder with
-      | `Await _ -> Error `Non_atomic
-      | `Malformed _ -> Error `Non_atomic
-      | `Flush decoder ->
-          let len = Bigstringaf.length buffers.o - Zl.Inf.dst_rem decoder in
-          Ok (Zl.Inf.flush decoder, len)
-      | `End _ -> Ok (Zl.Inf.flush decoder, 0)
-    in
     let open Rresult in
-    match res with
+    match Zl.Inf.Ns.inflate i buffers.o with
     | Ok (_, len) ->
         let raw = Cstruct.of_bigarray buffers.o ~off:0 ~len in
         let contents, kind, length = hdr raw in
         if Int64.of_int (Cstruct.len contents) <> length then
           return (Error `Non_atomic)
         else return (Ok (Carton.Dec.v ~kind (Cstruct.to_bigarray contents)))
-    | Error _ as err -> return err
+    | Error _ -> return (Error `Non_atomic)
 
   let size_and_kind { Carton.return; bind } t buffers store ~hdr uid =
     let ( >>= ) = bind in


### PR DESCRIPTION
Use the non-streamable API when the transactions are supposed to be atomic.
It uses this [pull request](https://github.com/mirage/decompress/pull/102) which should be accepted soon