### PR TITLE
Do not append a leading slash to path

### DIFF
--- a/src/not-so-smart/smart_git.ml
+++ b/src/not-so-smart/smart_git.ml
@@ -45,11 +45,11 @@ module Endpoint = struct
           Fmt.(option (const string ":" ++ int))
           port path
     | { scheme = `HTTP _; path; port; hostname } ->
-        Fmt.pf ppf "http://%s%a/%s" hostname
+        Fmt.pf ppf "http://%s%a%s" hostname
           Fmt.(option (const string ":" ++ int))
           port path
     | { scheme = `HTTPS _; path; port; hostname } ->
-        Fmt.pf ppf "https://%s%a/%s" hostname
+        Fmt.pf ppf "https://%s%a%s" hostname
           Fmt.(option (const string ":" ++ int))
           port path
     | { scheme = `Scheme scheme; path; port; hostname } ->
@@ -138,13 +138,13 @@ module Endpoint = struct
       | `HTTP _ ->
           Some
             (Uri.of_string
-               (Fmt.str "http://%s%a/%s" edn.hostname
+               (Fmt.str "http://%s%a%s" edn.hostname
                   Fmt.(option (const string ":" ++ int))
                   edn.port edn.path))
       | `HTTPS _ ->
           Some
             (Uri.of_string
-               (Fmt.str "https://%s%a/%s" edn.hostname
+               (Fmt.str "https://%s%a%s" edn.hostname
                   Fmt.(option (const string ":" ++ int))
                   edn.port edn.path))
       | _ -> None

--- a/test/smart/dune
+++ b/test/smart/dune
@@ -54,7 +54,7 @@
 (executable
  (name test_edn)
  (modules test_edn)
- (libraries alcotest fmt ipaddr domain-name git.nss.git))
+ (libraries alcotest fmt ipaddr domain-name git.nss.git mimic uri))
 
 (rule
  (alias runtest)

--- a/test/smart/test_edn.ml
+++ b/test/smart/test_edn.ml
@@ -1,7 +1,6 @@
 let ( <.> ) f g x = f (g x)
 let github_com = "github.com"
 let private_network = "10.0.0.0"
-
 let uri_testable = Alcotest.testable Uri.pp Uri.equal
 
 let test01 =
@@ -90,20 +89,22 @@ let test06 =
 
 let test07 =
   Alcotest.test_case "edn07" `Quick @@ fun () ->
-  let uri = "http://git.data.coop/halfd/new-website.git"  in
+  let uri = "http://git.data.coop/halfd/new-website.git" in
   match Smart_git.Endpoint.of_string uri with
   | Ok
       ({
-        Smart_git.Endpoint.scheme = `HTTP [];
-        hostname = "git.data.coop";
-        port = None;
-        path = "/halfd/new-website.git";
-      } as edn) ->
-    let ctx = Smart_git.Endpoint.to_ctx edn Mimic.empty in
-    Alcotest.(check (option uri_testable)) "uri" (Mimic.get Smart_git.git_uri ctx) (Some (Uri.of_string uri))
+         Smart_git.Endpoint.scheme = `HTTP [];
+         hostname = "git.data.coop";
+         port = None;
+         path = "/halfd/new-website.git";
+       } as edn) ->
+      let ctx = Smart_git.Endpoint.to_ctx edn Mimic.empty in
+      Alcotest.(check (option uri_testable))
+        "uri"
+        (Mimic.get Smart_git.git_uri ctx)
+        (Some (Uri.of_string uri))
   | Ok v -> Alcotest.failf "Unexpeted Git endpoint: %a" Smart_git.Endpoint.pp v
   | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
-
 
 let () =
   Alcotest.run "smart git endpoint"

--- a/test/smart/test_edn.ml
+++ b/test/smart/test_edn.ml
@@ -2,6 +2,8 @@ let ( <.> ) f g x = f (g x)
 let github_com = "github.com"
 let private_network = "10.0.0.0"
 
+let uri_testable = Alcotest.testable Uri.pp Uri.equal
+
 let test01 =
   Alcotest.test_case "edn01" `Quick @@ fun () ->
   match Smart_git.Endpoint.of_string "git@github.com:mirage/ocaml.git" with
@@ -86,6 +88,23 @@ let test06 =
   | Ok v -> Alcotest.failf "Unexpeted Git endpoint: %a" Smart_git.Endpoint.pp v
   | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
 
+let test07 =
+  Alcotest.test_case "edn07" `Quick @@ fun () ->
+  let uri = "http://git.data.coop/halfd/new-website.git"  in
+  match Smart_git.Endpoint.of_string uri with
+  | Ok
+      ({
+        Smart_git.Endpoint.scheme = `HTTP [];
+        hostname = "git.data.coop";
+        port = None;
+        path = "/halfd/new-website.git";
+      } as edn) ->
+    let ctx = Smart_git.Endpoint.to_ctx edn Mimic.empty in
+    Alcotest.(check (option uri_testable)) "uri" (Mimic.get Smart_git.git_uri ctx) (Some (Uri.of_string uri))
+  | Ok v -> Alcotest.failf "Unexpeted Git endpoint: %a" Smart_git.Endpoint.pp v
+  | Error (`Msg err) -> Alcotest.failf "Unexpected error: %S" err
+
+
 let () =
   Alcotest.run "smart git endpoint"
-    [ "endpoint", [ test01; test02; test03; test04; test05; test06 ] ]
+    [ "endpoint", [ test01; test02; test03; test04; test05; test06; test07 ] ]


### PR DESCRIPTION
I found that I could not fetch the repo http://git.data.coop/halfd/new-website.git. With full debug logs I was able to gather that http://git.data.coop//halfd/new-website.git was requested instead, and gitea treats that as an error and returns 404.

This PR removes the extra leading slash and adds a test case.