### PR TITLE
carton: Add compatibility with OCaml 4.13

### DIFF
--- a/bin/carton/index_pack.ml
+++ b/bin/carton/index_pack.ml
@@ -284,7 +284,7 @@ let values_from_src = function
       let fd = Unix.openfile (Fpath.to_string fpath) Unix.[ O_RDONLY ] 0o644 in
       let max = (Unix.LargeFile.fstat fd).Unix.LargeFile.st_size in
       let map () ~pos len =
-        let len = Stdlib.min len Int64.(to_int (sub max pos)) in
+        let len = Stdlib.min len (Int64.to_int (Int64.sub max pos)) in
         let res =
           Mmap.V1.map_file fd ~pos Bigarray.char Bigarray.c_layout false
             [| len |]

--- a/bin/carton/verify_pack.ml
+++ b/bin/carton/verify_pack.ml
@@ -152,7 +152,7 @@ let first_pass fpath =
       return (Ok (hash, oracle, matrix, length, carbon))
 
 let map ~max fd ~pos len =
-  let len = Stdlib.min len Int64.(to_int (sub max pos)) in
+  let len = Stdlib.min len (Int64.to_int (Int64.sub max pos)) in
   let res =
     Mmap.V1.map_file fd ~pos Bigarray.char Bigarray.c_layout false [| len |]
   in


### PR DESCRIPTION
OCaml 4.13 added `Int64.max` and thus made theses two lines break.
In general I would encourage people to avoid opens when possible at makes it more likely to have code that breaks in this fashion.