### PR TITLE
git-mirage: avoid failwith, use exit 64 (argument error)

### DIFF
--- a/src/git-mirage/git_mirage_http.ml
+++ b/src/git-mirage/git_mirage_http.ml
@@ -269,11 +269,15 @@ struct
       | None -> (
           match NSS.authenticator () with
           | Ok authenticator -> authenticator
-          | Error (`Msg err) -> failwith err)
+          | Error (`Msg err) ->
+            print_endline ("[git-mirage-http] NSS authenticator error: " ^ err);
+            exit 64)
       | Some str -> (
           match X509.Authenticator.of_string str with
           | Ok auth -> auth time
-          | Error (`Msg msg) -> failwith msg)
+          | Error (`Msg msg) ->
+            print_endline ("[git-mirage-http] authenticator error: " ^ msg);
+            exit 64)
     in
     let tls = Tls.Config.client ~authenticator () in
     let ctx = Mimic.add git_mirage_http_tls_config tls ctx in

--- a/src/git-mirage/git_mirage_ssh.ml
+++ b/src/git-mirage/git_mirage_ssh.ml
@@ -150,14 +150,20 @@ struct
     let key = Option.map Awa.Keys.of_string key in
     let ctx =
       match authenticator with
-      | Some (Error err) -> failwith err
+      | Some (Error err) ->
+        print_endline ("[git-mirage-ssh] authenticator error: " ^ err);
+        exit 64
       | Some (Ok authenticator) ->
           Mimic.add git_mirage_ssh_authenticator authenticator ctx
       | None -> ctx
     in
     match key, password with
-    | Some (Error (`Msg err)), _ -> failwith err
-    | Some _, Some _ -> failwith "both key and password provided"
+    | Some (Error (`Msg err)), _ ->
+      print_endline ("[git-mirage-ssh] ssh key error: " ^ err);
+      exit 64
+    | Some _, Some _ ->
+      print_endline "[git-mirage-ssh] both key and password provided";
+      exit 64
     | Some (Ok key), None ->
         let ctx = Mimic.add git_mirage_ssh_key key ctx in
         Lwt.return ctx


### PR DESCRIPTION
The issue I observed was a unikernel that restarted all the time, but its argument had an issue "wrong padding" was the output, but while there was a backtrace, there was no useful information. I tracked it back that git-mirage-ssh got a ssh private key where the padding was bad.

So, this PR does (a) prefix the output with slightly more information and (b) returns exit code 64 (as defined in Mirage_runtime.argument_error) -- this is crucial since albatross then won't restart such a unikernel (that will not be able to succeed a startup, since the error will persist until the command line argument is changed).