### PR TITLE
Remove OCaml 5 warning

### DIFF
--- a/test/smart/dune
+++ b/test/smart/dune
@@ -49,7 +49,8 @@
   fmt.tty
   logs
   logs.fmt
-  alcotest-lwt))
+  alcotest-lwt
+  unix))
 
 (executable
  (name test_edn)


### PR DESCRIPTION
Otherwise got:

    File "_none_", line 1:
    Alert ocaml_deprecated_auto_include:
    OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
    automatically added to the search path, but you should add -I +unix to the
    command-line to silence this alert (e.g. by adding unix to the list of
    libraries in your dune file, or adding use_unix to your _tags file for
    ocamlbuild, or using -package unix for ocamlfind).