### PR TITLE
Give a pause when we iter on the index file and when we decompress a PACK file

### DIFF
--- a/carton.opam
+++ b/carton.opam
@@ -27,7 +27,7 @@ depends: [
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
   "result"
-  "rresult"
+  "rresult" {>= "0.7.0"}
   "fpath"
   "base64" {with-test & >= "3.0.0"}
   "bos"

--- a/src/carton-lwt/carton_lwt.ml
+++ b/src/carton-lwt/carton_lwt.ml
@@ -183,7 +183,8 @@ module Thin = struct
 
     let with_pause f x =
       let open Lwt.Infix in
-      f x >>= fun r -> Lwt.pause () >|= fun () -> r
+      f x >>= fun r ->
+      Lwt.pause () >|= fun () -> r
 
     let canonicalize ~light_load ~heavy_load ~src ~dst fs n requireds weight =
       let light_load uid = inj (with_pause light_load uid) in

--- a/src/carton-lwt/carton_lwt.ml
+++ b/src/carton-lwt/carton_lwt.ml
@@ -181,9 +181,13 @@ module Thin = struct
   module Make (Uid : Carton.UID) = struct
     include Thin.Make (Lwt_scheduler) (Lwt_io) (Uid)
 
+    let with_pause f x =
+      let open Lwt.Infix in
+      f x >>= fun r -> Lwt.pause () >|= fun () -> r
+
     let canonicalize ~light_load ~heavy_load ~src ~dst fs n requireds weight =
-      let light_load uid = inj (light_load uid) in
-      let heavy_load uid = inj (heavy_load uid) in
+      let light_load uid = inj (with_pause light_load uid) in
+      let heavy_load uid = inj (with_pause heavy_load uid) in
       canonicalize ~light_load ~heavy_load ~src ~dst fs n requireds weight
   end
 end

--- a/src/carton-lwt/lwt_io.ml
+++ b/src/carton-lwt/lwt_io.ml
@@ -39,7 +39,7 @@ let parallel_iter ~f lst = Lwt_list.iter_p f lst
 let detach f =
   let th, wk = Lwt.wait () in
   Lwt.async (fun () ->
+      let open Lwt.Infix in
       let res = f () in
-      Lwt.wakeup_later wk res;
-      Lwt.return_unit);
+      Lwt.pause () >|= fun () -> Lwt.wakeup_later wk res);
   th

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -212,6 +212,7 @@ module Make (Digestif : Digestif.S) = struct
       Lwt.return hash
 
   let read_inflated t h =
+    let open Lwt.Infix in
     try
       let value = Lazy.force (Hashtbl.find t.values h) in
       let kind =
@@ -222,11 +223,11 @@ module Make (Digestif : Digestif.S) = struct
         | Tag _ -> `Tag
       in
       let raw = Value.to_raw_without_header value in
-      Lwt.return_some (kind, Cstruct.of_string raw)
+      Lwt.pause () >|= fun () -> Some (kind, Cstruct.of_string raw)
     with Not_found -> (
       try
         let kind, raw = Hashtbl.find t.inflated h in
-        Lwt.return_some (kind, raw)
+        Lwt.pause () >|= fun () -> Some (kind, raw)
       with Not_found -> Lwt.return_none)
 
   let read t h =

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -261,14 +261,16 @@ module Make (Digestif : Digestif.S) = struct
     Lwt.return v
 
   let read_exn t h =
+    let open Lwt.Infix in
     match read t h with
     | Error _ -> Lwt.fail (failuref "%a not found" Hash.pp h)
-    | Ok v -> Lwt.return v
+    | Ok v -> Lwt.pause () >|= fun () -> v
 
   let read_opt t h =
+    let open Lwt.Infix in
     match read t h with
     | Error (`Not_found _) -> Lwt.return (Ok None)
-    | Ok v -> Lwt.return (Ok (Some v))
+    | Ok v -> Lwt.pause () >|= fun () -> Ok (Some v)
 
   let contents t =
     let open Lwt.Infix in
@@ -282,8 +284,9 @@ module Make (Digestif : Digestif.S) = struct
     Lwt.return res
 
   let read t h =
+    let open Lwt.Infix in
     match read t h with
-    | Ok _ as v -> Lwt.return v
+    | Ok _ as v -> Lwt.pause () >|= fun () -> v
     | Error _ as err -> Lwt.return err
 
   let is_shallowed t hash = Shallow.exists t.shallows ~equal:Hash.equal hash
@@ -304,6 +307,18 @@ module Make (Digestif : Digestif.S) = struct
 
   let fold = Traverse.fold
   let iter = Traverse.iter
+
+  let map ~f idx =
+    let open Lwt.Infix in
+    let rec go acc n =
+      if Carton.Dec.Idx.max idx == n then Lwt.return (List.rev acc)
+      else
+        let uid = Carton.Dec.Idx.get_uid idx n
+        and offset = Carton.Dec.Idx.get_offset idx n
+        and crc = Carton.Dec.Idx.get_crc idx n in
+        f ~uid ~offset ~crc >>= fun entry -> go (entry :: acc) (succ n)
+    in
+    go [] 0
 
   (* XXX(dinosaure): extraction of Git objects from a PACK file stored
      into a [Cstruct.t] is not scheduled by any blocking _syscall_. In this
@@ -333,10 +348,8 @@ module Make (Digestif : Digestif.S) = struct
       (* XXX(dinosaure): when the pack is huge, we must give a pause
          for each entry because our [batch_write] tries to extract all
          objects the second time. *)
-      let f ~uid ~offset ~crc:_ =
-        Lwt.apply f (uid, offset) >>= fun res ->
-        Lwt.pause () >>= fun () -> Lwt.return res in
-      Carton.Dec.Idx.map ~f index |> Lwt.join >>= Lwt.pause
+      let f ~uid ~offset ~crc:_ = f (uid, offset) >>= Lwt.pause in
+      map ~f index >>= fun _units -> Lwt.return_unit
     in
     let map pck_contents ~pos len =
       let pos = Int64.to_int pos in

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -335,7 +335,7 @@ module Make (Digestif : Digestif.S) = struct
          objects the second time. *)
       let f ~uid ~offset ~crc:_ =
         Lwt.apply f (uid, offset) >>= fun res ->
-        Lwt.pause () >>= Lwt.return res in
+        Lwt.pause () >>= fun () -> Lwt.return res in
       Carton.Dec.Idx.map ~f index |> Lwt.join >>= Lwt.pause
     in
     let map pck_contents ~pos len =

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -331,7 +331,7 @@ module Make (Digestif : Digestif.S) = struct
     let iter index ~f =
       let f (uid, offset) = f uid offset in
       let f ~uid ~offset ~crc:_ = Lwt.apply f (uid, offset) in
-      Carton.Dec.Idx.map ~f index |> Lwt.join
+      Carton.Dec.Idx.map ~f index |> Lwt.join >>= Lwt.pause
     in
     let map pck_contents ~pos len =
       let pos = Int64.to_int pos in


### PR DESCRIPTION
/cc @hannesm: a probably solution to let the `opam-mirror` unikernel be available even if we try to clone.