### PR TITLE
opam: require rresult 0.7.0

### DIFF
--- a/carton-git.opam
+++ b/carton-git.opam
@@ -28,7 +28,7 @@ depends: [
   "cstruct" {>= "6.1.0" & with-test}
   "logs" {>= "0.7.0"}
   "mirage-flow" {>= "2.0.1" & with-test}
-  "rresult" {>= "0.6.0" & with-test}
+  "rresult" {>= "0.7.0" & with-test}
   "ke" {>= "0.6" & with-test}
 ]
 conflicts: [ "result" {< "1.5"} ]

--- a/carton-lwt.opam
+++ b/carton-lwt.opam
@@ -25,7 +25,7 @@ depends: [
   "fmt" {>= "0.8.9" & with-test}
   "logs" {>= "0.7.0" & with-test}
   "mirage-flow" {>= "2.0.1" & with-test}
-  "rresult" {>= "0.6.0" & with-test}
+  "rresult" {>= "0.7.0" & with-test}
   "ke" {>= "0.6" & with-test}
   "base64" {>= "3.4.0" & with-test}
   "bos" {>= "0.2.0" & with-test}

--- a/git-mirage.opam
+++ b/git-mirage.opam
@@ -36,7 +36,7 @@ depends: [
   "mirage-clock" {>= "3.1.0"}
   "mirage-flow" {>= "4.0.0"}
   "mirage-time" {>= "2.0.1"}
-  "rresult" {>= "0.6.0"}
+  "rresult" {>= "0.7.0"}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}
   "bigstringaf" {>= "0.9.0" & with-test}

--- a/git-paf.opam
+++ b/git-paf.opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-clock"
   "tcpip" {>= "7.0.0"}
   "mirage-time"
-  "rresult"
+  "rresult" {>= "0.7.0"}
   "tls" {>= "0.14.0"}
   "uri"
   "bigstringaf"

--- a/git-unix.opam
+++ b/git-unix.opam
@@ -12,7 +12,7 @@ depends: [
   "git" {= version}
   "git-mirage" {= version}
   "happy-eyeballs-lwt" {>= "0.1.2"}
-  "rresult"
+  "rresult" {>= "0.7.0"}
   "bigstringaf" {>= "0.9.0"}
   "fmt" {>= "0.8.7"}
   "bos"

--- a/git.opam
+++ b/git.opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "digestif" {>= "1.1.2"}
-  "rresult"
+  "rresult" {>= "0.7.0"}
   "base64" {>= "3.0.0"}
   "bigstringaf" {>= "0.9.0"}
   "optint"


### PR DESCRIPTION
there are CI failures in https://github.com/ocaml/opam-repository/pull/25893 that I think are fixed by this.

also https://github.com/dinosaure/opam-repository/pull/1 for your opam-repo PR