### PR TITLE
Fix example in README.md (wrong branch name.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ module Search :
   let open Lwt_result.Syntax in
   (* get store located in current root's .git folder *)
   let* store = Store.v (Fpath.v (Sys.getcwd ())) in
-  (* find obj-id pointed at by master branch (reference) *)
-  let* commit_id = Store.Ref.resolve store Git.Reference.master in
+  (* find obj-id pointed at by main branch (reference) *)
+  let* commit_id = Store.Ref.resolve store Git.Reference.main in
   let open Lwt.Syntax in
   (* find obj-id of of [filename] as a git blob *)
   let* blob_id = Search.find store commit_id (`Commit (`Path [ filename ])) in


### PR DESCRIPTION
Example was using 'master', rather than 'main'.

It was previously giving the error:
```
utop # Lwt_main.run Lwt.Infix.(read "README.md" >|= pp Fmt.stdout) ;;
[DEBUG]Reading HEAD.
[DEBUG]146 packed-refs added.
[DEBUG]Resolve reference refs/heads/master.
[DEBUG]Reading refs/heads/master.
refs/heads/master not found- : unit = ()
'''

Also the Travis link in the Readme is linking to master. I didn't fix that since it doesn't seem to be in use ATM  and didn't know what you want to do with it e.g. delete it or change to display the status on another build service.