### PR TITLE
Add missing dependencies on Unix

### DIFF
--- a/bin/carton/dune
+++ b/bin/carton/dune
@@ -17,6 +17,7 @@
   fmt
   carton
   fiber
+  unix
   digestif.c))
 
 (executable
@@ -43,6 +44,7 @@
   fmt
   carton
   fiber
+  unix
   digestif.c))
 
 (executable
@@ -67,6 +69,7 @@
   fmt
   carton
   fiber
+  unix
   digestif.c))
 
 (library

--- a/bin/fiber/dune
+++ b/bin/fiber/dune
@@ -2,4 +2,4 @@
  (name fiber)
  (flags
   (:standard -thread))
- (libraries fmt threads))
+ (libraries fmt threads unix))

--- a/src/carton-git/dune
+++ b/src/carton-git/dune
@@ -28,4 +28,5 @@
   carton
   carton-lwt
   carton-git
+  unix
   lwt.unix))

--- a/src/git-index/dune
+++ b/src/git-index/dune
@@ -12,4 +12,5 @@
   digestif
   fpath
   bigstringaf
+  unix
   git-unix))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.