### PR TITLE
Preview: upgrade to ocamlformat.0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.20.0
+version=0.21.0
 module-item-spacing=compact
 break-infix=fit-or-vertical
 parens-tuple=multi-line-only

--- a/src/git-unix/git_unix.ml
+++ b/src/git-unix/git_unix.ml
@@ -157,7 +157,6 @@ module Minor_heap (Digestif : Digestif.S) = struct
   module Log = (val Logs.src_log src : Logs.LOG)
 
   type t = Fpath.t (* [.git/objects] *)
-
   type uid = Digestif.t
   type error = [ `Not_found of Digestif.t | `Msg of string ]
 
@@ -327,7 +326,6 @@ module Major_heap = struct
   module Log = (val Logs.src_log src : Logs.LOG)
 
   type t = Fpath.t (* [.git/objects/pack] *)
-
   type uid = Fpath.t
   type 'a rd = < rd : unit ; .. > as 'a
   type 'a wr = < wr : unit ; .. > as 'a
@@ -509,7 +507,6 @@ module Reference_heap = struct
   (* XXX(dinosaure): ensure the atomicity. *)
 
   type t = Fpath.t (* [.git] *)
-
   type error = [ `Not_found of Git.Reference.t | `Msg of string ]
 
   let pp_error ppf = function

--- a/test/carton/test.ml
+++ b/test/carton/test.ml
@@ -834,13 +834,11 @@ let cycle () =
   randomize b;
   let ea =
     Carton.Enc.make_entry ~kind:`A ~length:(Bigstringaf.length a)
-      ~delta:(Carton.Enc.From `B)
-      `A
+      ~delta:(Carton.Enc.From `B) `A
   in
   let eb =
     Carton.Enc.make_entry ~kind:`A ~length:(Bigstringaf.length b)
-      ~delta:(Carton.Enc.From `A)
-      `B
+      ~delta:(Carton.Enc.From `A) `B
   in
 
   let load = function


### PR DESCRIPTION
This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

The changes on this project are due to:
- the list of arguments of function applications break on "complex" argument, an argument being composed of a variant is not considered being "complex" anymore.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!