### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,7 +1,6 @@
-version=0.19.0
-module-item-spacing=compact
+version=0.20.0
+profile=conventional
 break-struct=natural
 break-infix=fit-or-vertical
 parens-tuple=multi-line-only
-wrap-comments=false
 break-collection-expressions=wrap

--- a/src/carton/dec.ml
+++ b/src/carton/dec.ml
@@ -573,7 +573,6 @@ module W = struct
   }
 
   and slice = { offset : int64; length : int; payload : Bigstringaf.t }
-
   and 'fd map = 'fd -> pos:int64 -> int -> Bigstringaf.t
 
   let make ?(sector = 4096L) fd =
@@ -1449,7 +1448,6 @@ let uid_of_offset_with_source :
       | _ -> assert false)
 
 type 'uid node = Node of int64 * 'uid * 'uid node list | Leaf of int64 * 'uid
-
 and 'uid tree = Base of kind * int64 * 'uid * 'uid node list
 
 type 'uid children = cursor:int64 -> uid:'uid -> int64 list

--- a/src/carton/dec.mli
+++ b/src/carton/dec.mli
@@ -40,9 +40,7 @@ open Sigs
     the call by a simple internal table of {i weak pointers}. *)
 module W : sig
   type 'fd t
-
   and slice = { offset : int64; length : int; payload : Bigstringaf.t }
-
   and 'fd map = 'fd -> pos:int64 -> int -> Bigstringaf.t
 
   val reset : 'fd t -> unit

--- a/src/carton/enc.mli
+++ b/src/carton/enc.mli
@@ -13,12 +13,7 @@ val make_entry :
 
 val length : 'uid entry -> int
 
-type 'uid q
-
-and 'uid p
-
-and 'uid patch
-
+type 'uid q and 'uid p and 'uid patch
 type ('uid, 's) load = 'uid -> (Dec.v, 's) io
 type ('uid, 's) find = 'uid -> (int option, 's) io
 type 'uid uid = { uid_ln : int; uid_rw : 'uid -> string }

--- a/src/carton/h.ml
+++ b/src/carton/h.ml
@@ -147,7 +147,6 @@ module M = struct
   }
 
   and ret = Await | Stop | End | Malformed of string
-
   and state = Header | Postprocess | Cmd | Cp of int | It of int
 
   let variable_length buf off top =

--- a/src/carton/idx.ml
+++ b/src/carton/idx.ml
@@ -49,7 +49,6 @@ type 'uid idx = {
 }
 
 and sub = { off : int; len : int }
-
 and optint = Optint.t
 
 let make :

--- a/src/git/tree.ml
+++ b/src/git/tree.ml
@@ -181,10 +181,7 @@ end
 
 module Make (Hash : S.HASH) : S with type hash = Hash.t = struct
   type hash = Hash.t
-
-  type nonrec entry = hash entry
-
-  and t = hash t
+  type nonrec entry = hash entry and t = hash t
 
   let pp ppf t = pp ~pp:Hash.pp ppf t
   let entry ~name perm node = entry ~name perm node

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -117,7 +117,8 @@ struct
     Store.Value.Commit.make
       ~tree:(Store.Value.Tree.digest t5)
       ~parents:[ Store.Value.Commit.digest c3 ]
-      ~author:thomas ~committer:thomas ~extra:[ "gpgsig", gpg ]
+      ~author:thomas ~committer:thomas
+      ~extra:[ "gpgsig", gpg ]
       (Some "with GPG")
 
   let tt1 =


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions
- the `.ocamlformat` file has been simplified according to the selected profile