### PR TITLE
Link with logs and logs.fmt

### DIFF
--- a/bin/guit/dune
+++ b/bin/guit/dune
@@ -8,6 +8,7 @@
   git
   git.nss.git
   logs
+  logs.fmt
   fmt
   mtime
   mtime.clock.os
@@ -40,6 +41,7 @@
   mtime.clock.os
   rresult
   logs
+  logs.fmt
   logs.cli
   fmt.tty
   fmt.cli

--- a/test/smart/dune
+++ b/test/smart/dune
@@ -48,6 +48,7 @@
   cstruct
   uri
   fmt.tty
+  logs
   logs.fmt
   alcotest-lwt
   cohttp-lwt-unix


### PR DESCRIPTION
There are a couple of places where the link with `logs` or `logs.fmt` was forgotten in 3.6.0. This breaks the package installation in my opam switch :/