### PR TITLE
Be compatible with alcotest.1.4.0 and localize tmp directory in the same hard disk

### DIFF
--- a/test/carton/test.ml
+++ b/test/carton/test.ml
@@ -33,7 +33,7 @@ let () = Random.full_init seed
 
 open Prelude
 
-let failf fmt = Fmt.kstr Alcotest.fail fmt
+let failf fmt = Alcotest.failf fmt
 
 let bigstringaf =
   Alcotest.testable
@@ -1046,7 +1046,18 @@ let git_version =
       | Some version -> version
       | None -> Fmt.failwith "Impossible to parse the Git version: %s" str)
 
+let tmp = "tmp"
+
 let () =
+  let fiber =
+    let open Bos in
+    let open Rresult in
+    OS.Dir.current () >>= fun current ->
+    OS.Dir.create Fpath.(current / tmp) >>= fun _ -> R.ok Fpath.(current / tmp)
+  in
+  let tmp = Rresult.R.failwith_error_msg fiber in
+  Bos.OS.Dir.set_default_tmp tmp;
+
   Alcotest.run "carton"
     [
       "weights", [ weights ]; "loads", [ loads ];

--- a/test/cstruct_append/test.ml
+++ b/test/cstruct_append/test.ml
@@ -95,7 +95,6 @@ let test_three_contents =
     ~f:(fun fd str ->
       let v = Cstruct_append.map device fd ~pos:0L 1 in
       Alcotest.(check string) "contents" (Bigstringaf.to_string v) "\x00";
-      (* O_TRUNC *)
       Cstruct_append.append device fd str)
     device c "lol"
   >>= fun () ->

--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -112,7 +112,7 @@ let create_tmp_dir ?(mode = 0o700) ?prefix_path pat =
       r
   | Error _ as e -> e
 
-(* XXX(dinosaure): FIFO "à la BOS".*)
+(* XXX(dinosaure): FIFO "à la BOS". *)
 
 (** to keep track of named pipes (aka FIFOs) created by unit tests
     and clean them up afterwards *)
@@ -286,11 +286,7 @@ let sync_err r = R.reword_error (fun e -> `Sync e) r
 let bad_input_err r = R.reword_error (fun e -> `Bad_input e) r
 
 let test_sync_fetch () =
-  Alcotest_lwt.test_case
-    "Sync.fetch fetches given remote ref and overwrites existing and \
-     non-existing local ref"
-    `Quick
-  @@ fun _switch () ->
+  Alcotest_lwt.test_case "set local ref" `Quick @@ fun _switch () ->
   let open Lwt.Infix in
   let module Sync = Git.Mem.Sync (Git.Mem.Store) (Git_cohttp_unix) in
   let capabilities = [ `Side_band_64k ] in


### PR DESCRIPTION
Upgrade with `alcotest.1.4.0` and set the `tmp` directory to something which is in the same hard disk (we found some problems on the `opam-ci` about bad use of `rename`).