### PR TITLE
Specify on headers the Smart version of the protocol and the type of the protocol

### DIFF
--- a/git.opam
+++ b/git.opam
@@ -59,3 +59,6 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+pin-depends: [
+  [ "mimic.dev" "git+https://github.com/dinosaure/mimic.git#e679ff43a85d9e51de66a97325f8e3c84e63d292" ]
+]

--- a/test/smart/test.ml
+++ b/test/smart/test.ml
@@ -1451,7 +1451,6 @@ let test_negotiation_http () =
       Mimic.register ~name:"fake-http" (module HTTP)
     in
     let handshake ~uri0:_ ~uri1:_ flow =
-      Fmt.epr ">>> HANDSHAKE\n%!";
       let module M = (val Mimic.repr fake_http) in
       match flow with
       | M.T flow ->


### PR DESCRIPTION
This PR is untested but it probably helps to `fetch`/`push` to a server with the Smart protocol 1 (/cc @reynir who spotted the bug with gitea).