### PR TITLE
carton-lwt.opam: remove bigarray-compat

### DIFF
--- a/carton-lwt.opam
+++ b/carton-lwt.opam
@@ -19,7 +19,6 @@ depends: [
   "decompress" {>= "1.4.3"}
   "optint" {>= "0.0.4"}
   "bigstringaf" {>= "0.9.0"}
-  "bigarray-compat" {with-test}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}
   "cstruct" {>= "6.1.0" & with-test}


### PR DESCRIPTION
since this only changes the opam dependency, the same could be done to the carton-lwt 0.4.4 release to opam-repository (i.e. no need for a new release).