### PR TITLE
git: provide a `Store.read_opt` function for finding potentially-absent objects

### DIFF
--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -261,6 +261,11 @@ module Make (Digestif : Digestif.S) = struct
     | Error _ -> Lwt.fail (failuref "%a not found" Hash.pp h)
     | Ok v -> Lwt.return v
 
+  let read_opt t h =
+    match read t h with
+    | Error (`Not_found _) -> Lwt.return (Ok None)
+    | Ok v -> Lwt.return (Ok (Some v))
+
   let contents t =
     let open Lwt.Infix in
     list t >>= fun hashes ->

--- a/src/git/minimal.ml
+++ b/src/git/minimal.ml
@@ -1,12 +1,11 @@
 module type S = sig
   type t
   type hash
+  type decode_error := [ `Msg of string ]
 
   type error =
     private
-    [> `Not_found of hash
-    | `Reference_not_found of Reference.t
-    | `Msg of string ]
+    [> `Not_found of hash | `Reference_not_found of Reference.t | decode_error ]
 
   val pp_error : error Fmt.t
 
@@ -45,6 +44,11 @@ module type S = sig
   val read : t -> hash -> (Value.t, error) result Lwt.t
   (** [read state hash] can retrieve a git object from the current repository
       [state]. It de-serializes the git object to an OCaml value. *)
+
+  val read_opt : t -> hash -> (Value.t option, decode_error) result Lwt.t
+  (** [read_opt state hash] is like {!read} but does not return (or log) an
+      error if the git object referenced by [hash] cannot be retrieved from
+      [state]. *)
 
   val read_exn : t -> hash -> Value.t Lwt.t
   (** [read_exn state hash] is an alias of {!read} but raise an exception


### PR DESCRIPTION
Following discussion in https://github.com/mirage/irmin/pull/1698.