### PR TITLE
Fix tests for git 2.41.0+

### DIFF
--- a/test/carton/test.ml
+++ b/test/carton/test.ml
@@ -277,7 +277,7 @@ let empty_index, uid_empty_index =
   let res =
     let open Rresult in
     Bos.OS.Dir.current () >>= fun current ->
-    let dst = Fpath.(current / "index-null") in
+    let dst = Fpath.(current / "index-null.idx") in
     ( Bos.OS.Dir.with_tmp "git-%s" @@ fun path ->
       Bos.OS.Dir.with_current path @@ fun () ->
       Bos.OS.Cmd.run_status Bos.Cmd.(v "git" % "init") >>= fun _ ->
@@ -299,7 +299,7 @@ let empty_index, uid_empty_index =
     | Ok () -> ()
     | Error (`Msg err) -> Alcotest.fail err
   in
-  let ic = open_in_bin "index-null" in
+  let ic = open_in_bin "index-null.idx" in
   let ln = in_channel_length ic in
   let rs = Bytes.create ln in
   really_input ic rs 0 ln;

--- a/test/unix/test.ml
+++ b/test/unix/test.ml
@@ -263,6 +263,7 @@ let author () =
          match Ptime_clock.current_tz_offset_s () with
          | Some s ->
              let sign = if s < 0 then `Minus else `Plus in
+             let s = abs s in
              let hours = s / 3600 in
              let minutes = s mod 3600 / 60 in
              Some { Git.User.sign; hours; minutes }


### PR DESCRIPTION
- `git index-path` now requires a '.idx' extension for the index file
- `git fsck` has stricter timezone parsing and caught a bug in date calculation in a test when the current timezone is negative

Fixes #617 