### PR TITLE
Warn instead of error in `Ref.read` function for missing reference

### DIFF
--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -445,7 +445,7 @@ struct
       match res with
       | Ok _ as v -> Lwt.return v
       | Error (`Not_found refname) ->
-          Log.err (fun m -> m "Reference %a not found." Reference.pp refname);
+          Log.warn (fun m -> m "Reference %a not found." Reference.pp refname);
           Lwt.return_error (`Reference_not_found refname)
 
     let resolve t refname =


### PR DESCRIPTION
Right now the Irmin CLI logs an error any time the git store is used for the first time:

```
main.exe: [ERROR] Reference refs/heads/master not found.
```

This PR converts that to a warning instead - I guess this warning will still be displayed to irmin users but won't make it look like the command failed.

 If you have another suggestion I'm happy to do that, this just seemed like the simplest fix.