### PR TITLE
Fix fmt deps for v.exe

### DIFF
--- a/bin/guit/dune
+++ b/bin/guit/dune
@@ -42,6 +42,7 @@
   logs
   logs.fmt
   logs.cli
+  fmt
   fmt.tty
   fmt.cli
   lwt


### PR DESCRIPTION
Hi dear `ocaml-git` maintainers,
Following this PR (https://github.com/mirage/ocaml-git/pull/499), I added `fmt` as a dependency to `v` to make `opam monorepo` work with `ocaml-git.3.8.0` and `irmin` lock file.