### PR TITLE
Fix breaking change from `mtime.2.0.0`

### DIFF
--- a/bin/guit/fetch.ml
+++ b/bin/guit/fetch.ml
@@ -32,10 +32,10 @@ let reporter ppf =
       k ()
     in
     let with_src_and_stamp h _ k fmt =
-      let dt = Mtime.Span.to_us (Mtime_clock.elapsed ()) in
+      let dt_us = 1e-3 *. Int64.to_float (Mtime_clock.elapsed_ns ()) in
       Fmt.kpf k ppf
         ("%s %a %a: @[" ^^ fmt ^^ "@]@.")
-        (pad 10 (Fmt.str "%+04.0fus" dt))
+        (pad 10 (Fmt.str "%+04.0fus" dt_us))
         pp_header (level, h)
         Fmt.(styled `Magenta string)
         (pad 10 @@ Logs.Src.name src)

--- a/bin/guit/v.ml
+++ b/bin/guit/v.ml
@@ -32,10 +32,10 @@ let reporter ppf =
       k ()
     in
     let with_src_and_stamp h _ k fmt =
-      let dt = Mtime.Span.to_us (Mtime_clock.elapsed ()) in
+      let dt_us = 1e-3 *. Int64.to_float (Mtime_clock.elapsed_ns ()) in
       Fmt.kpf k ppf
         ("%s %a %a: @[" ^^ fmt ^^ "@]@.")
-        (pad 10 (Fmt.str "%+04.0fus" dt))
+        (pad 10 (Fmt.str "%+04.0fus" dt_us))
         pp_header (level, h)
         Fmt.(styled `Magenta string)
         (pad 10 @@ Logs.Src.name src)


### PR DESCRIPTION
`mtime.2.0.0` [`CHANGES.md`](https://github.com/dbuenzli/mtime/blob/master/CHANGES.md):
> Remove deprecated values `Mtime.s_to_*` and `Mtime.Span.to_*` floating points functions. Note that the implementation of `Mtime.Span.to_*` functions was broken if your span exceeded `Int64.max_int`. Thanks to Thomas Leonard for the report ([#46](https://github.com/dbuenzli/mtime/issues/46)).

The behaviour is broken if the provided span exceeds `Int64.max_int`, but since this comes only from `Mtime_clock.elapsed_ns` it's probably safe to assume we've not been running for a few centuries. Thus I just copied the implementation of the old `Mtime.to_us` function.