### PR TITLE
Try to bounds the stream between the receiver and the PACK decoder

### DIFF
--- a/src/not-so-smart/fetch.mli
+++ b/src/not-so-smart/fetch.mli
@@ -23,6 +23,6 @@ module Make
     (Uid.t, Uid.t * int ref * int64, 'g) store ->
     (Uid.t, _, Uid.t * int ref * int64, 'g, Scheduler.t) access ->
     configuration ->
-    (string * int * int -> unit) ->
+    (string * int * int -> unit IO.t) ->
     (Ref.t * Uid.t) list IO.t
 end

--- a/src/not-so-smart/protocol.mli
+++ b/src/not-so-smart/protocol.mli
@@ -164,11 +164,15 @@ module Decoder : sig
 
   val decode_pack :
     ?side_band:bool ->
-    push_pack:(string * int * int -> unit) ->
     push_stdout:(string -> unit) ->
     push_stderr:(string -> unit) ->
     decoder ->
-    (bool, [> error ]) state
+    ( [ `Payload of string * int * int
+      | `End_of_transmission
+      | `Stdout
+      | `Stderr ],
+      [> error ] )
+    state
 
   val decode_negotiation : decoder -> (string Negotiation.t, [> error ]) state
   val decode_shallows : decoder -> (string Shallow.t list, [> error ]) state

--- a/src/not-so-smart/smart.mli
+++ b/src/not-so-smart/smart.mli
@@ -216,11 +216,11 @@ val advertised_refs : (string, string) Advertised_refs.t recv
 val negotiation_result : string Result.t recv
 
 val recv_pack :
-  ?side_band:bool ->
   ?push_stdout:(string -> unit) ->
   ?push_stderr:(string -> unit) ->
-  (string * int * int -> unit) ->
-  bool recv
+  bool ->
+  [ `Payload of string * int * int | `End_of_transmission | `Stdout | `Stderr ]
+  recv
 
 val recv_flush : unit recv
 val recv_commands : (string, string) Commands.t option recv

--- a/src/not-so-smart/smart_git.ml
+++ b/src/not-so-smart/smart_git.ml
@@ -420,15 +420,15 @@ struct
     in
     Mimic.replace git_http_headers headers ctx
 
-  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ?threads ~ctx
-      (access, light_load, heavy_load) store edn ?(version = `V1)
+  let fetch ?(push_stdout = ignore) ?(push_stderr = ignore) ?(bounds = 10)
+      ?threads ~ctx (access, light_load, heavy_load) store edn ?(version = `V1)
       ?(capabilities = default_capabilities) ?deepen want t_pck t_idx ~src ~dst
       ~idx =
     let open Rresult in
     let open Lwt.Infix in
     let hostname = edn.Endpoint.hostname in
     let path = edn.Endpoint.path in
-    let stream, emitter = Lwt_stream.create_bounded 10 in
+    let stream, emitter = Lwt_stream.create_bounded bounds in
     let pusher_with_logging = function
       | Some (str, off, len) ->
           Log.debug (fun m -> m "Download %d byte(s) of the PACK file." len);

--- a/src/not-so-smart/smart_git_intf.ml
+++ b/src/not-so-smart/smart_git_intf.ml
@@ -128,6 +128,7 @@ module type SMART_GIT = sig
     val fetch :
       ?push_stdout:(string -> unit) ->
       ?push_stderr:(string -> unit) ->
+      ?bounds:int ->
       ?threads:int ->
       ctx:Mimic.ctx ->
       (Uid.t, _, Uid.t * int ref * int64, 'g, Scheduler.t) Sigs.access


### PR DESCRIPTION
Already spotted into `multipart_form` but currently, the stream of the PACK file is not bound. The side effect is: `lwt` does not really do the concurrence between the receiving and the decoding and we need to limit how many chunks we can have into our stream. So we use `Lwt_stream.bounded_push`.

The final expectation is to give opportunities to some processes to run even if we started to decode the PACK file. Now, the decoding is highly bound to the receiver (the _socket_) which can block. That mostly means that, by transitivity, the decoder can block too and let opportunities to some other processes.