### PR TITLE
drop unneeded mirage-protocols dependency

### DIFF
--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -23,7 +23,6 @@ depends: [
   "lwt" {>= "5.3.0"}
   "mirage-clock" {>= "3.1.0"}
   "mirage-flow" {>= "2.0.1"}
-  "mirage-protocols" {>= "5.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.1"}
   "result" {>= "1.5"}

--- a/src/git-mirage/dune
+++ b/src/git-mirage/dune
@@ -2,15 +2,7 @@
  (name git_mirage_tcp)
  (modules git_mirage_tcp)
  (public_name git-mirage.tcp)
- (libraries
-  git.nss.git
-  mimic
-  result
-  fmt
-  lwt
-  mirage-flow
-  ipaddr
-  mirage-stack))
+ (libraries git.nss.git mimic result fmt lwt mirage-flow ipaddr mirage-stack))
 
 (library
  (name git_mirage_ssh)

--- a/src/git-mirage/dune
+++ b/src/git-mirage/dune
@@ -10,7 +10,6 @@
   lwt
   mirage-flow
   ipaddr
-  mirage-protocols
   mirage-stack))
 
 (library
@@ -25,7 +24,6 @@
   lwt
   fmt
   ipaddr
-  mirage-protocols
   mirage-stack
   mirage-flow
   mirage-clock
@@ -45,7 +43,6 @@
   mirage-random
   mirage-time
   mirage-clock
-  mirage-protocols
   mirage-stack
   dns
   tls


### PR DESCRIPTION
while investigating reverse dependencies (via https://opam.ocaml.org/packages/mirage-protocols/) I encountered ocaml-git which does not use this package