### PR TITLE
Raise instead of lwt fail

### DIFF
--- a/git.opam
+++ b/git.opam
@@ -24,7 +24,7 @@ depends: [
   "optint"
   "decompress" {>= "1.4.0"}
   "logs"
-  "lwt"
+  "lwt" {>= "5.7.0"}
   "mimic" {>= "0.0.6"}
   "cstruct" {>= "6.0.0"}
   "angstrom" {>= "0.14.0"}

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -264,7 +264,8 @@ module Make (Digestif : Digestif.S) = struct
   let read_exn t h =
     let open Lwt.Infix in
     match read t h with
-    | Error _ -> Lwt.fail (failuref "%a not found" Hash.pp h)
+    | Error e ->
+      Lwt.fail (failuref "%a not found: %a" Hash.pp h pp_error e)
     | Ok v -> Lwt.pause () >|= fun () -> v
 
   let read_opt t h =

--- a/src/git/mem.ml
+++ b/src/git/mem.ml
@@ -265,7 +265,7 @@ module Make (Digestif : Digestif.S) = struct
     let open Lwt.Infix in
     match read t h with
     | Error e ->
-      Lwt.fail (failuref "%a not found: %a" Hash.pp h pp_error e)
+      raise (failuref "%a not found: %a" Hash.pp h pp_error e)
     | Ok v -> Lwt.pause () >|= fun () -> v
 
   let read_opt t h =

--- a/src/git/store.ml
+++ b/src/git/store.ml
@@ -257,7 +257,7 @@ struct
     | Ok v -> Lwt.return v
     | Error _ ->
         let err = Fmt.str "Git.Store.read_exn: %a not found" Hash.pp hash in
-        Lwt.fail_invalid_arg err
+        raise (Invalid_argument err)
 
   let stream_of_raw ?(chunk = De.io_buffer_size) raw =
     let len = Carton.Dec.len raw in
@@ -327,7 +327,7 @@ struct
     Loose.atomic_add t.minor buffers v >>= function
     | Ok (hash, _) -> Lwt.return hash
     | Error (`Store err) ->
-        Lwt.fail (Failure (Fmt.str "%a" pp_error (`Minor err)))
+        raise (Failure (Fmt.str "%a" pp_error (`Minor err)))
     | Error `Non_atomic -> (
         let consumed = Stdlib.ref false in
         let stream () =
@@ -339,7 +339,7 @@ struct
         Loose.add t.minor buffers (kind, Int64.of_int len) stream >>= function
         | Ok (hash, _) -> Lwt.return hash
         | Error (`Store err) ->
-            Lwt.fail (Failure (Fmt.str "%a" pp_error (`Minor err))))
+            raise (Failure (Fmt.str "%a" pp_error (`Minor err))))
 
   let mem t hash =
     if not (Pack.exists t.major t.packs hash) then Loose.exists t.minor hash

--- a/src/git/sync.ml
+++ b/src/git/sync.ml
@@ -179,7 +179,7 @@ struct
         in
         let raw = Bigstringaf.copy buffer ~off ~len in
         Lwt.return (Carton.Dec.v ~kind raw)
-    | None -> Lwt.fail Not_found
+    | None -> raise Not_found
 
   include Smart_git.Make (Scheduler) (Pack) (Index) (Hash) (Reference)
 

--- a/src/git/value.ml
+++ b/src/git/value.ml
@@ -349,8 +349,8 @@ module Make (Hash : S.HASH) : S with type hash = Hash.t = struct
               Lwt.return_some str
               (* XXX(dinosaure): replace by [(string * int * int)]. *)
           | Encore.Lavoisier.Done -> Lwt.return_none
-          | Encore.Lavoisier.Fail -> Lwt.fail (Failure "Value.stream")
-          | exception _ -> Lwt.fail (Failure "Value.stream")
+          | Encore.Lavoisier.Fail -> raise (Failure "Value.stream")
+          | exception e -> Lwt.reraise e
         in
         stream
 

--- a/src/not-so-smart/smart_git.ml
+++ b/src/not-so-smart/smart_git.ml
@@ -273,7 +273,7 @@ struct
               go ({ Carton.Dec.Idx.offset; crc; uid } :: entries) offsets)
             (fun exn ->
               Printexc.print_backtrace stdout;
-              Lwt.fail exn)
+              Lwt.reraise exn)
     in
     go [] offsets >>= fun entries ->
     Pack.close t fd >>? fun () -> Lwt.return_ok entries
@@ -375,7 +375,7 @@ struct
         Mimic.close flow >>= fun () -> Lwt.return_ok refs)
     @@ fun exn ->
     pack None >>= fun () ->
-    Mimic.close flow >>= fun () -> Lwt.fail exn
+    Mimic.close flow >>= fun () -> Lwt.reraise exn
 
   let default_capabilities =
     [


### PR DESCRIPTION
based on #652, go a step further and instead of Lwt.fail, we raise the exception -- with the hope we'll see some more useful backtraces (currently starting the unikernel in question)