### PR TITLE
Update to tls.0.14.0

### DIFF
--- a/git-paf.opam
+++ b/git-paf.opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-time"
   "result"
   "rresult"
-  "tls" {>= "0.13.0"}
+  "tls" {>= "0.14.0"}
   "uri"
   "bigarray-compat"
   "bigstringaf"

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -46,8 +46,8 @@ depends: [
   "ptime"
   "mimic"
   "ca-certs-nss" {>= "3.60"}
-  "tls" {>= "0.12.8"}
-  "tls-mirage" {>= "0.12.8"}
+  "tls" {>= "0.14.0"}
+  "tls-mirage" {>= "0.14.0"}
   "cohttp-lwt-unix" {with-test}
 ]
 build: [

--- a/src/git-paf/git_paf.ml
+++ b/src/git-paf/git_paf.ml
@@ -245,14 +245,11 @@ struct
       * Ipaddr.t
       * int
 
-    let connect (domain_name, cfg, stack, ipaddr, port) =
+    let connect (host, cfg, stack, ipaddr, port) =
       let t = Stack.tcp stack in
       Stack.TCP.create_connection t (ipaddr, port) >>= function
       | Error err -> Lwt.return_error (`Read err)
-      | Ok flow ->
-          client_of_flow cfg
-            ?host:(Option.map Domain_name.to_string domain_name)
-            flow
+      | Ok flow -> client_of_flow cfg ?host flow
   end
 
   let tls_edn, _tls_protocol = Mimic.register ~name:"tls" (module TLS)

--- a/src/git-unix/git_unix_mimic.ml
+++ b/src/git-unix/git_unix_mimic.ml
@@ -65,11 +65,9 @@ module TLS = struct
   type endpoint =
     Tls.Config.client * [ `host ] Domain_name.t option * Unix.sockaddr
 
-  let connect (tls, domain_name, sockaddr) =
+  let connect (tls, host, sockaddr) =
     TCP.connect sockaddr >|= R.reword_error (fun err -> `Read err)
-    >>? fun flow ->
-    let host = Option.map Domain_name.to_string domain_name in
-    client_of_flow tls ?host flow
+    >>? fun flow -> client_of_flow tls ?host flow
 end
 
 module Nss = Ca_certs_nss.Make (Ptime_clock)


### PR DESCRIPTION
Until ocaml/opam-repository#19218, this PR will fail. But then, it will unlock the dependency graph to use `tls.0.14.0`.